### PR TITLE
[CI-5758] [CI-6410] [DOC-2351] - Connector settings, Connector authentication, Connectors in CI steps

### DIFF
--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic describes settings for the **Build and Push an image to Docker registry** step, which creates a Docker image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/) and pushes it to a Docker registry.
 
-You may also use this step to push to an Azure Container Registry (ACR)This step is the equivalent to the [docker build command](https://docs.docker.com/engine/reference/commandline/build/).
+You may also use this step to push to an Azure Container Registry (ACR), because this step is the equivalent to the [docker build command](https://docs.docker.com/engine/reference/commandline/build/).
 
 ### Name
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -20,6 +20,12 @@ The unique name for this step.
 
 The Harness Docker Registry Connector to use for uploading the image. See [Docker Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md).
 
+:::note
+
+This step supports Docker connectors that use either anonymous or username and password authentication.
+
+:::
+
 ### Docker Repository
 
 The name of the Repository. For example, `<hub-user>/<repo-name>`.

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic describes settings for the **Build and Push an image to Docker registry** step, which creates a Docker image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/) and pushes it to a Docker registry.
 
-You may also use this step to push to an Azure Container Registry (ACR), because this step is the equivalent to the [docker build command](https://docs.docker.com/engine/reference/commandline/build/).
+You also use this step to push to Azure Container Registry (ACR) because this step is equivalent to the Docker [build](https://docs.docker.com/engine/reference/commandline/build/) and [push](https://docs.docker.com/engine/reference/commandline/push/) commands.
 
 ### Name
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -18,13 +18,7 @@ The unique name for this step.
 
 ### Docker Connector
 
-The Harness Docker Registry Connector to use for uploading the image. See [Docker Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md).
-
-:::note
-
-This step supports Docker connectors that use either anonymous or username and password authentication.
-
-:::
+The Harness Docker Registry Connector to use for uploading the image. See [Docker Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md). This step supports Docker connectors that use either anonymous or username and password authentication.
 
 ### Docker Repository
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -24,6 +24,14 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness AWS Connector to use to connect to ECR. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to ECR. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
+
+:::note
+
+This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
+
+:::
+
+
 ### Region
 
 The AWS region to use when pushing the image. The registry format for ECR is `aws_account_id.dkr.ecr.region.amazonaws.com` and a region is required. See [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) from AWS.

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -22,15 +22,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 ### AWS Connector
 
-The Harness AWS Connector to use to connect to ECR. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to ECR. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
-
-
-:::note
-
-This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
-
-:::
-
+The Harness AWS Connector to use to connect to ECR. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to ECR. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md). This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
 
 ### Region
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -26,6 +26,12 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness GCP Connector to use to connect to GCR. See [Google Cloud Platform (GCP) Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
 
+:::note
+
+This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
+
+:::
+
 ### Host
 
 The GCR registry hostname. For example, `us.gcr.io` hosts images in data centers in the United States, in a separate storage bucket from images hosted by `gcr.io`.

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -26,11 +26,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness GCP Connector to use to connect to GCR. See [Google Cloud Platform (GCP) Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
 
-:::note
-
-This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
-
-:::
+This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
 ### Host
 

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
@@ -22,6 +22,12 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector for the GCP account where you saved the cache.
 
+:::note
+
+This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
+
+:::
+
 ### Bucket
 
 GCS bucket name.

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
@@ -20,11 +20,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 ### GCP Connector
 
-The Harness Connector for the GCP account where you saved the cache.
-
-:::note
-
-This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
+The Harness connector for the GCP account where you saved the cache. This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
 :::
 

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
@@ -24,6 +24,16 @@ The Harness Connector to use when restoring the cache from AWS S3. Typically, th
 
 The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to read from S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
+:::note
+
+This step supports AWS connectors using **AWS Access Key** and **Assume IAM role on Delegate** authentication methods *without* cross account access (ARN/STS).
+
+AWS connectors using IRSA authentication may encounter problems during pipeline execution.
+
+This step does not support AWS connectors that have enabled cross account access (ARN/STS), regardless of authentication method.
+
+:::
+
 ### Region
 
 An AWS region you used when you saved the cache. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
@@ -28,12 +28,9 @@ The AWS IAM roles and policies associated with the account used in the Harness A
 
 This step supports AWS connectors using **AWS Access Key** and **Assume IAM role on Delegate** authentication methods *without* cross account access (ARN/STS).
 
-AWS connectors using IRSA authentication may encounter problems during pipeline execution.
-
-This step does not support AWS connectors that have enabled cross account access (ARN/STS), regardless of authentication method.
+This step does not support AWS connectors using IRSA authentication, and it does not support AWS connectors that have enabled cross account access (ARN/STS) for any authentication method.
 
 :::
-
 ### Region
 
 An AWS region you used when you saved the cache. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
@@ -22,6 +22,12 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector for the GCP account where you want to save the cache.
 
+:::note
+
+This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
+
+:::
+
 ### Bucket
 
 GCS bucket name.

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
@@ -22,11 +22,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector for the GCP account where you want to save the cache.
 
-:::note
-
-This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
-
-:::
+This step support GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
 ### Bucket
 

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
@@ -22,7 +22,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector for the GCP account where you want to save the cache.
 
-This step support GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
+This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
 ### Bucket
 

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
@@ -24,6 +24,16 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector to use when saving the cache to an S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to write to S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
+:::note
+
+This step supports AWS connectors using **AWS Access Key** and **Assume IAM role on Delegate** authentication methods *without* cross account access (ARN/STS).
+
+AWS connectors using IRSA authentication may encounter problems during pipeline execution.
+
+This step does not support AWS connectors that have enabled cross account access (ARN/STS), regardless of authentication method.
+
+:::
+
 ### Region
 
 An AWS region you selected when you created AWS S3 bucket. See [Creating and configuring an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-configure-bucket.html) in the AWS docs.

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
@@ -28,9 +28,7 @@ The Harness Connector to use when saving the cache to an S3. The AWS IAM roles a
 
 This step supports AWS connectors using **AWS Access Key** and **Assume IAM role on Delegate** authentication methods *without* cross account access (ARN/STS).
 
-AWS connectors using IRSA authentication may encounter problems during pipeline execution.
-
-This step does not support AWS connectors that have enabled cross account access (ARN/STS), regardless of authentication method.
+This step does not support AWS connectors using IRSA authentication, and it does not support AWS connectors that have enabled cross account access (ARN/STS) for any authentication method.
 
 :::
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
@@ -22,6 +22,12 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 The Harness Connector for the GCP account where you want to upload the artifact. See [Google Cloud Platform (GCP) Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
 
+:::note
+
+This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
+
+:::
+
 ### Bucket
 
 GCS destination bucket name.

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
@@ -20,14 +20,7 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 
 ### GCP Connector
 
-The Harness Connector for the GCP account where you want to upload the artifact. See [Google Cloud Platform (GCP) Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
-
-:::note
-
-This step has been tested with GCP connectors that use access key authentication. GCP connectors that inherit delegate credentials may encounter problems during pipeline execution.
-
-:::
-
+The Harness connector for the GCP account where you want to upload the artifact. For more information, go to [Google Cloud Platform (GCP) connector settings reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md). This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 ### Bucket
 
 GCS destination bucket name.

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
@@ -24,6 +24,12 @@ Select the Harness Artifactory Connector to use for this upload.
 
 See [Artifactory Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/artifactory-connector-settings-reference.md).
 
+:::note
+
+This step supports Artifactory connectors that use either anonymous or username and password authentication.
+
+:::
+
 ### Target
 
 The target folder in the registry.

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
@@ -22,13 +22,7 @@ Text string.
 
 Select the Harness Artifactory Connector to use for this upload.
 
-See [Artifactory Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/artifactory-connector-settings-reference.md).
-
-:::note
-
-This step supports Artifactory connectors that use either anonymous or username and password authentication.
-
-:::
+See [Artifactory Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/artifactory-connector-settings-reference.md). This step supports Artifactory connectors that use either anonymous or username and password authentication.
 
 ### Target
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Upload Artifacts to S3 Step Settings
-description: This topic provides settings for the Upload Artifacts to S3 step, which uploads artifacts to AWS or other S3 providers such as MinIo. S3 buckets use private ACLs by default. To use a different ACL, s…
+title: Upload Artifacts to S3 step settings
+description: The Upload Artifacts to S3 step uploads artifacts to AWS or other S3 providers such as MinIo.
 sidebar_position: 160
 helpdocs_topic_id: wdzojt3ep3
 helpdocs_category_id: 4xo13zdnfx
@@ -8,9 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings for the Upload Artifacts to S3 step, which uploads artifacts to AWS or other S3 providers such as [MinIo](https://docs.min.io/docs/minio-gateway-for-s3.html).
-
-S3 buckets use [private](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) ACLs by default. To use a different ACL, set a stage variable `PLUGIN_ACL` with the ACL you want to use.
+This topic provides details about the settings for the Upload Artifacts to S3 step, which uploads artifacts to AWS or other S3 providers such as [MinIo](https://docs.min.io/docs/minio-gateway-for-s3.html).
 
 ### Name
 
@@ -23,6 +21,29 @@ See [Entity Identifier Reference](../../platform/20_References/entity-identifier
 ### AWS Connector
 
 The Harness Connector to use when connecting to AWS S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
+
+<details>
+<summary>Stage variable required for non-default ACLs</summary>
+
+S3 buckets use [private ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) by default. Your pipeline must have a `PLUGIN_ACL` stage variable if you want to use a different ACL.
+
+1. In the Pipeline Studio, select the relevant stage, and then select the **Overview** tab.
+2. In the **Advanced** section, add a stage variable.
+3. Input `PLUGIN_ACL` as the **Variable Name**, set the **Type** to **String**, and then select **Save**.
+4. Input the relevant ACL in the **Value** field.
+
+</details>
+
+<details>
+<summary>Stage variable required for ARNs</summary>
+
+If your AWS connector's authentication uses a cross-account role (ARN), pipeline stages with **Upload Artifacts to S3** steps must have a `PLUGIN_USER_ROLE_ARN` stage variable.
+
+1. In the Pipeline Studio, select the stage with the **Upload Artifacts to S3** step, and then select the **Overview** tab.
+2. In the **Advanced** section, add a stage variable.
+3. Input `PLUGIN_USER_ROLE_ARN` as the **Variable Name**, set the **Type** to **String**, and then select **Save**.
+4. In the **Value** field, input the full ARN value that corresponds with the AWS connector's ARN.
+</details>
 
 ### Bucket
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -27,24 +27,28 @@ The AWS IAM roles and policies associated with the account connected to the Harn
 <details>
 <summary>Stage variable required for non-default ACLs</summary>
 
+```mdx-code-block
 S3 buckets use [private ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) by default. Your pipeline must have a `PLUGIN_ACL` stage variable if you want to use a different ACL.
 
 1. In the Pipeline Studio, select the relevant stage, and then select the **Overview** tab.
 2. In the **Advanced** section, add a stage variable.
 3. Input `PLUGIN_ACL` as the **Variable Name**, set the **Type** to **String**, and then select **Save**.
 4. Input the relevant ACL in the **Value** field.
-
+```
 </details>
 
 <details>
 <summary>Stage variable required for ARNs</summary>
 
+```mdx-code-block
 If your AWS connector's authentication uses a cross-account role (ARN), pipeline stages with **Upload Artifacts to S3** steps must have a `PLUGIN_USER_ROLE_ARN` stage variable.
 
 1. In the Pipeline Studio, select the stage with the **Upload Artifacts to S3** step, and then select the **Overview** tab.
 2. In the **Advanced** section, add a stage variable.
 3. Input `PLUGIN_USER_ROLE_ARN` as the **Variable Name**, set the **Type** to **String**, and then select **Save**.
 4. In the **Value** field, input the full ARN value that corresponds with the AWS connector's ARN.
+```
+
 </details>
 
 ## Region

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -10,17 +10,19 @@ helpdocs_is_published: true
 
 This topic provides details about the settings for the Upload Artifacts to S3 step, which uploads artifacts to AWS or other S3 providers such as [MinIo](https://docs.min.io/docs/minio-gateway-for-s3.html).
 
-### Name
+## Name
 
 The unique name for this step.
 
-### Id
+An **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) is generated based on the name The **Id** can be edited.
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## AWS Connector
 
-### AWS Connector
+The Harness AWS connector to use when connecting to AWS S3.
 
-The Harness Connector to use when connecting to AWS S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
+The AWS IAM roles and policies associated with the account connected to the Harness AWS connector must be able to push to S3. For more information about roles and permissions for AWS connectors, go to:
+* [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
+* [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
 <details>
 <summary>Stage variable required for non-default ACLs</summary>
@@ -45,52 +47,47 @@ If your AWS connector's authentication uses a cross-account role (ARN), pipeline
 4. In the **Value** field, input the full ARN value that corresponds with the AWS connector's ARN.
 </details>
 
-### Bucket
+## Region
 
-The bucket name for the uploaded artifact.
+Define the AWS region to use when pushing the image.
 
-### Source Path
+## Bucket
 
-Path to the artifact files you want to upload. You can use standard [glob expressions](https://en.wikipedia.org/wiki/Glob_(programming)) to upload multiple files. For example, `src/js/**/*.js` will upload all Javascript files in `src/js/subfolder-1/`, `src/js/subfolder-2`, and so on.
+The S3 bucket name for the uploaded artifact.
 
-### Optional Configuration
+## Source Path
 
-Configure the following options to add additional configuration for the Step.
+Path to the artifact files that you want to upload.
 
-#### Endpoint URL
+You can use standard [glob expressions](https://en.wikipedia.org/wiki/Glob_(programming)) to upload multiple files. For example, `src/js/**/*.js` uploads all Javascript files in matching directories, such as `src/js/subfolder-1/`, `src/js/subfolder-2`, and so on.
 
-Endpoint URL for S3-compatible providers (not needed for AWS).
+## Optional Configuration
 
-#### Target
+Use the following settings to add additional configuration to the step.
 
-The bucket path where the artifact will be stored.
+### Endpoint URL
 
-Do not include the bucket name. It is specified in **Bucket**.
+Endpoint URL for S3-compatible providers. It is not needed for AWS.
 
-If no target is provided, the cache is saved to `[bucket]/[key]`.
+### Target
 
-#### Run as User
+The path, relative to the S3 **Bucket**, where you want to store the artifact. Do not include the bucket name; you specified this in **Bucket**.
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+If unspecified, the cache is saved to `[bucket]/[key]`.
 
-#### Set container resources
+### Run as User
 
-Maximum resources limit values for the resources used by the container at runtime.
+Set the value to specify the user id for all processes in the pod, running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-##### Limit Memory
+### Set Container Resources
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+Maximum resources limits for the resources used by the container at runtime:
 
-##### Limit CPU
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+* **Timeout:** Timeout limit for the step. Once the timeout is reached, the step fails and pipeline execution continues.
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.ACL
-
-### See Also
+## See Also
 
 * [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
 * [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Upload Artifacts to S3 step settings
-description: The Upload Artifacts to S3 step uploads artifacts to AWS or other S3 providers such as MinIo.
+description: Upload artifacts to AWS or other S3 providers such as MinIo.
 sidebar_position: 160
 helpdocs_topic_id: wdzojt3ep3
 helpdocs_category_id: 4xo13zdnfx

--- a/docs/platform/7_Connectors/add-aws-connector.md
+++ b/docs/platform/7_Connectors/add-aws-connector.md
@@ -66,7 +66,7 @@ Setting up IRSA credentials requires a few more steps than other methods, but it
        --override-existing-serviceaccounts —region=us-east-1
    ```
 
-3. In Harness, download the Harness Kubernetes delegate YAML file. For instructions, go to [Install a Kubernetes Delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md).
+3. In Harness, download the Harness Kubernetes delegate YAML file. For instructions, go to [Install a Kubernetes Delegate](../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md).
 4. Open the delegate YAML file in text editor.
 5. Add the service account with access to IAM role to the delegate YAML. There are two sections in the Delegate YAML that you must update:
    1. Update the `ClusterRoleBinding` by replacing the subject name `default` with the name of the service account with the attached IAM role, for example:
@@ -104,7 +104,7 @@ Setting up IRSA credentials requires a few more steps than other methods, but it
       ```
 
 6. Save the delegate YAML file.
-7. If you haven't already installed the delegate, [Install the Kubernetes delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md) in your EKS cluster and register the delegate with Harness. When you install the delegate in the cluster, the SA you added is used, and the environment variables `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are added automatically by EKS.
+7. If you haven't already installed the delegate, [Install the Kubernetes delegate](../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md) in your EKS cluster and register the delegate with Harness. When you install the delegate in the cluster, the SA you added is used, and the environment variables `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are added automatically by EKS.
 
 </details>
 

--- a/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
+++ b/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
@@ -1,6 +1,6 @@
 ---
-title: Add a Google Cloud Platform (GCP) Connector
-description: Add a Harness GCP Connector.
+title: Add a Google Cloud Platform (GCP) connector
+description: Use a Harness GCP connector to integrate GCP with Harness.
 # sidebar_position: 2
 helpdocs_topic_id: cii3t8ra3v
 helpdocs_category_id: o1zhrfo8n5
@@ -8,98 +8,80 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Google Cloud Platform (GCP) is integrated with Harness using a Harness GCP Connector. You can use GCP with Harness for obtaining artifacts, communicating with GCP services, provisioning infrastructure, and deploying microservices, and other workloads.
+Use a Harness Google Cloud Platform (GCP) connector to integrate GCP with Harness. Use GCP with Harness to obtain artifacts, communicate with GCP services, provision infrastructure, deploy microservices, and manage other workloads.
 
-This topic explains how to set up the GCP Connector.
+You can use the GCP connector to connect to Kubernetes clusters in GCP. You can also use the [platform-agnostic Kubernetes Cluster connector](ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
 
-**What IAM roles should my GCP account have?** What IAM roles and policies needed by the GCP account used in the Connector depend on what GCP service you are using with Harness and what operations you want Harness to perform in GCP. For a list of roles and policies, see [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
+This topic explains how to set up a GCP connector.
 
-### Before you begin
+## Before you begin
 
-* [Learn Harness' Key Concepts](../../getting-started/learn-harness-key-concepts.md)
+Before you begin, you must:
 
-### Limitations
+* **Assign IAM roles to the GCP service account or Harness delegate that you will attach to the connector.**
+  * The necessary IAM roles and policies depend on which GCP service you'll use with Harness and which operations you'll want Harness to perform in GCP.
+  * GCP connectors can also inherit IAM roles from Harness delegates running in GCP. If you want your connector to inherit from a delegate, make sure the delegate has the necessary roles.
+  * If you find that the IAM role associated with your GCP connector don't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the GCP account or the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+  * For a list of roles and policies, go to [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
+  * The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is useful for evaluating policies and access.
+* **Check your GKE version.**
+  * Harness supports GKE 1.19 and later.
+  * If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](add-a-kubernetes-cluster-connector.md).
 
-Harness supports GKE 1.19 and later.
+## Add a GCP connector and configure credentials
 
-If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](add-a-kubernetes-cluster-connector.md).
+1. Open a Harness project, and select **Connectors** under **Project Setup**.
+2. Select **New Connector**, and then select **GCP** under **Cloud Providers**.
 
-### Supported Platforms and Technologies
+   ![](./static/connect-to-google-cloud-platform-gcp-07.png)
 
-For a list of the platforms and technologies supported by Harness, see [Supported Platforms and Technologies](../../getting-started/supported-platforms-and-technologies.md).
+3. Input a **Name** for the connector. **Description** and **Tags** are optional.
+   Harness automatically creates an **Id** ([entity identifier](../20_References/entity-identifier-reference.md)) for the connector based on the **Name**.
+4. Select **Continue** to configure credentials. Select one of the following authentication options:
+   * Select **Specify credentials here** to use a GCP service account key.
+   * Select **Use the credentials of a specific Harness Delegate** to allow the connector to inherit its authentication credentials from the Harness delegate that is running in GCP.
+5. Select **Continue** to proceed to **Select Connectivity Mode**.
 
-### Review: Connecting to Kubernetes Clusters
+<details>
+<summary>Learn more about credential inheritance</summary>
 
-You can connect to a Kubernetes cluster running in GCP using a GCP Connector or the platform-agnostic Kubernetes Cluster Connector.
+* **IAM role inheritance:** The connector inherits the GCP IAM role assigned to the delegate in GCP, such a Harness Kubernetes delegate running in Google Kubernetes Engine (GKE). Make sure the delegate has the IAM roles that your connector needs.
+* **GCP workload identity:** If you installed the Harness [Kubernetes delegate](/docs/first-gen/firstgen-platform/account/manage-delegates/install-kubernetes-delegate/) in a Kubernetes cluster in GKE that has [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity?hl=tr#enable_on_cluster) enabled and uses the same service account and node pool annotation, then the Google Cloud Platform (GCP) connector inherits these credentials if it uses that delegate.
+* **Role and policy changes:** If you find that the IAM role associated with your GCP connector don't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+* **See also:**
+  * [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md)
+  * [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access)
 
-See [Kubernetes Cluster Connector Settings Reference](ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
+</details>
 
-### Review: IAM Roles and Policies for the Connector
+## Select connectivity mode
 
-The IAM roles and policies needed by the GCP account used in the Connector depend on what GCP service you are using with Harness and what operations you want Harness to perform in GCP.
+Harness uses GCP connectors during pipeline runs to authenticate and perform operations with GCP.
 
-For a list of roles and policies, see [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
+1. Select how you want Harness to connect to GCP:
+   *  **Connect through Harness Platform:** Use a direct, secure communication between Harness and GCP.
+   *  **Connect through a Harness Delegate:** Harness communicates with GCP through a Harness delegate in GCP. You must choose this option if you chose to inherit delegate credentials.
+2. If connecting through a Harness delegate, select either:
+   * **Use any available Delegate**: Harness selects an available Delegate at runtime. To learn how Harness selects delegates, go to [Delegates Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md).
+   * **Only use Delegates with all of the following tags**: Use **Tags** to match one or more suitable delegates. To learn more about Delegate tags, go to [Select Delegates with Tags](/docs/platform/2_Delegates/manage-delegates/select-delegates-with-selectors.md).
+     * Select **Install new Delegate** to add a delegate without exiting connector configuration. For guidance on installing delegates, go to [Delegate Installation Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegate-installation-overview.md).
+3. Select **Save and Continue** to run the connection test, and then, if the test succeeds, select **Finish**. The connection test confirms that your authentication and delegate selections are valid.
 
-The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is a useful tool for evaluating policies and access.
+<details>
+<summary>GCP connector errors</summary>
 
-### Review: Switching IAM Policies
+If the connection test fails due to a credentials issue, use the GCP CLI or console to check the GCP service account or delegate's credentials. The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is useful for evaluating policies and access.
 
-If the IAM role used by your GCP Connector does not have the policies required by the GCP service you want to access, you can modify or switch the role.
+Due to the limited scope of the initial connection test, credentials can pass the connection test and then fail when you use the connector in a pipeline if the IAM role the connector is using doesn't have the roles and policies needed for the pipeline's operations. For example, if a pipeline has a Run step that references a GCP connector, the connector may need to have specific roles or policies to be able to execute the operations required by the Run step.
 
-You simply change the role assigned to the GCP account or the Harness Delegate your GCP Connector is using.
+If you experience any errors with GCP connectors, verify that the IAM roles and policies it is using are correct.
 
-When you switch or modify the IAM role, it might take up to 5 minutes to take effect.
+For a list of roles and policies, go to the [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
 
-### Review: GCP Workload Identity
+</details>
 
-If you installed the Harness [Kubernetes Delegate](/docs/first-gen/firstgen-platform/account/manage-delegates/install-kubernetes-delegate/) in a Kubernetes cluster (in GKE) that has [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity?hl=tr#enable_on_cluster) enabled and uses the same service account and node pool annotation, the Google Cloud Platform (GCP) Connector will inherit these credentials if it uses that Delegate.
+## See also
 
-### Step 1: Add a GCP Connector
-
-Open a Harness Project.
-
-In **Project Setup**, click **Connectors**.
-
-Click **New Connector**, and click **GCP**. The GCP Connector settings appear.
-
-![](./static/connect-to-google-cloud-platform-gcp-07.png)
-In **Name**, enter a name for this connector.
-
-Harness automatically creates the corresponding Id ([entity identifier](../20_References/entity-identifier-reference.md)).
-
-Click **Continue**.
-
-### Step 2: Enter Credentials
-
-There are two options for authenticating with GCP:
-
-* **Specify credentials here:** use a GCP Service Account Key.
-* **Use the credentials of a specific Harness Delegate:** have the Connector inherit the credentials used by the Harness Delegate running in GCP. The GCP IAM role used when installing the Delegate in GCP is used for authentication by the GCP Connector.  
-For example, you can add or select a Harness Kubernetes Delegate running in Google Kubernetes Engine (GKE).
-
-All of the settings for these options are described in detail in [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
-
-### Step 3: Set Up Delegates
-
-Harness uses GCP Connectors at Pipeline runtime to authenticate and perform operations with GCP. Authentications and operations are performed by Harness Delegates.
-
-You can select **Any Available Harness Delegate** and Harness will select the Delegate. For a description of how Harness picks Delegates, see [Delegates Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md).
-
-You can use Delegate Tags to select one or more Delegates. For details on Delegate Tags, see [Select Delegates with Tags](/docs/platform/2_Delegates/manage-delegates/select-delegates-with-selectors.md).
-
-If you need to install a Delegate, see [Delegate Installation Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegate-installation-overview.md).
-
-Click **Save and Continue**.
-
-Harness tests the credentials you provided using the Delegates you selected.
-
-If the credentials fail, you'll see an error. Check your credentials by using them with the GCP CLI or console.
-
-The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is a useful tool for evaluating policies and access.The credentials might work fine for authentication, but might fail later when you use the Connector with a Pipeline because the IAM role the Connector is using does not have the roles and policies needed for the Pipeline's operations.
-
-If you run into any error with a GCP Connector, verify that the IAM roles and policies it using are correct.
-
-For a list of roles and policies, see [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
-
-Click **Finish**.
-
+* [Harness Key Concepts](../../getting-started/learn-harness-key-concepts.md).
+* [Supported Platforms and Technologies](../../getting-started/supported-platforms-and-technologies.md).
+* [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md)

--- a/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
+++ b/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
@@ -59,8 +59,8 @@ Before you begin, you must:
 Harness uses GCP connectors during pipeline runs to authenticate and perform operations with GCP.
 
 1. Select how you want Harness to connect to GCP:
-   *  **Connect through Harness Platform:** Use a direct, secure communication between Harness and GCP.
-   *  **Connect through a Harness Delegate:** Harness communicates with GCP through a Harness delegate in GCP. You must choose this option if you chose to inherit delegate credentials.
+   * **Connect through Harness Platform:** Use a direct, secure communication between Harness and GCP.
+   * **Connect through a Harness Delegate:** Harness communicates with GCP through a Harness delegate in GCP. You must choose this option if you chose to inherit delegate credentials.
 2. If connecting through a Harness delegate, select either:
    * **Use any available Delegate**: Harness selects an available Delegate at runtime. To learn how Harness selects delegates, go to [Delegates Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md).
    * **Only use Delegates with all of the following tags**: Use **Tags** to match one or more suitable delegates. To learn more about Delegate tags, go to [Select Delegates with Tags](/docs/platform/2_Delegates/manage-delegates/select-delegates-with-selectors.md).

--- a/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
+++ b/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Use a Harness Google Cloud Platform (GCP) connector to integrate GCP with Harness. Use GCP with Harness to obtain artifacts, communicate with GCP services, provision infrastructure, deploy microservices, and manage other workloads.
+Use a Harness Google Cloud Platform (GCP) connector to integrate GCP with Harness. Use GCP with Harness to obtain artifacts, communicate with GCP services, provision infrastructure, and deploy microservices and other workloads.
 
 You can use the GCP connector to connect to Kubernetes clusters in GCP. You can also use the [platform-agnostic Kubernetes Cluster connector](ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
 
@@ -21,7 +21,7 @@ Before you begin, you must:
 * **Assign IAM roles to the GCP service account or Harness delegate that you will attach to the connector.**
   * The necessary IAM roles and policies depend on which GCP service you'll use with Harness and which operations you'll want Harness to perform in GCP.
   * GCP connectors can also inherit IAM roles from Harness delegates running in GCP. If you want your connector to inherit from a delegate, make sure the delegate has the necessary roles.
-  * If you find that the IAM role associated with your GCP connector don't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the GCP account or the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+  * If you find that the IAM role associated with your GCP connector doesn't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the GCP account or the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
   * For a list of roles and policies, go to [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
   * The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is useful for evaluating policies and access.
 * **Check your GKE version.**
@@ -47,7 +47,7 @@ Before you begin, you must:
 
 * **IAM role inheritance:** The connector inherits the GCP IAM role assigned to the delegate in GCP, such a Harness Kubernetes delegate running in Google Kubernetes Engine (GKE). Make sure the delegate has the IAM roles that your connector needs.
 * **GCP workload identity:** If you installed the Harness [Kubernetes delegate](/docs/first-gen/firstgen-platform/account/manage-delegates/install-kubernetes-delegate/) in a Kubernetes cluster in GKE that has [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity?hl=tr#enable_on_cluster) enabled and uses the same service account and node pool annotation, then the Google Cloud Platform (GCP) connector inherits these credentials if it uses that delegate.
-* **Role and policy changes:** If you find that the IAM role associated with your GCP connector don't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+* **Role and policy changes:** If you find that the IAM role associated with your GCP connector doesn't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
 * **See also:**
   * [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md)
   * [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access)
@@ -82,6 +82,6 @@ For a list of roles and policies, go to the [Google Cloud Platform (GCP) Connect
 
 ## See also
 
-* [Harness Key Concepts](../../getting-started/learn-harness-key-concepts.md).
-* [Supported Platforms and Technologies](../../getting-started/supported-platforms-and-technologies.md).
+* [Harness Key Concepts](../../getting-started/learn-harness-key-concepts.md)
+* [Supported Platforms and Technologies](../../getting-started/supported-platforms-and-technologies.md)
 * [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md)

--- a/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
+++ b/docs/platform/7_Connectors/connect-to-google-cloud-platform-gcp.md
@@ -21,7 +21,7 @@ Before you begin, you must:
 * **Assign IAM roles to the GCP service account or Harness delegate that you will attach to the connector.**
   * The necessary IAM roles and policies depend on which GCP service you'll use with Harness and which operations you'll want Harness to perform in GCP.
   * GCP connectors can also inherit IAM roles from Harness delegates running in GCP. If you want your connector to inherit from a delegate, make sure the delegate has the necessary roles.
-  * If you find that the IAM role associated with your GCP connector doesn't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the GCP account or the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+  * If you find that the IAM role associated with your GCP connector doesn't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the GCP account or the Harness delegate that your GCP connector is using. You might need to wait up to five minutes for the change to take effect.
   * For a list of roles and policies, go to [Google Cloud Platform (GCP) Connector Settings Reference](ref-cloud-providers/gcs-connector-settings-reference.md).
   * The [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access) is useful for evaluating policies and access.
 * **Check your GKE version.**
@@ -45,7 +45,7 @@ Before you begin, you must:
 <details>
 <summary>Learn more about credential inheritance</summary>
 
-* **IAM role inheritance:** The connector inherits the GCP IAM role assigned to the delegate in GCP, such a Harness Kubernetes delegate running in Google Kubernetes Engine (GKE). Make sure the delegate has the IAM roles that your connector needs.
+* **IAM role inheritance:** The connector inherits the GCP IAM role assigned to the delegate in GCP, such a Harness Kubernetes delegate running in Google Kubernetes Engine (GKE). Ensure the delegate has the IAM roles that your connector needs to perform the necessary operations.
 * **GCP workload identity:** If you installed the Harness [Kubernetes delegate](/docs/first-gen/firstgen-platform/account/manage-delegates/install-kubernetes-delegate/) in a Kubernetes cluster in GKE that has [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity?hl=tr#enable_on_cluster) enabled and uses the same service account and node pool annotation, then the Google Cloud Platform (GCP) connector inherits these credentials if it uses that delegate.
 * **Role and policy changes:** If you find that the IAM role associated with your GCP connector doesn't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
 * **See also:**

--- a/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
@@ -378,7 +378,7 @@ This example policy gives limited permission to EKS clusters.
 
 ## Connect to EKS
 
-If you want to connect Harness to Elastic Kubernetes Service (Amazon EKS), use the platform-agnostic [Kubernetes Cluster Connector](kubernetes-cluster-connector-settings-reference.md).
+If you want to connect Harness to Elastic Kubernetes Service (Amazon EKS), use the platform-agnostic [Kubernetes cluster connector](kubernetes-cluster-connector-settings-reference.md).
 
 ## AWS Serverless Lambda
 
@@ -571,7 +571,7 @@ In rare cases when the delegate OS does not support `apt`, such as Red Hat Linux
 
 ### Serverless cross-account access (STS Role)
 
-If you use the **Enable cross-account access (STS Role)** option in the AWS connector for a Serverless Lambda deployment, the delegate that is used by the Connector must have the AWS CLI installed. The AWS CLI is not required for the other authentication methods.
+If you use the **Enable cross-account access (STS Role)** option in the AWS connector for a Serverless Lambda deployment, the delegate that is used by the connector must have the AWS CLI installed. The AWS CLI is not required for the other authentication methods.
 
 For instructions on installing software with the delegate, go to [Run initialization scripts on delegates](../../2_Delegates/configure-delegates/run-scripts-on-delegates.md).
 

--- a/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
@@ -573,7 +573,7 @@ In rare cases when the delegate OS does not support `apt`, such as Red Hat Linux
 
 If you use the **Enable cross-account access (STS Role)** option in the AWS connector for a Serverless Lambda deployment, the delegate that is used by the connector must have the AWS CLI installed. The AWS CLI is not required for the other authentication methods.
 
-For instructions on installing software with the delegate, go to [Run initialization scripts on delegates](../../2_Delegates/configure-delegates/run-scripts-on-delegates.md).
+For more information about installing software with the delegate, go to [Build custom delegate images with third-party tools](../../2_Delegates/customize-delegates/build-custom-delegate-images-with-third-party-tools.md).
 
 ## Harness AWS connector settings
 

--- a/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md
@@ -1,6 +1,6 @@
 ---
-title: AWS Connector Settings Reference
-description: This topic provides settings and permissions for the AWS Connector.
+title: AWS connector settings reference
+description: This topic provides settings and permissions for Harness AWS connectors.
 # sidebar_position: 2
 helpdocs_topic_id: m5vkql35ca
 helpdocs_category_id: 1ehb4tcksy
@@ -8,856 +8,692 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-AWS is used as a Harness Connector for activities such as obtaining artifacts, building and deploying services, and verifying deployments.
+Harness uses AWS connectors for activities such as obtaining artifacts, building and deploying services, and verifying deployments.
 
-This topic provides settings and permissions for the AWS Connector.
+This topic describes settings and permissions for AWS connectors.
 
-
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target or build infrastructures.
-
-:::
-
-### AWS Permissions
-
-
-:::note
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target or build infrastructure.
-
-:::
+## AWS permissions and policies
 
 The AWS role policy requirements depend on what AWS services you are using for your artifacts and target infrastructure.
 
-Here are the user and access type requirements that you need to consider.
+Consider the following user and access type requirements:
 
-**User:** Harness requires the IAM user be able to make API requests to AWS. For more information, see [Creating an IAM User in Your AWS Account](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) from AWS.
+* **User:** Harness requires that the IAM user can make API requests to AWS. For more information, go to [Creating an IAM User in Your AWS Account](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).
+* **User Access Type:* Programmatic access:** This enables an access key ID and secret access key for the AWS API, CLI, SDK, and other development tools.
+* **DescribeRegions:** Required for all AWS Cloud Provider connections.
 
-**User Access Type:** **Programmatic access**. This enables an access key ID and secret access key for the AWS API, CLI, SDK, and other development tools.
+:::caution
 
-As described below, `DescribeRegions` is required for all AWS Cloud Provider connections.
+The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS connectors regardless of what AWS service you are using for your target or build infrastructure.
 
-### All AWS Connectors: DescribeRegions Required
+Harness needs a policy with the `DescribeRegions` action so that it can list the available regions when you define your target architecture.
 
+To do this, create a [Customer Managed Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies), add the `DescribeRegions` action to list those regions, and add that to any role used by the connector.
 
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target or build infrastructure.
+For example:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ec2:DescribeRegions",
+            "Resource": "*"
+        }
+    ]
+}
+```
 
 :::
 
-Harness needs a policy with the `DescribeRegions` action so that it can list the available regions for you when you define your target architecture.
+:::tip
 
-Create a [Customer Managed Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies), add the `DescribeRegions` action to list those regions, and add that to any role used by the Connector.
-
-
-```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Sid": "VisualEditor0",  
-            "Effect": "Allow",  
-            "Action": "ec2:DescribeRegions",  
-            "Resource": "*"  
-        }  
-    ]  
-}
-```
-### AWS Policies Required
-
-
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target or build infrastructure.
+The AWS [IAM Policy Simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) is useful for evaluating policies and access.
 
 :::
 
-### AWS S3
+## AWS S3 policies and permissions
 
-#### Reading from AWS S3
+Several policies are required to read from AWS S3, write to AWS S3, or both read and write to AWS S3.
 
-There are two policies required:
+:::tip
 
-* The Managed Policy **AmazonS3ReadOnlyAccess**.
-* The [Customer Managed Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies) you create using `ec2:DescribeRegions`.
-
-
-:::warning
-The AWS [IAM Policy Simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) is a useful tool for evaluating policies and access.
+If you want to use an S3 bucket that is in a separate account than the account used to set up the AWS Cloud Provider, you can grant cross-account bucket access. For more information, go to the AWS documentation on [Bucket Owner Granting Cross-Account Bucket Permissions](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example2.html).
 
 :::
 
-**Policy Name**: `AmazonS3ReadOnlyAccess`.
+### Read from AWS S3
 
-**Policy ARN:** `arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess`.
+There are two required policies to read from AWS S3:
 
-**Description:** Provides read-only access to all buckets via the AWS Management Console.
+* `AmazonS3ReadOnlyAccess` managed policy
+* A [Customer Managed Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies) you create using `ec2:DescribeRegions`
 
-**Policy JSON:**
+<details>
+<summary>AmazonS3ReadOnlyAccess managed policy</summary>
 
-
-```
-{  
-  "Version": "2012-10-17",  
-  "Statement": [  
-    {  
-      "Effect": "Allow",  
-      "Action": [  
-        "s3:Get*",  
-        "s3:List*"  
-      ],  
-      "Resource": "*"  
-    }  
-  ]  
-}
-```
-**Policy Name:** `HarnessS3`.
-
-**Description:** Harness S3 policy that uses EC2 permissions. This is a customer-managed policy you must create. In this example we have named it `HarnessS3`.
-
-**Policy JSON:**
-
+* **Policy Name:** `AmazonS3ReadOnlyAccess`
+* **Policy ARN:** `arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess`
+* **Description:** `Provides read-only access to all buckets via the AWS Management Console`
+* **Policy JSON:**
 
 ```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Sid": "VisualEditor0",  
-            "Effect": "Allow",  
-            "Action": "ec2:DescribeRegions",  
-            "Resource": "*"  
-        }  
-    ]  
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 ```
 
-:::note
-If you want to use an S3 bucket that is in a separate account than the account used to set up the AWS Cloud Provider, you can grant cross-account bucket access. For more information, see [Bucket Owner Granting Cross-Account Bucket Permissions](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example2.html) from AWS.
+</details>
 
-:::
+<details>
+<summary>ec2:DescribeRegions customer managed policy</summary>
 
-#### Writing to AWS S3
-
-There are two policies required:
-
-* The [Customer Managed Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies) you create, for example **HarnessS3Write**.
-* The Customer Managed Policy you create using `ec2:DescribeRegions`.
-
-**Policy Name**:`HarnessS3Write`.
-
-**Description:** Custom policy for pushing to S3.
-
-**Policy JSON:**
-
+* **Policy Name:** Any name, such as `HarnessS3`
+* **Description:** `Harness S3 policy that uses EC2 permissions.`
+* **Policy JSON:**
 
 ```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Sid": "AllObjectActions",  
-            "Effect": "Allow",  
-            "Action": "s3:*Object",  
-            "Resource": ["arn:aws:s3:::bucket-name/*"]  
-        }  
-    ]  
-}
-```
-**Policy Name:** `HarnessS3`.
-
-**Description:** Harness S3 policy that uses EC2 permissions. This is a customer-managed policy you must create. In this example we have named it `HarnessS3`.
-
-**Policy JSON:**
-
-
-```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Sid": "VisualEditor0",  
-            "Effect": "Allow",  
-            "Action": "ec2:DescribeRegions",  
-            "Resource": "*"  
-        }  
-    ]  
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ec2:DescribeRegions",
+            "Resource": "*"
+        }
+    ]
 }
 ```
 
-:::note
-If you want to use an S3 bucket that is in a separate account than the account used to set up the AWS Cloud Provider, you can grant cross-account bucket access. For more information, see [Bucket Owner Granting Cross-Account Bucket Permissions](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example2.html) from AWS.
+</details>
 
-:::
+### Write to AWS S3
 
-#### Read and Write to AWS S3
+There are two [Customer Managed Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies) required to write to AWS S3.
 
-You can have a single policy that reads and writes with an S3 bucket.
+<details>
+<summary>S3 write customer managed policy</summary>
 
-See [Allows read and write access to objects in an S3 Bucket](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) and [Allows read and write access to objects in an S3 Bucket, programmatically and in the console](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket-console.html) from AWS.
-
-Here is an example that includes AWS console access:
-
+* **Policy Name:** `HarnessS3Write`
+* **Description:** `Custom policy for pushing to S3.`
+* **Policy JSON:**
 
 ```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Sid": "ConsoleAccess",  
-            "Effect": "Allow",  
-            "Action": [  
-                "s3:GetAccountPublicAccessBlock",  
-                "s3:GetBucketAcl",  
-                "s3:GetBucketLocation",  
-                "s3:GetBucketPolicyStatus",  
-                "s3:GetBucketPublicAccessBlock",  
-                "s3:ListAllMyBuckets"  
-            ],  
-            "Resource": "*"  
-        },  
-        {  
-            "Sid": "ListObjectsInBucket",  
-            "Effect": "Allow",  
-            "Action": "s3:ListBucket",  
-            "Resource": ["arn:aws:s3:::bucket-name"]  
-        },  
-        {  
-            "Sid": "AllObjectActions",  
-            "Effect": "Allow",  
-            "Action": "s3:*Object",  
-            "Resource": ["arn:aws:s3:::bucket-name/*"]  
-        }  
-    ]  
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::bucket-name/*"]
+        }
+    ]
 }
 ```
-### AWS Elastic Container Registry (ECR)
 
-#### Pulling from ECR
+</details>
 
-**Policy Name**:`AmazonEC2ContainerRegistryReadOnly`.
+<details>
+<summary>ec2:DescribeRegions customer managed policy</summary>
 
-**Policy ARN:** `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly`.
-
-**Description:** Provides read-only access to Amazon EC2 Container Registry repositories.
-
-**Policy JSON:**
-
+* **Policy Name:** Any name, such as `HarnessS3`
+* **Description:** `Harness S3 policy that uses EC2 permissions.`
+* **Policy JSON:**
 
 ```
-{  
-  "Version": "2012-10-17",  
-  "Statement": [  
-      {  
-              "Effect": "Allow",  
-              "Action": [  
-                  "ecr:GetAuthorizationToken",  
-                  "ecr:BatchCheckLayerAvailability",  
-                  "ecr:GetDownloadUrlForLayer",  
-                  "ecr:GetRepositoryPolicy",  
-                  "ecr:DescribeRepositories",  
-                  "ecr:ListImages",  
-                  "ecr:DescribeImages",  
-                  "ecr:BatchGetImage"  
-              ],  
-              "Resource": "*"  
-      }  
-  ]  
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ec2:DescribeRegions",
+            "Resource": "*"
+        }
+    ]
 }
 ```
-#### Pushing to ECR
 
-**Policy Name**: `AmazonEC2ContainerRegistryFullAccess`.
+</details>
 
-**Policy ARN:** `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess`. See [AWS managed policies for Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam-awsmanpol.html) from AWS.
+### Read and Write to AWS S3
 
-**Policy JSON Example:**
+You can have a single policy that reads and writes to an S3 bucket.
 
+<details>
+<summary>S3 read and write policy JSON example</summary>
+
+Here is a JSON example of a policy that includes AWS console access:
 
 ```
-{  
-    "Version": "2012-10-17",  
-    "Statement": [  
-        {  
-            "Effect": "Allow",  
-            "Action": [  
-                "ecr:*",  
-                "cloudtrail:LookupEvents"  
-            ],  
-            "Resource": "*"  
-        },  
-        {  
-            "Effect": "Allow",  
-            "Action": [  
-                "iam:CreateServiceLinkedRole"  
-            ],  
-            "Resource": "*",  
-            "Condition": {  
-                "StringEquals": {  
-                    "iam:AWSServiceName": [  
-                        "replication.ecr.amazonaws.com"  
-                    ]  
-                }  
-            }  
-        }  
-    ]  
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ConsoleAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetAccountPublicAccessBlock",
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ListObjectsInBucket",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": ["arn:aws:s3:::bucket-name"]
+        },
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::bucket-name/*"]
+        }
+    ]
 }
 ```
-### AWS CloudFormation
 
-The credentials required for provisioning depend on what you are provisioning.
+</details>
 
-For example, if you wanted to give full access to create and manage EKS clusters, you could use a policy like this:
+For more information, go to the following AWS documentation:
+* [Allow read and write access to objects in an S3 Bucket](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html)
+* [Allow read and write access to objects in an S3 Bucket, programmatically and in the console](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket-console.html).
 
+## AWS Elastic Container Registry (ECR) policies and permissions
+
+Use these policies to pull or push to ECR. For more information, go to the AWS documentation about [AWS managed policies for Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam-awsmanpol.html).
+
+<details>
+<summary>Pull from ECR policy</summary>
+
+* **Policy Name:** `AmazonEC2ContainerRegistryReadOnly`
+* **Policy ARN:** `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly`
+* **Description:** `Provides read-only access to Amazon EC2 Container Registry repositories.`
+* **Policy JSON:**
 
 ```
-{  
-     "Version": "2012-10-17",  
-     "Statement": [  
-         {  
-             "Effect": "Allow",  
-             "Action": [  
-                 "autoscaling:*",  
-                 "cloudformation:*",  
-                 "ec2:*",  
-                 "eks:*",  
-                 "iam:*",  
-                 "ssm:*"  
-             ],  
-             "Resource": "*"  
-         }  
-     ]  
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+              "Effect": "Allow",
+              "Action": [
+                  "ecr:GetAuthorizationToken",
+                  "ecr:BatchCheckLayerAvailability",
+                  "ecr:GetDownloadUrlForLayer",
+                  "ecr:GetRepositoryPolicy",
+                  "ecr:DescribeRepositories",
+                  "ecr:ListImages",
+                  "ecr:DescribeImages",
+                  "ecr:BatchGetImage"
+              ],
+              "Resource": "*"
+      }
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary>Push to ECR</summary>
+
+* **Policy Name:** `AmazonEC2ContainerRegistryFullAccess`
+* **Policy ARN:** `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess`
+* **Policy JSON:**
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:*",
+                "cloudtrail:LookupEvents"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": [
+                        "replication.ecr.amazonaws.com"
+                    ]
+                }
+            }
+        }
+    ]
+}
+```
+
+</details>
+
+## AWS CloudFormation policies
+
+The required policies depend on what you are provisioning. Here are some examples:
+
+<details>
+<summary>Example: Create and manage EKS clusters</summary>
+
+This example policy gives full access to create and manage EKS clusters.
+
+```
+{
+     "Version": "2012-10-17",
+     "Statement": [
+         {
+             "Effect": "Allow",
+             "Action": [
+                 "autoscaling:*",
+                 "cloudformation:*",
+                 "ec2:*",
+                 "eks:*",
+                 "iam:*",
+                 "ssm:*"
+             ],
+             "Resource": "*"
+         }
+     ]
  }
 ```
-If you wanted to provide limited permissions for EKS clusters, you might use a policy like this:
 
+</details>
+
+<details>
+<summary>Example: Limited permissions for EKS clusters</summary>
+
+This example policy gives limited permission to EKS clusters.
 
 ```
- {  
-     "Version": "2012-10-17",  
-     "Statement": [  
-         {  
-             "Effect": "Allow",  
-             "Action": [  
-                 "autoscaling:CreateAutoScalingGroup",  
-                 "autoscaling:DescribeAutoScalingGroups",  
-                 "autoscaling:DescribeScalingActivities",  
-                 "autoscaling:UpdateAutoScalingGroup",  
-                 "autoscaling:CreateLaunchConfiguration",  
-                 "autoscaling:DescribeLaunchConfigurations",  
-                 "cloudformation:CreateStack",  
-                 "cloudformation:DescribeStacks",  
-                 "ec2:AuthorizeSecurityGroupEgress",  
-                 "ec2:AuthorizeSecurityGroupIngress",  
-                 "ec2:RevokeSecurityGroupEgress",  
-                 "ec2:RevokeSecurityGroupIngress",  
-                 "ec2:CreateSecurityGroup",  
-                 "ec2:createTags",  
-                 "ec2:DescribeImages",  
-                 "ec2:DescribeKeyPairs",  
-                 "ec2:DescribeRegions",  
-                 "ec2:DescribeSecurityGroups",  
-                 "ec2:DescribeSubnets",  
-                 "ec2:DescribeVpcs",  
-                 "eks:CreateCluster",  
-                 "eks:DescribeCluster",  
-                 "iam:AddRoleToInstanceProfile",  
-                 "iam:AttachRolePolicy",  
-                 "iam:CreateRole",  
-                 "iam:CreateInstanceProfile",  
-                 "iam:CreateServiceLinkedRole",  
-                 "iam:GetRole",  
-                 "iam:ListRoles",  
-                 "iam:PassRole",  
-                 "ssm:GetParameters"  
-             ],  
-             "Resource": "*"  
-         }  
-     ]  
+ {
+     "Version": "2012-10-17",
+     "Statement": [
+         {
+             "Effect": "Allow",
+             "Action": [
+                 "autoscaling:CreateAutoScalingGroup",
+                 "autoscaling:DescribeAutoScalingGroups",
+                 "autoscaling:DescribeScalingActivities",
+                 "autoscaling:UpdateAutoScalingGroup",
+                 "autoscaling:CreateLaunchConfiguration",
+                 "autoscaling:DescribeLaunchConfigurations",
+                 "cloudformation:CreateStack",
+                 "cloudformation:DescribeStacks",
+                 "ec2:AuthorizeSecurityGroupEgress",
+                 "ec2:AuthorizeSecurityGroupIngress",
+                 "ec2:RevokeSecurityGroupEgress",
+                 "ec2:RevokeSecurityGroupIngress",
+                 "ec2:CreateSecurityGroup",
+                 "ec2:createTags",
+                 "ec2:DescribeImages",
+                 "ec2:DescribeKeyPairs",
+                 "ec2:DescribeRegions",
+                 "ec2:DescribeSecurityGroups",
+                 "ec2:DescribeSubnets",
+                 "ec2:DescribeVpcs",
+                 "eks:CreateCluster",
+                 "eks:DescribeCluster",
+                 "iam:AddRoleToInstanceProfile",
+                 "iam:AttachRolePolicy",
+                 "iam:CreateRole",
+                 "iam:CreateInstanceProfile",
+                 "iam:CreateServiceLinkedRole",
+                 "iam:GetRole",
+                 "iam:ListRoles",
+                 "iam:PassRole",
+                 "ssm:GetParameters"
+             ],
+             "Resource": "*"
+         }
+     ]
  }
 ```
-### Use Kubernetes Cluster Connector for EKS
+
+</details>
+
+## Connect to EKS
 
 If you want to connect Harness to Elastic Kubernetes Service (Amazon EKS), use the platform-agnostic [Kubernetes Cluster Connector](kubernetes-cluster-connector-settings-reference.md).
 
-### AWS Serverless Lambda
+## AWS Serverless Lambda
 
-There are three authentication options for the AWS Connector when used for AWS ECS images for AWS Serverless Lambda deployments:
+There are three authentication options for the AWS connector when used for AWS ECS images for AWS Serverless Lambda deployments:
 
 * [AWS Access Key](#aws-access-key)
 * [Assume IAM Role on Delegate](#assume-iam-role-on-delegate)
 * [Use IRSA](#use-irsa-iam-roles-for-service-accounts)
-* [Enable cross-account access (STS Role)](#enable-cross-account-access-sts-role)
-	+ Requires that the AWS CLI is installed on the Delegate. See [Serverless and ​Enable cross-account access (STS Role)](#serverless-and-​enable-cross-account-access-sts-role).
 
-For steps on Serverless Lambda deployments, see [Serverless Lambda CD Quickstart](../../../continuous-delivery/onboard-cd/cd-quickstarts/serverless-lambda-cd-quickstart.md).
+You can also use STS roles with Serverless Lambda deployments. For details about this, go to [Serverless cross-account access (STS Role)](#serverless-cross-account-access-sts-role).
 
+For instructions for Serverless Lambda deployments, go to [Serverless Lambda CD quickstart](../../../continuous-delivery/onboard-cd/cd-quickstarts/serverless-lambda-cd-quickstart.md).
 
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target or build infrastructure.
+### Permissions
 
-:::
+All authentication methods for Serverless deployments require an AWS User with specific AWS permissions, as described in the Serverless documentation on [AWS Credentials](https://www.serverless.com/framework/docs/providers/aws/guide/credentials).
 
-#### Permissions
+To create the AWS user, do the following:
 
-All authentication methods for Serverless deployments require an AWS User with specific AWS permissions, as described in [AWS Credentials](https://www.serverless.com/framework/docs/providers/aws/guide/credentials) from Serverless. To create the AWS User, do the following:
+1. Log into your AWS account, and go to the Identity & Access Management (IAM) page.
+2. Select **Users**, and then **Add user**. Enter a name, enable **Programmatic access**, and then select **Next**.
+3. On the **Permissions** page, do one of the following:
+	* **Full Admin Access:** Select **Attach existing policies directly**, search for and select **AdministratorAccess**, and then select **Next: Review**. Review the configuration and select **Create user**.
+	* **Limited Access:** Select **Create policy**, select the **JSON** tab, and add the following [Serverless gist](https://gist.github.com/ServerlessBot/7618156b8671840a539f405dea2704c8) JSON code:
 
-* Log into your AWS account and go to the Identity & Access Management (IAM) page.
-* Click **Users**, and then **Add user**. Enter a name. Enable **Programmatic access** by clicking the checkbox. Click **Next** to go to the **Permissions** page. Do one of the following:
-	+ **Full Admin Access:** click on **Attach existing policies directly**. Search for and select **AdministratorAccess** then click **Next: Review**. Check to make sure everything looks good and click **Create user**.
-	+ **Limited Access:** click on **Create policy**. Select the **JSON** tab, and add the JSON using the following code from the [Serverless gist](https://gist.github.com/ServerlessBot/7618156b8671840a539f405dea2704c8):
+<details>
+<summary>IAMCredentials.json</summary>
 
-IAMCredentials.json
 ```
-{  
-    "Statement": [  
-        {  
-            "Action": [  
-                "apigateway:*",  
-                "cloudformation:CancelUpdateStack",  
-                "cloudformation:ContinueUpdateRollback",  
-                "cloudformation:CreateChangeSet",  
-                "cloudformation:CreateStack",  
-                "cloudformation:CreateUploadBucket",  
-                "cloudformation:DeleteStack",  
-                "cloudformation:Describe*",  
-                "cloudformation:EstimateTemplateCost",  
-                "cloudformation:ExecuteChangeSet",  
-                "cloudformation:Get*",  
-                "cloudformation:List*",  
-                "cloudformation:UpdateStack",  
-                "cloudformation:UpdateTerminationProtection",  
-                "cloudformation:ValidateTemplate",  
-                "dynamodb:CreateTable",  
-                "dynamodb:DeleteTable",  
-                "dynamodb:DescribeTable",  
-                "dynamodb:DescribeTimeToLive",  
-                "dynamodb:UpdateTimeToLive",  
-                "ec2:AttachInternetGateway",  
-                "ec2:AuthorizeSecurityGroupIngress",  
-                "ec2:CreateInternetGateway",  
-                "ec2:CreateNetworkAcl",  
-                "ec2:CreateNetworkAclEntry",  
-                "ec2:CreateRouteTable",  
-                "ec2:CreateSecurityGroup",  
-                "ec2:CreateSubnet",  
-                "ec2:CreateTags",  
-                "ec2:CreateVpc",  
-                "ec2:DeleteInternetGateway",  
-                "ec2:DeleteNetworkAcl",  
-                "ec2:DeleteNetworkAclEntry",  
-                "ec2:DeleteRouteTable",  
-                "ec2:DeleteSecurityGroup",  
-                "ec2:DeleteSubnet",  
-                "ec2:DeleteVpc",  
-                "ec2:Describe*",  
-                "ec2:DetachInternetGateway",  
-                "ec2:ModifyVpcAttribute",  
-                "events:DeleteRule",  
-                "events:DescribeRule",  
-                "events:ListRuleNamesByTarget",  
-                "events:ListRules",  
-                "events:ListTargetsByRule",  
-                "events:PutRule",  
-                "events:PutTargets",  
-                "events:RemoveTargets",  
-                "iam:AttachRolePolicy",  
-                "iam:CreateRole",  
-                "iam:DeleteRole",  
-                "iam:DeleteRolePolicy",  
-                "iam:DetachRolePolicy",  
-                "iam:GetRole",  
-                "iam:PassRole",  
-                "iam:PutRolePolicy",  
-                "iot:CreateTopicRule",  
-                "iot:DeleteTopicRule",  
-                "iot:DisableTopicRule",  
-                "iot:EnableTopicRule",  
-                "iot:ReplaceTopicRule",  
-                "kinesis:CreateStream",  
-                "kinesis:DeleteStream",  
-                "kinesis:DescribeStream",  
-                "lambda:*",  
-                "logs:CreateLogGroup",  
-                "logs:DeleteLogGroup",  
-                "logs:DescribeLogGroups",  
-                "logs:DescribeLogStreams",  
-                "logs:FilterLogEvents",  
-                "logs:GetLogEvents",  
-                "logs:PutSubscriptionFilter",  
-                "s3:CreateBucket",  
-                "s3:DeleteBucket",  
-                "s3:DeleteBucketPolicy",  
-                "s3:DeleteObject",  
-                "s3:DeleteObjectVersion",  
-                "s3:GetObject",  
-                "s3:GetObjectVersion",  
-                "s3:ListAllMyBuckets",  
-                "s3:ListBucket",  
-                "s3:PutBucketNotification",  
-                "s3:PutBucketPolicy",  
-                "s3:PutBucketTagging",  
-                "s3:PutBucketWebsite",  
-                "s3:PutEncryptionConfiguration",  
-                "s3:PutObject",  
-                "sns:CreateTopic",  
-                "sns:DeleteTopic",  
-                "sns:GetSubscriptionAttributes",  
-                "sns:GetTopicAttributes",  
-                "sns:ListSubscriptions",  
-                "sns:ListSubscriptionsByTopic",  
-                "sns:ListTopics",  
-                "sns:SetSubscriptionAttributes",  
-                "sns:SetTopicAttributes",  
-                "sns:Subscribe",  
-                "sns:Unsubscribe",  
-                "states:CreateStateMachine",  
-                "states:DeleteStateMachine"  
-            ],  
-            "Effect": "Allow",  
-            "Resource": "*"  
-        }  
-    ],  
-    "Version": "2012-10-17"  
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:*",
+                "cloudformation:CancelUpdateStack",
+                "cloudformation:ContinueUpdateRollback",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:CreateStack",
+                "cloudformation:CreateUploadBucket",
+                "cloudformation:DeleteStack",
+                "cloudformation:Describe*",
+                "cloudformation:EstimateTemplateCost",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:Get*",
+                "cloudformation:List*",
+                "cloudformation:UpdateStack",
+                "cloudformation:UpdateTerminationProtection",
+                "cloudformation:ValidateTemplate",
+                "dynamodb:CreateTable",
+                "dynamodb:DeleteTable",
+                "dynamodb:DescribeTable",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:UpdateTimeToLive",
+                "ec2:AttachInternetGateway",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateInternetGateway",
+                "ec2:CreateNetworkAcl",
+                "ec2:CreateNetworkAclEntry",
+                "ec2:CreateRouteTable",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateSubnet",
+                "ec2:CreateTags",
+                "ec2:CreateVpc",
+                "ec2:DeleteInternetGateway",
+                "ec2:DeleteNetworkAcl",
+                "ec2:DeleteNetworkAclEntry",
+                "ec2:DeleteRouteTable",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DeleteSubnet",
+                "ec2:DeleteVpc",
+                "ec2:Describe*",
+                "ec2:DetachInternetGateway",
+                "ec2:ModifyVpcAttribute",
+                "events:DeleteRule",
+                "events:DescribeRule",
+                "events:ListRuleNamesByTarget",
+                "events:ListRules",
+                "events:ListTargetsByRule",
+                "events:PutRule",
+                "events:PutTargets",
+                "events:RemoveTargets",
+                "iam:AttachRolePolicy",
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iot:CreateTopicRule",
+                "iot:DeleteTopicRule",
+                "iot:DisableTopicRule",
+                "iot:EnableTopicRule",
+                "iot:ReplaceTopicRule",
+                "kinesis:CreateStream",
+                "kinesis:DeleteStream",
+                "kinesis:DescribeStream",
+                "lambda:*",
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:FilterLogEvents",
+                "logs:GetLogEvents",
+                "logs:PutSubscriptionFilter",
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:ListAllMyBuckets",
+                "s3:ListBucket",
+                "s3:PutBucketNotification",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketTagging",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutObject",
+                "sns:CreateTopic",
+                "sns:DeleteTopic",
+                "sns:GetSubscriptionAttributes",
+                "sns:GetTopicAttributes",
+                "sns:ListSubscriptions",
+                "sns:ListSubscriptionsByTopic",
+                "sns:ListTopics",
+                "sns:SetSubscriptionAttributes",
+                "sns:SetTopicAttributes",
+                "sns:Subscribe",
+                "sns:Unsubscribe",
+                "states:CreateStateMachine",
+                "states:DeleteStateMachine"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
 }
 ```
-* View and copy the API Key and Secret to a temporary place. You'll need them when setting up the Harness AWS Connector later in this quickstart.
 
-#### Installing Serverless on the Delegate
+</details>
 
-The Delegate(s) used by the AWS Connector must have Serverless installed.
+4. View and copy the API Key and Secret to a safe place. You'll need them to set up the Harness AWS connector.
 
-To install Serverless on a Kubernetes Delegate, edit the Delegate YAML to install Serverless when the Delegate pods are created.
+### Installing Serverless on the delegate
 
-Open the Delegate YAML in a text editor.
+The delegate(s) used by the Harness AWS connector must have Serverless installed.
 
-Locate the Environment variable `INIT_SCRIPT` in the `StatefulSet`.
+To install Serverless on a Kubernetes delegate, edit the delegate YAML to install Serverless when the delegate pods are created.
 
+1. Open the delegate YAML in a text editor.
+2. Locate the environment variable `INIT_SCRIPT` in the `StatefulSet`.
 
 ```
-...  
-        - name: INIT_SCRIPT  
-          value: ""  
 ...
-```
-Replace the value with the follow Serverless installation script.
-
-
-```
-...  
-        - name: INIT_SCRIPT  
-          value: |-  
-            #!/bin/bash  
-            echo "Start"  
-            export DEBIAN_FRONTEND=noninteractive  
-            echo "non-inte"  
-            apt-get update  
-            echo "updagte"  
-            apt install -yq npm  
-            echo "npm"  
-            npm install -g serverless@v2.50.0  
-            echo "Done"  
+        - name: INIT_SCRIPT
+          value: ""
 ...
 ```
 
-:::note
-In rare cases when the Delegate OS does not support `apt` (like Red Hat Linux), you can can edit this script to install `npm`. The rest of the code should remain the same.Save the YAML file as **harness-delegate.yml**.
-
-:::
-
-You can now apply the Delegate YAML: `kubectl apply -f harness-delegate.yml`.
-
-#### Serverless and ​Enable cross-account access (STS Role)
-
-If you use the ​**Enable cross-account access (STS Role)** option in the AWS Connector for a Serverless Lambda deployment, the Delegate that is used by the Connector must have the AWS CLI installed.
-
-The AWS CLI is not required for the other authentication methods.
-
-For steps on installing software with the Delegate, see [Build custom delegate images with third-party tools](/docs/platform/2_Delegates/customize-delegates/build-custom-delegate-images-with-third-party-tools.md).
-
-### Switching Policies
-
-If the IAM role used by your AWS Connector does not have the policies required by the AWS service you want to access, you can modify or switch the role.
-
-This entails changing the role assigned to the AWS account or Harness Delegate your AWS Connector is using.
-
-When you switch or modify the IAM role used by the Connector, it might take up to 5 minutes to take effect.
-
-### AWS Connector Settings
-
-The AWS Connector settings are described below.
-
-#### Name
-
-The unique name for this Connector.
-
-#### ID
-
-See [Entity Identifier Reference](../../20_References/entity-identifier-reference.md).
-
-#### Description
-
-Text string.
-
-#### Tags
-
-See [Tags Reference](../../20_References/tags-reference.md).
-
-#### Credentials
-
-
-:::note
-Ensure that the AWS IAM roles applied to the credentials you use (the Harness Delegate or the access key) includes the policies needed by Harness to deploy to the target AWS service.
-
-:::
-
-
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target infrastructure.
-
-:::
-
-Credentials that enable Harness to connect your AWS account.
-
-There are three options:
-
-* Assume IAM Role on Delegate
-* AWS Access Keys manually
-* Use IRSA
-
-The settings for each option are described below.
-
-### Assume IAM Role on Delegate
-
-
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target infrastructure.
-
-:::
-
-This is often the simplest method for connecting Harness to your AWS account and services.
-
-Once you select this option, you can select a Delegate in the next step of the AWS Connector.
-
-Typically, the Delegate(s) is running in the target infrastructure.
-
-### AWS Access Key
-
-The access key and your secret key of the IAM Role to use for the AWS account.
-
-You can use Harness secrets for both. See [Add Text Secrets](../../6_Security/2-add-use-text-secrets.md).
-
-#### Access and Secret Keys
-
-See [Access Keys (Access Key ID and Secret Access Key)](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) from AWS.
-
-### Use IRSA (IAM roles for service accounts)
-
-Select **Use IRSA** if you want to have the Harness Kubernetes Delegate in AWS EKS use a specific IAM role when making authenticated requests to resources.
-
-By default, the Harness Kubernetes Delegate uses a ClusterRoleBinding to the **default** service account. Instead, you can use AWS IAM roles for service accounts (IRSA) to associate a specific IAM role with the service account used by the Harness Kubernetes Delegate.
-
-
-:::note
-See [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) from AWS.
-
-:::
-
-Setting up this feature requires a few more steps than other methods, but it is a simple process.
-
-
-:::note
-The following steps are for a new Delegate installation and new AWS Connector. If you updating an existing Delegate and AWS Connector, you can simply edit the Delegate YAML for your existing Delegate as described below, and select the **Use IRSA** option in your AWS Connector.
-
-:::
-
-Create the IAM role with the policies you want the Delegate to use. The policies you select with depend on what AWS resources you are deploying via the Delegate. See the different [AWS Policies Required](#aws-policies-required) sections in this document.
-
-In the cluster where the Delegate will be installed, create a service account and attach the IAM role to it.
-
-Here is an example of how to create a new service account in the cluster where you will install the Delegate and attach the IAM policy to it:
-
+3. Replace the `value` with the follow Serverless installation script:
 
 ```
-eksctl create iamserviceaccount \  
-    --name=cdp-admin \  
-    --namespace=default \  
-    --cluster=test-eks \  
-    --attach-policy-arn=<policy-arn> \  
-    --approve \  
-    --override-existing-serviceaccounts —region=us-east-1
-```
-In Harness, download the Harness Kubernetes Delegate YAML file. See [Install a Kubernetes Delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md).
-
-Open the Delegate YAML file in text editor.
-
-Add service account with access to IAM role to Delegate YAML.
-
-There are two sections in the Delegate YAML that you must update.
-
-First, update the `ClusterRoleBinding` by adding replacing the subject name `default` with the name of the service account with the attached IAM role.
-
-Old `ClusterRoleBinding`:
-
-```
----  
-apiVersion: rbac.authorization.k8s.io/v1beta1  
-kind: ClusterRoleBinding  
-metadata:  
-  name: harness-delegate-cluster-admin  
-subjects:  
-  - kind: ServiceAccount  
-    name: default  
-    namespace: harness-delegate-ng 
-roleRef:  
-  kind: ClusterRole  
-  name: cluster-admin  
-  apiGroup: rbac.authorization.k8s.io  
----
-```
-
-New `ClusterRoleBinding` (for example, using the name `iamserviceaccount`):
-
-```
----  
-apiVersion: rbac.authorization.k8s.io/v1beta1  
-kind: ClusterRoleBinding  
-metadata:  
-  name: harness-delegate-cluster-admin  
-subjects:  
-  - kind: ServiceAccount  
-    name: iamserviceaccount
-    namespace: harness-delegate-ng
-roleRef:  
-  kind: ClusterRole  
-  name: cluster-admin  
-  apiGroup: rbac.authorization.k8s.io  
----
-```
-
-Next, update StatefulSet spec with the new `serviceAccountName`.
-
-Old StatefulSet spec `serviceAccountName`:
-
-```
-...  
-    spec:  
-      containers:  
-      - image: harness/delegate:latest  
-        imagePullPolicy: Always  
-        name: harness-delegate-instance  
-        ports:  
-          - containerPort: 8080  
+...
+        - name: INIT_SCRIPT
+          value: |-
+            #!/bin/bash
+            echo "Start"
+            export DEBIAN_FRONTEND=noninteractive
+            echo "non-inte"
+            apt-get update
+            echo "updagte"
+            apt install -yq npm
+            echo "npm"
+            npm install -g serverless@v2.50.0
+            echo "Done"
 ...
 ```
 
-New StatefulSet spec serviceAccountName (for example, using the name `iamserviceaccount`):
-
-```
-...  
-    spec:  
-      serviceAccountName: iamserviceaccount
-      containers:  
-      - image: harness/delegate:latest  
-        imagePullPolicy: Always  
-        name: harness-delegate-instance  
-        ports:  
-          - containerPort: 8080  
-...
-```
-
-Save the Delegate YAML file.
-
-Install the Delegate in your EKS cluster and register the Delegate with Harness. See [Install a Kubernetes Delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md).
-
-
 :::note
-When you install the Delegate in the cluster, the serviceAccount you added is used and the environment variables `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are added automatically by EKS.Create a new AWS Connector.
+
+In rare cases when the delegate OS does not support `apt`, such as Red Hat Linux, you must edit this script to install `npm`. The rest of the code should remain the same.
 
 :::
 
-In **Credentials**, select **Use IRSA**.
+4. Save the YAML file as `harness-delegate.yml`.
+5. Apply the delegate YAML: `kubectl apply -f harness-delegate.yml`
 
-In **Set up** **Delegates**, select the Delegate you used.
+### Serverless cross-account access (STS Role)
 
-Click **Save and Continue** to verify the Delegate credentials.
+If you use the **Enable cross-account access (STS Role)** option in the AWS connector for a Serverless Lambda deployment, the delegate that is used by the Connector must have the AWS CLI installed. The AWS CLI is not required for the other authentication methods.
+
+For instructions on installing software with the delegate, go to [Run initialization scripts on delegates](../../2_Delegates/configure-delegates/run-scripts-on-delegates.md).
+
+## Harness AWS connector settings
+
+The AWS connector settings include:
+* **Name:** The unique name for the connector
+* **Id:** Go to [Entity Identifier reference](../../20_References/entity-identifier-reference.md)
+* **Description:** Text string
+* **Tags**: Go to [Tags reference](../../20_References/tags-reference.md)
+* **Credentials**: Credentials that enable Harness to connect your AWS account. There are three primary options:
+  * **Assume IAM Role on Delegate:** This is often the simplest method for connecting Harness to your AWS account and services. Once you select this option, you can select a delegate in the next step of AWS connector creation. Typically, the delegate runs in the target infrastructure.
+  * **AWS Access Key:** The [Access Key and Secret Access Key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) of the IAM Role to use for the AWS account. You can use [Harness Text Secrets](../../6_Security/2-add-use-text-secrets.md) for both.
+  * **Use IRSA:** Allows the Harness Kubernetes delegate in AWS EKS to use a specific IAM role when making authenticated requests to resources. By default, the Harness Kubernetes delegate uses a ClusterRoleBinding to the **default** service account; whereas, with this option, you can use AWS [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to associate a specific IAM role with the service account used by the Harness Kubernetes delegate.
+
+<details>
+<summary>Configure IRSA credentials for AWS connectors</summary>
+
+Setting up IRSA credentials requires a few more steps than other methods, but it is a simple process.
+
+:::tip
+
+The following steps assume this is a new delegate installation and a new AWS connector. If you are updating an existing delegate and AWS connector, you only need to edit the delegate YAML for your existing delegate, as described below, and select the **Use IRSA** option in your AWS connector's **Credentials** settings.
+
+:::
+
+1. Create the IAM role with the policies that you want the Delegate to use. The policies you select depend on what AWS resources you are deploying via the delegate. For details, go to the [AWS permissions and policies](#aws-permissions-and-policies) section.
+2. In the cluster where the delegate will be installed, create a service account and attach the IAM role to it.
+   Here is an example of how to create a new service account in the cluster where you will install the delegate and attach the IAM policy to it:
+
+   ```
+   eksctl create iamserviceaccount \
+       --name=cdp-admin \
+       --namespace=default \
+       --cluster=test-eks \
+       --attach-policy-arn=<policy-arn> \
+       --approve \
+       --override-existing-serviceaccounts —region=us-east-1
+   ```
+
+3. In Harness, download the Harness Kubernetes delegate YAML file. For instructions, go to [Install a Kubernetes delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md).
+4. Open the delegate YAML file in text editor.
+5. Add the service account with access to IAM role to the delegate YAML. There are two sections in the Delegate YAML that you must update:
+   1. Update the `ClusterRoleBinding` by replacing the subject name `default` with the name of the service account with the attached IAM role, for example:
+
+      ```
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBinding
+      metadata:
+        name: harness-delegate-cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: default           // Change to relevant service account name, such as myserviceaccount
+          namespace: harness-delegate-ng
+      roleRef:
+        kind: ClusterRole
+        name: cluster-admin
+        apiGroup: rbac.authorization.k8s.io
+      ---
+      ```
+
+    2. Add `serviceAccountName` to the `StatefulSet` spec. For example:
+
+      ```
+      ...
+          spec:
+            serviceAccountName: myserviceaccount  // New line. Use the same service account name you used in the ClusterRole Binding.
+            containers:
+            - image: harness/delegate:latest
+              imagePullPolicy: Always
+              name: harness-delegate-instance
+              ports:
+               - containerPort: 8080
+      ...
+      ```
+
+6. Save the delegate YAML file.
+7. [Install the Kubernetes delegate](../../2_Delegates/advanced-installation/install-a-kubernetes-delegate.md) in your EKS cluster and register the delegate with Harness. When you install the delegate in the cluster, the SA you added is used, and the environment variables `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are added automatically by EKS.
+8. In Harness, create a new AWS connector.
+9. For **Credentials**, select **Use IRSA**.
+10. For **Select Connectivity Mode**, select **Connect through a Harness Delegate**, and then select the delegate you just installed.
+11. Select **Save and Continue** to verify the delegate credentials and test the connection.
+
+</details>
+
+:::caution
+
+Ensure that the AWS IAM roles applied to the credentials you use (the Harness delegate or the access key) includes the policies needed by Harness to deploy to the target AWS service.
+
+If the IAM role used by your AWS connector does not have the policies required by the AWS service you want to access, you can modify or switch the role. This entails changing the role assigned to the AWS account or Harness delegate that your AWS connector is using. When you switch or modify the IAM role used by the connector, it might take up to 5 minutes to take effect.
+
+Additionally, the [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS connectors regardless of what AWS service you are using for your target infrastructure.
+
+The AWS [IAM Policy Simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) is a useful tool for evaluating policies and access.
+
+:::
 
 ### Enable cross-account access (STS Role)
 
+If you want to use a certain AWS account for the connection and then deploy in a different AWS account, select **Enable cross-account access (STS Role)** in your AWS connector's **Credentials** settings. The STS role is supported for EC2 and ECS. It is supported for EKS if you use the IRSA credentials option.
 
-:::note
-Assume STS Role is supported for EC2 and ECS. It is supported for EKS if you use the IRSA option, described above.
+This option uses the [AWS Security Token Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) (STS) feature. The AWS account used for AWS access in the connector's **Credentials** settings assumes the IAM role you specify in the **Cross account role ARN** field. However, the Harness delegate always runs in the account you specify in the connector's **Credentials** through **AWS Access Key** or **Assume IAM Role on Delegate**.
 
-:::
+In the **Cross account role ARN** field, input the Amazon Resource Name (ARN) of the role that you want the connector to assume. This is an IAM role in the target deployment AWS account.
 
+The assumed ARN role must have all the IAM policies required to perform your Harness deployment, such as Amazon S3, ECS (Existing Cluster), and AWS EC2 policies. For more information, go to the AWS documentation on [Assuming an IAM Role in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html).
 
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target infrastructure.
+To assume the role specified in the **Cross account role ARN** field, the AWS account in **Credentials** must be trusted by the role. The trust relationship is defined in the ARN role's trust policy when the role is created. That trust policy states which accounts are allowed to give that access to users in the account. You can use an STS role to establish trust between roles in the same account, but cross-account trust is more common.
 
-:::
-
-If you want to use one AWS account for the connection, but you want to deploy in a different AWS account, use the **Assume STS Role** option.
-
-This option uses the [AWS Security Token Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) (STS) feature.
-
-In this scenario, the AWS account used for AWS access in **Credentials** will assume the IAM role you specify in **Role ARN** setting.
-
-
-:::note
-The Harness Delegate(s) always runs in the account you specify in **Credentials** via **Access/Secret Key** or **Assume IAM Role on Delegate**.
-
-:::
-
-To assume the role in **Role ARN**, the AWS account in **Credentials** must be trusted by the role. The trust relationship is defined in the **Role ARN** role's trust policy when the role is created. That trust policy states which accounts are allowed to give that access to users in the account.
-
-
-:::note
-You can use **Assume STS Role** to establish trust between roles in the same account, but cross-account trust is more common.
-
-:::
-
-#### Role ARN
-
-The Amazon Resource Name (ARN) of the role that you want to assume. This is an IAM role in the target deployment AWS account.
-
-The assumed role in **Role ARN** must have all the IAM policies required to perform your Harness deployment, such as Amazon S3, ECS (Existing Cluster), and AWS EC2 policies. For more information, see [Assuming an IAM Role in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html) from AWS.
-
-#### External ID
-
-If the administrator of the account to which the role belongs provided you with an external ID, then enter that value.
-
-For more information, see [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) from AWS.
-
-
-:::note
-The AWS [IAM Policy Simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) is a useful tool for evaluating policies and access.
-
-:::
+If the administrator of the account to which the role belongs provided you with an external ID, you can input this value in the **External Id** field. For more information, go to the AWS documentation about [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
 ### Test Region and AWS GovCloud Support
 
-By default, Harness uses the **us-east-1** region to test the credentials for this Connector.
+By default, Harness uses the `us-east-1` region to test the credentials for AWS connectors.
 
-If you want to use an AWS GovCloud account for this Connector, select it in **Test Region**.
+If you want to use an AWS GovCloud account for this connector, select it in the **Test Region** field. GovCloud is used by organizations such as government agencies at the federal, state, and local level, as well as contractors, educational institutions. It is also used for regulatory compliance with these organizations.
 
-GovCloud is used by organizations such as government agencies at the federal, state, and local level, as well as contractors, educational institutions. It is also used for regulatory compliance with these organizations.
+You can access AWS GovCloud with AWS GovCloud credentials (AWS GovCloud account access key and AWS GovCloud IAM user credentials). You can't access AWS GovCloud with standard AWS credentials. Likewise, you can't access standard AWS regions using AWS GovCloud credentials.
 
-#### Restrictions
+## See also
 
-You can access AWS GovCloud with AWS GovCloud credentials (AWS GovCloud account access key and AWS GovCloud IAM user credentials).
-
-You cannot access AWS GovCloud with standard AWS credentials. Likewise, you cannot access standard AWS regions using AWS GovCloud credentials.
-
-### Troubleshooting
-
-See [Troubleshooting Harness](../../../troubleshooting/troubleshooting-nextgen.md).
-
-
-:::warning
-The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Connectors regardless of what AWS service you are using for your target infrastructure.
-
-:::
-
-### See also
-
-* [Google Cloud Platform (GCP) Connector Settings Reference](gcs-connector-settings-reference.md)
-* [Kubernetes Cluster Connector Settings Reference](kubernetes-cluster-connector-settings-reference.md)
-
+* [Troubleshooting Harness](../../../troubleshooting/troubleshooting-nextgen.md)
+* [Google Cloud Platform (GCP) connector settings reference](gcs-connector-settings-reference.md)
+* [Kubernetes cluster connector settings reference](kubernetes-cluster-connector-settings-reference.md)

--- a/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
@@ -1,6 +1,6 @@
 ---
-title: Google Cloud Platform (GCP) Connector Settings Reference
-description: This topic provides settings and permissions for the GCP Connector.
+title: Google Cloud Platform (GCP) connector settings reference
+description: This topic provides settings and permissions for the GCP connector.
 # sidebar_position: 2
 helpdocs_topic_id: yykfduond6
 helpdocs_category_id: 1ehb4tcksy
@@ -8,94 +8,109 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Harness Google Cloud Platform (GCP) Connector connects your Harness account to a GCP account.
+Use a Harness Google Cloud Platform (GCP) connector to integrate GCP with Harness. Use GCP with Harness to obtain artifacts, communicate with GCP services, provision infrastructure, deploy microservices, and manage other workloads.
 
-You add Connectors to your Harness Account and then reference them when defining resources and environments.
+You can use the GCP connector to connect to Kubernetes clusters in GCP. You can also use the [platform-agnostic Kubernetes Cluster connector](ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
 
+## Kubernetes role requirements
 
-### Limitations
+If you use the GCP connector to connect to GKE, the GCP service account used for any credentials requires the **Kubernetes Engine Developer** and **Storage Object Viewer** permissions.
 
-Harness supports GKE 1.19 and later.
+For instructions on adding roles to your service account, go to the Google documentation on [Granting Roles to Service Accounts](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts). For more information about GCP roles, go to the GCP documentation on [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles?_ga=2.123080387.-954998919.1531518087#curated_roles).
 
-If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](../add-a-kubernetes-cluster-connector.md).
+Alternately, you can use a service account that has only the **Storage Object Viewer** permission needed to query GCR, and then use either an in-cluster Kubernetes delegate or a direct [Kubernetes Cluster Connector](kubernetes-cluster-connector-settings-reference.md) with the Kubernetes service account token for performing deployment.
 
-### Kubernetes Role Requirements
+:::caution
 
-If you are using the GCP Connector to connect to GKE, the GCP service account used for any credentials requires the **Kubernetes Engine Developer** and **Storage Object Viewer** permissions.
+Harness supports GKE 1.19 and later. If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](../add-a-kubernetes-cluster-connector.md).
 
-If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](../add-a-kubernetes-cluster-connector.md).
+:::
 
-* For steps to add roles to your service account, see [Granting Roles to Service Accounts](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts) from Google. For more information, see [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles?_ga=2.123080387.-954998919.1531518087#curated_roles) from GCP.
-
-Another option is to use a service account that has only the Storage Object Viewer permission needed to query GCR, and then use either an in-cluster Kubernetes Delegate or a direct [Kubernetes Cluster Connector](kubernetes-cluster-connector-settings-reference.md) with the Kubernetes service account token for performing deployment.
-
-### GCS and GCR Role Requirements
+## GCS and GCR role requirements
 
 For Google Cloud Storage (GCS) and Google Container Registry (GCR), the following roles are required:
 
-* Storage Object Viewer (roles/storage.objectViewer)
-* Storage Object Admin (roles/storage.objectAdmin)
+* Storage Object Viewer (`roles/storage.objectViewer`)
+* Storage Object Admin (`roles/storage.objectAdmin`)
 
-See [Cloud IAM roles for Cloud Storage](https://cloud.google.com/storage/docs/access-control/iam-roles) from GCP.
+For more information, go to the GCP documentation about [Cloud IAM roles for Cloud Storage](https://cloud.google.com/storage/docs/access-control/iam-roles).
 
-Ensure the Harness Delegate you have installed can reach to the GCR registry host name you are using in **Registry Host Name** (for example, gcr.io) and storage.cloud.google.com.
+Ensure the Harness delegate you have installed can reach `storage.cloud.google.com` and your GCR registry host name, for example `gcr.io`. Registry host name is declared in, for example, the **Host** field in the [Build and Push to GCR step settings](../../../continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md).
 
-### Google Artifact Registry
+## Google Artifact Registry role requirements
 
 For Google Artifact Registry, the following roles are required:
 
-- Artifact Registry Reader
-- Artifact Registry Writer
+* Artifact Registry Reader
+* Artifact Registry Writer
 
-### Google Cloud Operations Suite (Stackdriver) Requirements
+## Google Cloud Operations Suite (Stackdriver) requirements
 
-Most APM and logging tools are added to Harness as Verification Providers. For Google Cloud's operations suite (formerly Stackdriver), you use the GCP Connector.
+Most APM and logging tools are added to Harness as Verification Providers. For Google Cloud's operations suite (formerly Stackdriver), use the GCP connector.
 
-##### Roles and Permissions
+The following roles and permissions are required:
 
-* **Stackdriver Logs** - The minimum role requirement is **Logs Viewer** (logging.viewer)**.**
-* **Stackdriver Metrics** - The minimum role requirements are **Compute Network Viewer** (compute.networkViewer) and **Monitoring Viewer** (monitoring.viewer).
+* **Stackdriver Logs:** The minimum role requirement is **Logs Viewer** (`logging.viewer`)
+* **Stackdriver Metrics:** The minimum role requirements are **Compute Network Viewer** (`compute.networkViewer`) and **Monitoring Viewer** (`monitoring.viewer`).
 
-See [Access control](https://cloud.google.com/monitoring/access-control) from Google.
+For more information, go to the Google documentation on [Access control](https://cloud.google.com/monitoring/access-control).
 
-### Proxies and GCP with Harness
+## Proxies and GCP with Harness
 
-If you are using a proxy server in your GCP account, but want to use GCP services with Harness, you need to set the following to not use your proxy:
+If you are using a proxy server in your GCP account, and you want to use GCP services with Harness, you must set the following to **not** use your proxy:
 
-* `googleapis.com`. See [Proxy servers](https://cloud.google.com/storage/docs/troubleshooting#proxy-server) from Google.
-* The `token_uri` value from your Google Service Account. See [Creating service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) from Google.
+* `googleapis.com`: For details, go to the Google documentation on [Proxy servers](https://cloud.google.com/storage/docs/troubleshooting#proxy-server).
+* The `token_uri` value from your Google Service Account: For details, go to the Google documentation on [Creating service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys).
 
-### GCP Connector Settings
+## GCP connector settings
 
-#### Name
+GCP connector settings include:
+* **Name:** The unique name for the connector
+* **Id:** Go to [Entity Identifier Reference](../../20_References/entity-identifier-reference.md)
+* **Description:** Text string
+* **Tags:** Go to [Tags Reference](../../20_References/tags-reference.md)
+* **Details:** Provide credentials that enable Harness to connect to your GCP account. There are two options:
+  * Select **Specify credentials here** to use a GCP service account key.
+  * Select **Use the credentials of a specific Harness Delegate** to allow the connector to inherit its authentication credentials from the Harness delegate that is running in GCP.
+* **Select connectivity mode**: Select whether Harness should communicate directly with GCP or go through a Harness delegate in GCP.
 
-The unique name for this Connector.
+<details>
+<summary>Store service account keys as Harness secrets</summary>
 
-#### ID
+You can store a GCP service account key in a [Harness Encrypted Text secret](../../6_Security/2-add-use-text-secrets.md).
 
-See [Entity Identifier Reference](../../20_References/entity-identifier-reference.md).
-
-#### Description
-
-Text string.
-
-#### Tags
-
-See [Tags Reference](../../20_References/tags-reference.md).
-
-#### Service Account Key
-
-Select or create a new [Harness Encrypted Text secret](../../6_Security/2-add-use-text-secrets.md) that contains the Google Cloud's Account Service Key File.
-
-To obtain the Google Cloud's Account Service Key File, see [Creating and managing service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) from Google (JSON is recommended).
+To obtain the Google Cloud's service account key file, go to the Google documentation on [Creating and managing service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys). JSON format is recommended.
 
 ![](./static/gcs-connector-settings-reference-00.png)
-(./static/gcs-connector-settings-reference-00.png)
-Once you have the key file from Google, open it, copy it, and paste it into the Harness Encrypted Text secret.
 
-Next, use that Harness Encrypted Text secret in **Service Account Key**.
+</details>
 
-### See also
+<details>
+<summary>Learn more about credential inheritance</summary>
+
+* **IAM role inheritance:** The connector inherits the GCP IAM role assigned to the delegate in GCP, such a Harness Kubernetes delegate running in Google Kubernetes Engine (GKE). Make sure the delegate has the IAM roles that your connector needs.
+* **GCP workload identity:** If you installed the Harness [Kubernetes delegate](/docs/first-gen/firstgen-platform/account/manage-delegates/install-kubernetes-delegate/) in a Kubernetes cluster in GKE that has [GCP Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity?hl=tr#enable_on_cluster) enabled and uses the same service account and node pool annotation, then the Google Cloud Platform (GCP) connector inherits these credentials if it uses that delegate.
+* **Role and policy changes:** If you find that the IAM role associated with your GCP connector don't have the policies required by the GCP service you want to access, you can modify or change the role assigned to the Harness delegate that your GCP connector is using. You may need to wait up to five minutes for the change to take effect.
+* **See also:**
+  * [Add a Google Cloud Platform (GCP) connector](../connect-to-google-cloud-platform-gcp.md)
+  * [GCP Policy Simulator](https://cloud.google.com/iam/docs/simulating-access)
+
+</details>
+
+<details>
+<summary>Learn more about connectivity modes</summary>
+
+* **Connect through Harness Platform:** Use a direct, secure communication between Harness and GCP.
+* **Connect through a Harness Delegate:** Harness communicates with GCP through a Harness delegate in GCP. You must choose this option if you chose to inherit delegate credentials.
+
+If connecting through a Harness delegate, select either:
+
+* **Use any available Delegate**: Harness selects an available Delegate at runtime. To learn how Harness selects delegates, go to [Delegates Overview](../../2_Delegates/get-started-with-delegates/delegates-overview.md).
+* **Only use Delegates with all of the following tags**: Use **Tags** to match one or more suitable delegates. To learn more about Delegate tags, go to [Select Delegates with Tags](../../2_Delegates/manage-delegates/select-delegates-with-selectors.md). You can select **Install new Delegate** to add a delegate without exiting connector configuration. For guidance on installing delegates, go to [Delegate Installation Overview](../../2_Delegates/get-started-with-delegates/delegate-installation-overview.md).
+
+</details>
+
+## See also
 
 * [AWS Connector Settings Reference](aws-connector-settings-reference.md)
 * [Kubernetes Cluster Connector Settings Reference](kubernetes-cluster-connector-settings-reference.md)

--- a/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 Use a Harness Google Cloud Platform (GCP) connector to integrate GCP with Harness. Use GCP with Harness to obtain artifacts, communicate with GCP services, provision infrastructure, deploy microservices, and manage other workloads.
 
-You can use the GCP connector to connect to Kubernetes clusters in GCP. You can also use the [platform-agnostic Kubernetes Cluster connector](ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
+You can use the GCP connector to connect to Kubernetes clusters in GCP. You can also use the [platform-agnostic Kubernetes Cluster connector](kubernetes-cluster-connector-settings-reference.md).
 
 ## Kubernetes role requirements
 

--- a/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Google Cloud Platform (GCP) connector settings reference
-description: This topic provides settings and permissions for the GCP connector.
+description: Settings and permissions for the GCP connector.
 # sidebar_position: 2
 helpdocs_topic_id: yykfduond6
 helpdocs_category_id: 1ehb4tcksy


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [x] Issue
- [x] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* CI-5758 : No specific change for this ticket, but applied general revisions to some GCP connector-related topics. I used the issue in this ticket for an example in the `GCP connector errors` part of `connect-to-google-cloud-platform-gcp.md`
* CI-6410 : Updated 9 step settings topics to include a note about which authentication methods are supported, not support, or untested (which I phrased as `may experience errors during pipeline runs`).
   * I only made the minimum edits to these topics since the PR already includes so many changes. 
   * Modified topics are the 'step setting' topics per the first column here: https://harness.atlassian.net/wiki/spaces/PD/pages/21254275563/Gaps+in+CI+Steps+with+Connectors 
   * EXCEPT:
      *  `run` step (which already got a great deal of changes from another PR and can use a variety of connectors; however, CI-5758 is included in this PR)
      * `build and push to acr` step (which is missing from the docs - I created DOC-2597 for this and I will address it if there is time before the release).
* DOC-2351 : upload-artifacts-to-s-3-step-settings.md : Add `Stage variable required for ARNs`
* Other topics also edited because they were referenced by topics I was already editing and they needed corresponding revisions to similar content

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
