### PR TITLE
10Jan23-FF-ReleaseNotes

### DIFF
--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -26,16 +26,16 @@ This release does not include early access features.
 ### Fixed issues
 #### Feature Flags on the Harness Platform
 
-- Fixed a bug where a completion tick never appeared on the UI after an evaluation had successfully passed. (FFM-6127)
+- Fixed a bug that prevented a completion tick from appearing in the UI after an evaluation had successfully passed. (FFM-6127)
 
-- Fixed an error that caused the Complete button at the end of the Get Started flow to link to the beginning of the flow, instead of the Feature Flag list page as expected. (FFM-5988)
+- Fixed an error that caused the Complete button at the end of the Get Started flow to link to the beginning of the flow instead of linking to the expected Feature Flag list page. (FFM-5988)
 
-- Resolved an issue that caused the user to scroll unnecessarily when they expanded the target attribute or operator drop down menus during the creating a target flow. (FFM-5187)
+- Resolved an issue that caused you to scroll unnecessarily when you expanded the target attribute or operator dropdown menus when creating a target. (FFM-5187)
 
-- Fixed a bug where scrollbars were unnecessarily displayed on the target groups section of the targets page. (FFM-4053)
+- Fixed a bug where scrollbars were unnecessarily displayed in the target groups section of the targets page during loading. (FFM-4053)
 
 #### Feature Flag SDKs
-The Ruby SDK has been updated to version 1.0.5. This fixes a bug that caused the SDK to not wait for initialization when using "wait_for_initialization" method. (FFM-6393)
+The Ruby SDK has been updated to version 1.0.5. This fixes a bug that caused the SDK to not wait for initialization when using the `wait_for_initialization` method. (FFM-6393)
 
 ## December 22, 2022
 

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -34,6 +34,9 @@ This release does not include early access features.
 
 - Fixed a bug where scrollbars were unnecessarily displayed on the target groups section of the targets page. (FFM-4053)
 
+#### Feature Flag SDKs
+The Ruby SDK has been updated to version 1.0.5. This fixes a bug that caused the SDK to not wait for initialization when using "wait_for_initialization" method. (FFM-6393)
+
 ## December 22, 2022
 
 ### What's new

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -13,6 +13,27 @@ Harness deploys updates progressively to different Harness SaaS clusters. You ca
 Additionally, the release notes below are only for NextGen SaaS. FirstGen SaaS release notes are available [here](/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes) and Self-Managed Enterprise Edition release notes are available [here](/release-notes/self-managed-enterprise-edition).
 :::
 
+## January 10, 2023
+
+### What's new
+
+This release does not include new features.
+
+### Early access
+
+This release does not include early access features.
+
+### Fixed issues
+#### Feature Flags on the Harness Platform
+
+- Fixed a bug where a completion tick never appeared on the UI after an evaluation had successfully passed. (FFM-6127)
+
+- Fixed an error that caused the Complete button at the end of the Get Started flow to link to the beginning of the flow, instead of the Feature Flag list page as expected. (FFM-5988)
+
+- Resolved an issue that caused the user to scroll unnecessarily when they expanded the target attribute or operator drop down menus during the creating a target flow. (FFM-5187)
+
+- Fixed a bug where scrollbars were unnecessarily displayed on the target groups section of the targets page. (FFM-4053)
+
 ## December 22, 2022
 
 ### What's new


### PR DESCRIPTION
Added release notes for 10th Jan 2023 release for FF.

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
