### PR TITLE
Update add-a-microsoft-azure-connector.md

### DIFF
--- a/docs/platform/7_Connectors/add-a-microsoft-azure-connector.md
+++ b/docs/platform/7_Connectors/add-a-microsoft-azure-connector.md
@@ -190,7 +190,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1  
 metadata:  
   name: cdp-qa-deployer-role  
-  namespace: default  
+  namespace: cdp-qa-app
 rules:  
   - apiGroups: ["", "apps"]  
     resources: ["pods", "configmaps", "deployments", "secrets", "events", "services",  "replicasets", "deployments/scale", "namespaces", "resourcequotas", "limitranges"]  
@@ -201,14 +201,14 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1  
 metadata:  
   name: cdp-qa-deployer-role-binding  
-  namespace: default  
+  namespace: cdp-qa-app  
 roleRef:  
   apiGroup: rbac.authorization.k8s.io  
   kind: Role  
   name: cdp-qa-deployer-role  
 subjects:  
   - kind: Group  
-    namespace: default  
+    namespace: cdp-qa-app  
     name: <AD group id to which the SP and MSI users are assigned to>
 ```
 ### Azure Container Repository (ACR) Roles


### PR DESCRIPTION
# Harness Developer Pull Request

the docs for creating a scoped k8s service-account for azure use "default" as the namespace which is confusing/detracting from the point of the article. In the real world you would have some specific namespace you are trying to scope access to.

a small change, but we think it makes the intended goal here more clear.

cc @suranc 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
