### PR TITLE
CHAOS-1219: Replaces default container runtime to containerd for faults

### DIFF
--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/container-kill.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/container-kill.md
@@ -85,12 +85,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path to the <code>containerd/crio/docker</code> socket file. </td>
-        <td> Defaults to <code>/var/run/docker.sock</code>. </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code>. </td>
       </tr>
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> Container runtime interface for the cluster. </td>
-        <td> Defaults to docker. Supported docker, containerd and crio.</td>
+        <td> Defaults to containerd. Supported docker, containerd and crio.</td>
       </tr>
     </table>
 </details>
@@ -136,8 +136,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variable that help set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains the path of the docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 [embedmd]: # "./static/manifests/container-kill/container-runtime-and-socket-path.yaml yaml"
 
@@ -163,10 +163,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             - name: TOTAL_CHAOS_DURATION
               VALUE: "60"
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-cpu-hog.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-cpu-hog.md
@@ -78,12 +78,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to <code>/var/run/docker.sock</code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr> 
       <tr>
         <td> RAMP_TIME </td>
@@ -178,8 +178,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -207,10 +207,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             - name: TOTAL_CHAOS_DURATION
               VALUE: "60"
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-dns-error.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-dns-error.md
@@ -66,12 +66,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker</td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the docker socket file </td>
-        <td> Defaults to <code>/var/run/docker.sock</code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> LIB_IMAGE </td>
@@ -168,8 +168,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker` runtime only.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`).
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -196,10 +196,10 @@ spec:
         # runtime for the container
         # supports docker
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-dns-spoof.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-dns-spoof.md
@@ -60,12 +60,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker</td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the docker socket file </td>
-        <td> Defaults to <code>/var/run/docker.sock</code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> LIB_IMAGE </td>
@@ -128,8 +128,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variables to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker` runtime only.
-- `SOCKET_PATH`: It contains path of the docker socket file, which by default, is `/var/run/docker.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.sock`.
 
 Use the following example to tune it:
 
@@ -157,10 +157,10 @@ spec:
             # runtime for the container
             # supports docker
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # map of host names
             - name: SPOOF_MAP
               value: '{"abc.com":"spoofabc.com"}'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-latency.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-latency.md
@@ -80,7 +80,7 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to <code>/run/containerd/containerd.sock<code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-latency.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-latency.md
@@ -75,12 +75,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock<code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -299,8 +299,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variables to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -328,10 +328,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # provide the port of the targeted service
             - name: TARGET_SERVICE_PORT
               value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-body.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-body.md
@@ -85,12 +85,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -356,8 +356,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variable to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -385,10 +385,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # provide the port of the targeted service
             - name: TARGET_SERVICE_PORT
               value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-header.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-header.md
@@ -79,12 +79,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -350,8 +350,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variables to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -379,10 +379,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # provide the port of the targeted service
             - name: TARGET_SERVICE_PORT
               value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
@@ -76,12 +76,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -299,8 +299,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune this:
 
@@ -328,10 +328,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # provide the port of the targeted service
             - name: TARGET_SERVICE_PORT
               value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-status-code.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-status-code.md
@@ -98,12 +98,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -461,8 +461,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune this:
 
@@ -490,10 +490,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             # provide the port of the targeted service
             - name: TARGET_SERVICE_PORT
               value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-io-stress.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-io-stress.md
@@ -82,12 +82,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to <code>/var/run/docker.sock</code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>    
       <tr>
         <td> RAMP_TIME </td>
@@ -184,8 +184,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune this:
 
@@ -213,10 +213,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             - name: TOTAL_CHAOS_DURATION
               VALUE: "60"
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-memory-hog.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-memory-hog.md
@@ -78,12 +78,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to <code>/var/run/docker.sock</code> </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>        
       <tr>
         <td> PODS_AFFECTED_PERC </td>
@@ -180,5 +180,5 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` envrionment variables to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-corruption.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-corruption.md
@@ -55,12 +55,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -224,8 +224,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` environment variables to set the container runtime and socket file path, respectively.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -252,10 +252,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-duplication.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-duplication.md
@@ -58,12 +58,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -230,8 +230,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune this:
 
@@ -259,10 +259,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             - name: TOTAL_CHAOS_DURATION
               VALUE: "60"
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-latency.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-latency.md
@@ -67,12 +67,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -271,8 +271,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune this:
 
@@ -300,10 +300,10 @@ spec:
             # runtime for the container
             # supports docker, containerd, crio
             - name: CONTAINER_RUNTIME
-              value: "docker"
+              value: "containerd"
             # path of the socket file
             - name: SOCKET_PATH
-              value: "/var/run/docker.sock"
+              value: "/run/containerd/containerd.sock"
             - name: TOTAL_CHAOS_DURATION
               VALUE: "60"
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-loss.md
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-loss.md
@@ -58,12 +58,12 @@ The application pods should be in running state before and after chaos injection
       <tr>
         <td> CONTAINER_RUNTIME </td>
         <td> container runtime interface for the cluster</td>
-        <td> Defaults to docker, supported values: docker, containerd and crio for litmus and only docker for pumba LIB </td>
+        <td> Defaults to containerd, supported values: docker, containerd and crio </td>
       </tr>
       <tr>
         <td> SOCKET_PATH </td>
         <td> Path of the containerd/crio/docker socket file </td>
-        <td> Defaults to `/var/run/docker.sock` </td>
+        <td> Defaults to <code>/run/containerd/containerd.sock</code> </td>
       </tr>
       <tr>
         <td> TOTAL_CHAOS_DURATION </td>
@@ -226,8 +226,8 @@ spec:
 
 It defines the `CONTAINER_RUNTIME` and `SOCKET_PATH` ENV to set the container runtime and socket file path.
 
-- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `docker`.
-- `SOCKET_PATH`: It contains path of docker socket file by default(`/var/run/docker.sock`). For `containerd`, specify path as `/var/containerd/containerd.sock`. For `crio`, speecify path as `/var/run/crio/crio.sock`.
+- `CONTAINER_RUNTIME`: It supports `docker`, `containerd`, and `crio` runtimes. The default value is `containerd`.
+- `SOCKET_PATH`: It contains path of containerd socket file by default(`/run/containerd/containerd.sock`). For `docker`, specify path as `/var/run/docker.sock`. For `crio`, specify path as `/var/run/crio/crio.sock`.
 
 Use the following example to tune it:
 
@@ -254,10 +254,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'
 ```

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/container-kill/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/container-kill/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-cpu-hog/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-cpu-hog/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-dns-error/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-dns-error/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-dns-spoof/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-dns-spoof/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # map of host names
         - name: SPOOF_MAP
           value: '{"abc.com":"spoofabc.com"}'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-latency/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-latency/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # provide the port of the targeted service
         - name: TARGET_SERVICE_PORT
           value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-modify-body/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-modify-body/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # provide the port of the targeted service
         - name: TARGET_SERVICE_PORT
           value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-modify-header/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-modify-header/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # provide the port of the targeted service
         - name: TARGET_SERVICE_PORT
           value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-reset-peer/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-reset-peer/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # provide the port of the targeted service
         - name: TARGET_SERVICE_PORT
           value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-status-code/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-http-status-code/container-runtime-and-socket-path.yaml
@@ -19,10 +19,10 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         # provide the port of the targeted service
         - name: TARGET_SERVICE_PORT
           value: "80"

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-io-stress/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-io-stress/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-corruption/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-corruption/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-duplication/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-duplication/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-latency/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-latency/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-loss/container-runtime-and-socket-path.yaml
+++ b/docs/chaos-engineering/chaos-faults/kubernetes/pod/static/manifests/pod-network-loss/container-runtime-and-socket-path.yaml
@@ -19,9 +19,9 @@ spec:
         # runtime for the container
         # supports docker, containerd, crio
         - name: CONTAINER_RUNTIME
-          value: 'docker'
+          value: 'containerd'
         # path of the socket file
         - name: SOCKET_PATH
-          value: '/var/run/docker.sock'
+          value: '/run/containerd/containerd.sock'
         - name: TOTAL_CHAOS_DURATION
           VALUE: '60'

--- a/docs/chaos-engineering/overview/Security/security-templates/psp.md
+++ b/docs/chaos-engineering/overview/Security/security-templates/psp.md
@@ -46,10 +46,10 @@ volumes:
 allowedHostPaths:
     # substitutes this path with an appropriate socket path
     # ex: '/var/run/docker.sock', '/run/containerd/containerd.sock', '/run/crio/crio.sock'
-    - pathPrefix: "/var/run/docker.sock"
+    - pathPrefix: "/run/containerd/containerd.sock"
     # substitutes this path with an appropriate container path
     # ex: '/var/lib/docker/containers', '/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io', '/var/lib/containers/storage/overlay/'
-    - pathPrefix: "/var/lib/docker/containers"
+    - pathPrefix: "/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io"
 
 allowedCapabilities:
     # NET_ADMIN & SYS_ADMIN: used in network chaos experiments to perform

--- a/docs/chaos-engineering/static/overview/manifest/kyverno-policies/allow-host-paths-for-litmus-experiments-which-uses-hostPaths.yaml
+++ b/docs/chaos-engineering/static/overview/manifest/kyverno-policies/allow-host-paths-for-litmus-experiments-which-uses-hostPaths.yaml
@@ -31,7 +31,7 @@ spec:
             # substitutes this path with an appropriate socket path
             # ex: '/var/run/docker.sock', '/run/containerd/containerd.sock', '/run/crio/crio.sock'
             - =(hostPath):
-                path: "/var/run/docker.sock"     
+                path: "/run/containerd/containerd.sock"     
     - name: check container host-path
       match:
         resources:

--- a/docs/chaos-engineering/static/overview/manifest/kyverno-policies/allow-host-paths-for-litmus-experiments-which-uses-hostPaths.yaml
+++ b/docs/chaos-engineering/static/overview/manifest/kyverno-policies/allow-host-paths-for-litmus-experiments-which-uses-hostPaths.yaml
@@ -50,7 +50,7 @@ spec:
              # substitutes this path with an appropriate container path
              # ex: '/var/lib/docker/containers', '/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io', '/var/lib/containers/storage/overlay/'
             - =(hostPath):
-                path: "/var/lib/docker/containers"
+                path: "/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io"
     - name: check service-kill host-path
       match:
         resources:

--- a/docs/chaos-engineering/static/overview/manifest/psp/psp-litmus.yaml
+++ b/docs/chaos-engineering/static/overview/manifest/psp/psp-litmus.yaml
@@ -27,10 +27,10 @@ apiVersion: policy/v1beta1
     allowedHostPaths:
         # substitutes this path with an appropriate socket path
         # ex: '/var/run/docker.sock', '/run/containerd/containerd.sock', '/run/crio/crio.sock'
-        - pathPrefix: "/var/run/docker.sock"
+        - pathPrefix: "/run/containerd/containerd.sock"
         # substitutes this path with an appropriate container path
         # ex: '/var/lib/docker/containers', '/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io', '/var/lib/containers/storage/overlay/'
-        - pathPrefix: "/var/lib/docker/containers"
+        - pathPrefix: "/var/lib/containerd/io.containerd.runtime.v1.linux/k8s.io"
 
     allowedCapabilities:
         # NET_ADMIN & SYS_ADMIN: used in network chaos experiments to perform


### PR DESCRIPTION
# Harness Developer Pull Request
- Replaces default container runtime to containerd for faults

## What Type of PR is This?
- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

## House Keeping
Some items to keep track of. Screenshots of changes are optional but would help the maintainers review quicker. 
- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
