### PR TITLE
[DOC-1815] [DOC-2502] [CI-5125] [CI-7162] - Standardized CI step settings references

### DIFF
--- a/docs/continuous-integration/ci-quickstarts/ci-concepts.md
+++ b/docs/continuous-integration/ci-quickstarts/ci-concepts.md
@@ -160,4 +160,4 @@ Harness CI offers popular object storage options such as JFrog, Amazon S3, and G
 
 ### Try Harness CI
 
-Interested in trying CI for yourself? No need to wait any longer! Book your [Demo](https://harness.io/demo) and [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+Interested in trying CI for yourself? No need to wait any longer! Book your [Demo](https://harness.io/demo) and [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).

--- a/docs/continuous-integration/ci-quickstarts/ci-concepts.md
+++ b/docs/continuous-integration/ci-quickstarts/ci-concepts.md
@@ -146,13 +146,7 @@ Caching ensures faster job execution by reusing data from previous jobs' expensi
 
 #### Remote Docker Layer Caching
 
-Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-You can also specify the same Docker repo for multiple Build and Push steps, which enables them to share the same remote cache.
-
-Remote Docker Layer Caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple Build and Push steps, which enables them to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 #### Artifact Repos
 

--- a/docs/continuous-integration/ci-quickstarts/ci-pipeline-basics.md
+++ b/docs/continuous-integration/ci-quickstarts/ci-pipeline-basics.md
@@ -56,13 +56,7 @@ Caching ensures faster job execution by reusing data from expensive fetch operat
 
 ### Remote Docker Layer Caching
 
-Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-You can also specify the same Docker repo for multiple Build and Push steps, enabling them to share the same remote cache.
-
-Remote Docker Layer Caching can dramatically improve build time by sharing layers across Pipelines, Stages, and steps.
+Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple Build and Push steps, enabling them to share the same remote cache. This can dramatically improve build time by sharing layers across Pipelines, Stages, and steps.
 
 ### Artifact Repos
 

--- a/docs/continuous-integration/ci-technical-reference/background-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/background-step-settings.md
@@ -19,9 +19,19 @@ Background steps are useful for running services that need to run for the entire
   ![The Background step ID, pythonscript, is used in a curl command in a Run step.](./static/background-step-settings-call-id-in-other-step.png)
 * If the pipeline runs on a VM build infrastructure, you can run the background service directly on the VM rather than in a container. To do this, leave the **Container Registry** and **Image** fields blank.
 
+:::info
+
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+
+:::
+
+## Name
+
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+
 ## Container Registry
 
-The Harness Connector for a container registry. This is the container registry for the image that you want Harness to run build commands on, such as DockerHub.
+A Harness container registry connector. This is the container registry for the image that you want Harness to run build commands on, such as DockerHub.
 
 ## Image
 
@@ -32,7 +42,7 @@ Different container registries require different name formats:
 * **Docker Registry:** Input the name of the artifact you want to deploy, for example: `library/tomcat`. Wildcards aren't supported.
 * **GCR:** Input the FQN (fully-qualified name) of the artifact you want to deploy. Images in repos must reference a path, for example: `us.gcr.io/playground-123/quickstart-image:latest`.
 
-![](./static/background-step-settings-08.png)
+   ![](./static/background-step-settings-08.png)
 
 * **ECR:** Input the FQN (fully-qualified name) of the artifact you want to deploy. Images in repos must reference a path, for example: `40000005317.dkr.ecr.us-east-1.amazonaws.com/todolist:0.2`.
 
@@ -56,7 +66,7 @@ Use these optional settings to add additional configuration to the step. Setting
 
 ### Privileged
 
-Enable this option to run the container with escalated privileges. This is the equivalent of running a container with the Docker `--privileged` flag.
+Select this option to run the container with escalated privileges. This is the equivalent of running a container with the Docker `--privileged` flag.
 
 ### Report Paths
 
@@ -105,18 +115,11 @@ If your build stage uses Harness Cloud build infrastructure and you are running 
 
 ### Run as User
 
-If the service is running in a container, you can set the value to specify the user Id for all processes in the pod. For more information about how to set the value, see [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+If the service is running in a container, you can specify the user ID to use for all processes in the pod. For more information about how to set the value, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
 ### Set Container Resources
 
 The maximum memory and cores that the container can use.
 
-### Limit Memory
-
-The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You may also use the power-of-two equivalents `Gi` and `Mi`.
-
-Do not include spaces when entering a fixed value. The default value, if unspecified, is `500Mi`.
-
-#### Limit CPU
-
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed; you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`. Do not include spaces when entering a fixed value. The default value is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).

--- a/docs/continuous-integration/ci-technical-reference/background-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/background-step-settings.md
@@ -21,17 +21,17 @@ Background steps are useful for running services that need to run for the entire
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Container Registry
 
-A Harness container registry connector. This is the container registry for the image that you want Harness to run build commands on, such as DockerHub.
+A Harness container registry connector that connects to the container registry from which you want Harness to pull an image, such as DockerHub.
 
 ## Image
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
@@ -110,6 +110,6 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 You can find the following settings on the **Advanced** tab in the step settings pane:
 
-* [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
-* [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
-* [Looping Strategies Overview -- Matrix, Repeat, and Parallelism](/docs/platform/8_Pipelines/looping-strategies-matrix-repeat-and-parallelism.md): Define a looping strategy for an individual step.
+* [Conditional Execution](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
+* [Failure Strategy](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
+* [Looping Strategies Overview -- Matrix, Repeat, and Parallelism](../../platform/8_Pipelines/looping-strategies-matrix-repeat-and-parallelism.md): Define a looping strategy for an individual step.

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
@@ -42,7 +42,7 @@ Add each tag separately.
 
 :::tip
 
-Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `Build ID: 9`. You can use the same tag in another stage to reference the same build by its tag.
+Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `9`. You can use the same tag in another stage to reference the same build by its tag.
 
 :::
 
@@ -76,17 +76,11 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
-
-Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
-
 Enter the name of the remote cache image, such as `<container-registry-name>.azurecr.io/<image-name>`.
 
 The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
+
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 ### Run as User
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
@@ -52,7 +52,7 @@ Use the following settings to add additional configuration to the step. Settings
 
 ### Optimize
 
-Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can reduce the time it takes to create snapshots. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
 
 ### Dockerfile
 
@@ -60,7 +60,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
+Enter a path to a directory containing files that make up the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
@@ -16,7 +16,7 @@ For other build infrastructures, you can use the [Build and Push an image to Doc
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Azure Connector
 
@@ -42,13 +42,13 @@ Add each tag separately.
 
 :::tip
 
-Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `9`. You can use the same tag in another stage to reference the same build by its tag.
+Harness expressions are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `9`. You can use the same tag in another stage to reference the same build by its tag.
 
 :::
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Optimize
 
@@ -60,7 +60,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Context represents a directory containing a Dockerfile which kaniko will use to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
+Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 
@@ -78,7 +78,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 Enter the name of the remote cache image, such as `<container-registry-name>.azurecr.io/<image-name>`.
 
-The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
+The remote cache repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
 
 Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-acr-step-settings.md
@@ -1,20 +1,16 @@
 ---
-title: Build and Push an image to Docker Registry step settings
-description: This topic describes settings for the Build and Push an image to Docker Registry step.
+title: Build and Push to ACR step settings
+description: This topic describes settings for the Build and Push to ACR step.
 sidebar_position: 20
-helpdocs_topic_id: q6fr5bj63w
-helpdocs_category_id: 4xo13zdnfx
-helpdocs_is_private: false
-helpdocs_is_published: true
 ---
 
-This topic describes settings for the **Build and Push an image to Docker Registry** step, which creates a Docker image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/) and pushes it to a Docker registry.
+This topic provides settings for the **Build and Push to ACR** step, which builds an image and pushes it to [Azure Container Registry](https://azure.microsoft.com/en-us/free/container-registry/) (ACR).
 
-Because this step is equivalent to the Docker [build](https://docs.docker.com/engine/reference/commandline/build/) and [push](https://docs.docker.com/engine/reference/commandline/push/) commands, you can use this step or the [Build and Push to ACR step](./build-and-push-to-acr-step-settings.md) to push to Azure Container Registry (ACR).
+:::note
 
-:::info
+The **Build and Push to ACR** step is supported on Kubernetes build infrastructures only.
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+For other build infrastructures, you can use the [Build and Push an image to Docker Registry step](./build-and-push-to-docker-hub-step-settings.md) to push to ACR.
 
 :::
 
@@ -22,25 +18,27 @@ Depending on the stage's build infrastructure, some settings may be unavailable.
 
 The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-## Docker Connector
+## Azure Connector
 
-The Harness Docker Registry connector where you want to upload the image. For more information, go to [Docker connector settings reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md).
+The Harness Azure Cloud connector to use to connect to your ACR. This step supports Azure Cloud connectors that use access key authentication. This step doesn't support Azure Cloud connectors that inherit delegate credentials.
 
-This step supports Docker connectors that use either anonymous or username and password authentication.
+For more information about Azure connectors, including details about required permissions, go to [Add a Microsoft Azure Cloud Provider connector](../../platform/7_Connectors/add-a-microsoft-azure-connector.md).
 
-## Docker Repository
+## Repository
 
-The name of the repository where you want to store the image, for example, `<hub-user>/<repo-name>`.
+The URL for the target ACR repository where you want to push your artifact. You must use this format: `<container-registry-name>.azurecr.io/<image-name>`.
 
-For private Docker registries, specify a fully qualified repo name.
+## Subscription Id
+
+Name or ID of an ACR subscription. This field is required for artifacts to appear in the build's **Artifacts** tab.
+
+For more information about, go to the Microsoft documentation about [How to manage Azure subscriptions with the Azure CLI](https://learn.microsoft.com/en-us/cli/azure/manage-azure-subscriptions-azure-cli).
 
 ## Tags
 
 Add [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag). This is equivalent to the `-t` flag.
 
 Add each tag separately.
-
-![](./static/build-and-push-to-docker-hub-step-settings-10.png)
 
 :::tip
 
@@ -64,10 +62,6 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 Context represents a directory containing a Dockerfile which kaniko will use to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
 
-Kaniko requires root access to build the Docker image. If you have not already enabled root access, you will receive the following error:
-
-`failed to create docker config file: open/kaniko/ .docker/config.json: permission denied`
-
 ### Labels
 
 Specify [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
@@ -76,25 +70,23 @@ Specify [Docker object labels](https://docs.docker.com/config/labels-custom-meta
 
 The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#build-arg). This is equivalent to the `--build-arg` flag.
 
-![](./static/build-and-push-to-docker-hub-step-settings-11.png)
-
 ### Target
 
 The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-### Remote Cache Repository
+### Remote Cache Image
 
-Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo.
 
 This is different from other CI vendors that are limited to local caching and persistent volumes.
 
-In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
+You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
 
 Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
-In the step's **Remote Cache Repository** field, enter the name of the remote cache repo where the cached image layers will be stored.
+Enter the name of the remote cache image, such as `<container-registry-name>.azurecr.io/<image-name>`.
 
-The remote cache repository needs to be created in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
 
 ### Run as User
 
@@ -113,3 +105,11 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 * [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
 * [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
+
+## Advanced settings
+
+You can find the following settings on the **Advanced** tab in the step settings pane:
+
+* [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
+* [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
+* [Looping Strategies Overview -- Matrix, Repeat, and Parallelism](/docs/platform/8_Pipelines/looping-strategies-matrix-repeat-and-parallelism.md): Define a looping strategy for an individual step.

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Build and Push an Image to Docker Registry Step Settings
-description: This topic describes settings for the Build and Push an image to Docker registry step.
+title: Build and Push an image to Docker Registry step settings
+description: This topic describes settings for the Build and Push an image to Docker Registry step.
 sidebar_position: 20
 helpdocs_topic_id: q6fr5bj63w
 helpdocs_category_id: 4xo13zdnfx
@@ -8,104 +8,102 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic describes settings for the **Build and Push an image to Docker registry** step, which creates a Docker image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/) and pushes it to a Docker registry.
+This topic describes settings for the **Build and Push an image to Docker Registry** step, which creates a Docker image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/) and pushes it to a Docker registry.
 
-You also use this step to push to Azure Container Registry (ACR) because this step is equivalent to the Docker [build](https://docs.docker.com/engine/reference/commandline/build/) and [push](https://docs.docker.com/engine/reference/commandline/push/) commands.
+You can also use this step to push to Azure Container Registry (ACR) because this step is equivalent to the Docker [build](https://docs.docker.com/engine/reference/commandline/build/) and [push](https://docs.docker.com/engine/reference/commandline/push/) commands.
 
-### Name
+:::info
 
-The unique name for this step.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### Docker Connector
+:::
 
-The Harness Docker Registry Connector to use for uploading the image. See [Docker Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md). This step supports Docker connectors that use either anonymous or username and password authentication.
+## Name
 
-### Docker Repository
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-The name of the Repository. For example, `<hub-user>/<repo-name>`.
+## Docker Connector
 
-When using private Docker registries, use a fully qualified repo name.
+The Harness Docker Registry connector where you want to upload the image. For more information, go to [Docker connector settings reference](../../platform/7_Connectors/ref-cloud-providers/docker-registry-connector-settings-reference.md).
 
-### Tags
+This step supports Docker connectors that use either anonymous or username and password authentication.
 
-[Docker build tag](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) (`-t`).
+## Docker Repository
+
+The name of the repository where you want to store the image, for example, `<hub-user>/<repo-name>`.
+
+For private Docker registries, specify a fully qualified repo name.
+
+## Tags
+
+Add [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag). This is equivalent to the `-t` flag.
 
 Add each tag separately.
 
 ![](./static/build-and-push-to-docker-hub-step-settings-10.png)
 
-### Optional Configurations
+## Optional Configuration
 
-#### Optimize
+Use the following settings to add additional configuration to the step.
 
-Enables this option to redo snapshot mode.
+### Optimize
 
-#### Dockerfile
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+
+### Dockerfile
 
 The name of the Dockerfile. If you don't provide a name, Harness assumes that the Dockerfile is in the root folder of the codebase.
 
-#### Context
+### Context
 
 Context represents a directory containing a Dockerfile which kaniko will use to build your image. For example, a`COPY` command in your Dockerfile should refer to a file in the build context.
 
-Kaniko requires root access to build the docker image. If you have not already enabled root access, you will receive the following error:
+Kaniko requires root access to build the Docker image. If you have not already enabled root access, you will receive the following error:
 
 `failed to create docker config file: open/kaniko/ .docker/config.json: permission denied`
 
-#### Labels
+### Labels
 
-[Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
+Specify [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
 
-#### Build Arguments
+### Build Arguments
 
-The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) (`--build-arg`).
+The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#build-arg). This is equivalent to the `--build-arg` flag.
 
 ![](./static/build-and-push-to-docker-hub-step-settings-11.png)
 
-#### Target
+### Target
 
-The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) (`--target`).
+The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-For example, `build-env`.
+### Remote Cache Repository
 
-#### Remote Cache Repository
-
-Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
 
 This is different from other CI vendors that are limited to local caching and persistent volumes.
 
-You can also specify the same Docker repo for multiple Build and Push steps, enabling them to share the same remote cache.
+In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
 
-Remote Docker Layer Caching can dramatically improve build time by sharing layers across Pipelines, Stages, and steps.
+Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
-The remote cache repository needs to be created in the same host and project as the build image. The repository will be automatically created if it doesn't exist.
+In the step's **Remote Cache Repository** field, enter the name of the remote cache repo where the cached image layers will be stored.
 
-Enter the name of the remote cache repo where the cached image layers will be stored.
+The remote cache repository needs to be created in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
 
-The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
+### Run as User
 
-#### Run as User
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+### Set Container Resources
 
-#### Set container resources
+Set maximum resource limits for the resources used by the container at runtime:
 
-Maximum resources limit values for the resources used by the container at runtime.
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-##### Limit Memory
+### Timeout
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-##### Limit CPU
-
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -54,7 +54,7 @@ Use the following settings to add additional configuration to the step. Settings
 
 ### Optimize
 
-Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can reduce the time it takes to create snapshots. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
 
 ### Dockerfile
 
@@ -62,7 +62,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
+Enter a path to a directory containing files that make up the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 Kaniko requires root access to build the Docker image. If you have not already enabled root access, you will receive the following error:
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -84,17 +84,11 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Repository
 
-Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
-
-Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
-
-In the step's **Remote Cache Repository** field, enter the name of the remote cache repo where the cached image layers will be stored.
+Enter the name of the remote cache repo where the cached image layers will be stored.
 
 The remote cache repository needs to be created in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 ### Run as User
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-docker-hub-step-settings.md
@@ -14,13 +14,13 @@ Because this step is equivalent to the Docker [build](https://docs.docker.com/en
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Docker Connector
 
@@ -44,13 +44,13 @@ Add each tag separately.
 
 :::tip
 
-Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `Build ID: 9`. You can use the same tag in another stage to reference the same build by its tag.
+Harness expressions are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `9`. You can use the same tag in another stage to reference the same build by its tag.
 
 :::
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Optimize
 
@@ -62,7 +62,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Context represents a directory containing a Dockerfile which kaniko will use to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
+Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 Kaniko requires root access to build the Docker image. If you have not already enabled root access, you will receive the following error:
 
@@ -82,11 +82,11 @@ The [Docker build-time variables](https://docs.docker.com/engine/reference/comma
 
 The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-### Remote Cache Repository
+### Remote Cache Image
 
-Enter the name of the remote cache repo where the cached image layers will be stored.
+Enter the name of the remote cache image, such as `<container-registry-repo-name>/<image-name>`.
 
-The remote cache repository needs to be created in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+The remote cache repository must exist in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
 
 Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Build and Push to ECR Step Settings
-description: This topic provides settings for the Build and Push to ECR step, which builds an image and pushes it to AWS ECR. See also Pushing a Docker image in the AWS docs. Name. The unique name for this Connec…
+title: Build and Push to ECR step settings
+description: This topic provides settings for the Build and Push to ECR step.
 sidebar_position: 30
 helpdocs_topic_id: aiqbxaef15
 helpdocs_category_id: 4xo13zdnfx
@@ -10,108 +10,115 @@ helpdocs_is_published: true
 
 This topic provides settings for the Build and Push to ECR step, which builds an image and pushes it to [AWS ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html).
 
-See also [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) in the AWS docs.
+For more information, go to the AWS documentation for [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
 
-### Name
+:::info
 
-The unique name for this Connector.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### Id
+:::
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## Name
 
-### AWS Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-The Harness AWS Connector to use to connect to ECR. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to push to ECR. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md). This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
+## AWS Connector
 
-### Region
+The Harness AWS connector to use to connect to ECR.
 
-The AWS region to use when pushing the image. The registry format for ECR is `aws_account_id.dkr.ecr.region.amazonaws.com` and a region is required. See [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) from AWS.
+The AWS IAM roles and policies associated with the account connected to the Harness AWS connector must be able to push to ECR. For more information about roles and permissions for AWS connectors, go to:
 
-### Account Id
+* [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
+* [AWS connector settings reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
-The AWS account Id to use when pushing the image. The registry format for ECR is `aws_account_id.dkr.ecr.region.amazonaws.com` and an account Id is required. See [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) from AWS.
+This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
 
-### Image Name
+## Region
+
+Define the AWS region to use when pushing the image.
+
+The registry format for ECR is `aws_account_id.dkr.ecr.region.amazonaws.com` and a region is required. For more information, go to the AWS documentation for [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
+
+## Account Id
+
+The AWS account ID to use when pushing the image. This is required.
+
+The registry format for ECR is `aws_account_id.dkr.ecr.region.amazonaws.com`. For more information, go to the AWS documentation for [Pushing a Docker image](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
+
+## Image Name
 
 The name of the image you are pushing. It can be any name.
 
-### Tags
+## Tags
 
- [Docker build tag](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t)   (`-t`).
+Add [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag). This is equivalent to the `-t` flag.
 
-Each tag should added separately.
+Add each tag separately.
 
 ![](./static/build-and-push-to-ecr-step-settings-24.png)
 
-### Optional Configuration
+## Optional Configuration
 
-#### Base Image Connector
+Use the following settings to add additional configuration to the step.
+
+### Base Image Connector
 
 Select an authenticated connector to download base images from a DockerHub container registry. If you do not specify a **Base Image Connector**, the step downloads base images without authentication. Specifying a **Base Image Connector** is recommended because unauthenticated downloads generally have a lower rate limit than authenticated downloads.
 
-#### Optimize
+### Optimize
 
-Enable this option to redo snapshot mode.
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
 
-#### Dockerfile
+### Dockerfile
 
 The name of the Dockerfile. If you don't provide a name, Harness assumes the Dockerfile is in the root folder of the codebase.
 
-#### Context
+### Context
 
-Context represents a directory containing a Dockerfile that kaniko uses to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
+Context represents a directory containing a Dockerfile that kaniko uses to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
 
-#### Labels
+### Labels
 
- [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
+Specify [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
 
-#### Build Arguments
+### Build Arguments
 
-The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) (`--build-arg`).
+The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#build-arg). This is equivalent to the `--build-arg` flag.
 
 ![](./static/build-and-push-to-ecr-step-settings-25.png)
 
-#### Target
+### Target
 
-The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) (--target). For example, `build-env`.
+The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-#### Remote Cache Image
+### Remote Cache Image
 
-Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
 
 This is different from other CI vendors that are limited to local caching and persistent volumes.
 
-In addition, you can specify the same Docker repo for multiple Build and Push steps, enabling them to share the same remote cache.
+In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
 
-Remote Docker Layer Caching can dramatically improve build time by sharing layers across Pipelines, Stages, and steps.
+Remote Docker layer caching can dramatically improve build times by sharing layers across pipelines, stages, and steps.
 
-Enter the name of the remote cache image (for example, `app/myImage`).
+Enter the name of the remote cache image, for example, `app/myImage`.
 
-The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
+The remote cache repository must be in the same account and organization as the build image. For caching to work, the specified image name must exist.
 
-#### Run as User
+### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-#### Set container resources
+### Set Container Resources
 
-Maximum resources limit values for the resources used by the container at runtime.
+Set maximum resource limits for the resources used by the container at runtime:
 
-##### Limit Memory
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-##### Limit CPU
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -93,17 +93,11 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
-
-Remote Docker layer caching can dramatically improve build times by sharing layers across pipelines, stages, and steps.
-
 Enter the name of the remote cache image, for example, `app/myImage`.
 
 The remote cache repository must be in the same account and organization as the build image. For caching to work, the specified image name must exist.
+
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in subsequent builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build times by sharing layers across pipelines, stages, and steps.
 
 ### Run as User
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -31,7 +31,7 @@ The AWS IAM roles and policies associated with the account connected to the Harn
 * [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
 * [AWS connector settings reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
-This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross account access).
+This step supports AWS connectors with any authentication method (AWS access key, Delegate IAM role assumption, IRSA, and cross-account access).
 
 ## Region
 
@@ -67,7 +67,7 @@ Select an authenticated connector to download base images from a DockerHub conta
 
 ### Optimize
 
-Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can reduce the time it takes to create snapshots. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
 
 ### Dockerfile
 
@@ -75,7 +75,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes the Doc
 
 ### Context
 
-Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
+Enter a path to a directory containing files that make up the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-ecr-step-settings.md
@@ -14,13 +14,13 @@ For more information, go to the AWS documentation for [Pushing a Docker image](h
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## AWS Connector
 
@@ -59,7 +59,7 @@ Add each tag separately.
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Base Image Connector
 
@@ -75,7 +75,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes the Doc
 
 ### Context
 
-Context represents a directory containing a Dockerfile that kaniko uses to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
+Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Build and Push to GCR Step Settings
-description: This topic provides settings for the Build and Push to GCR Step, which builds an image and pushes it to GCR. Requirements. This step assumes that the target GCR registry meets the GCR requirements fo…
+title: Build and Push to GCR step settings
+description: This topic provides settings for the Build and Push to GCR step.
 sidebar_position: 40
 helpdocs_topic_id: 66ykcm0sf0
 helpdocs_category_id: 4xo13zdnfx
@@ -8,104 +8,116 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings for the Build and Push to GCR Step, which builds an image and pushes it to GCR.
+This topic provides settings for the Build and Push to GCR Step, which builds an image and pushes it to GCR. This step assumes that the target GCR registry meets the GCR requirements for pushing images. For more information, go to the Google documentation on [Pushing and pulling images](https://cloud.google.com/container-registry/docs/pushing-and-pulling).
 
-### Requirements
+:::info
 
-This step assumes that the target GCR registry meets the GCR requirements for pushing images. See [Pushing and pulling images](https://cloud.google.com/container-registry/docs/pushing-and-pulling) from Google.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### Name
+:::
 
-The unique name for this Connector.
+## Name
 
-### ID
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## GCP Connector
 
-### GCP Connector
-
-The Harness GCP Connector to use to connect to GCR. See [Google Cloud Platform (GCP) Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
+The Harness GCP connector to use to connect to GCR. The GCP account associated with the GCP connector needs specific roles. For more information, go to [Google Cloud Platform (GCP) connector settings reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
 
 This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
-### Host
+## Host
 
-The GCR registry hostname. For example, `us.gcr.io` hosts images in data centers in the United States, in a separate storage bucket from images hosted by `gcr.io`.
+The Google Container Registry hostname. For example, `us.gcr.io` hosts images in data centers in the United States in a separate storage bucket from images hosted by `gcr.io`. For a list of Container Registries, go to the Google documentation on [Pushing and pulling images](https://cloud.google.com/container-registry/docs/pushing-and-pulling).
 
-### Project ID
+## Project ID
 
-The GCP [Resource Manager project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects).
+The [GCP resource manager project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects).
 
-### Image Name
+## Image Name
 
-The name of the image you want to build.
+The name of the image you want to build and push to the target container registry.
 
-### Tags
+## Tags
 
- [Docker build tag](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) (`-t`). Add each tag separately.
+Add [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag). This is equivalent to the `-t` flag.
 
-### Optional Configurations
+Add each tag separately.
 
-#### Dockerfile
+:::tip
+
+Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `Build ID: 9`. You can use the same tag in another stage to reference the same build by its tag.
+
+:::
+
+## Optional Configuration
+
+Use the following settings to add additional configuration to the step.
+
+### Optimize
+
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+
+### Dockerfile
 
 The name of the Dockerfile. If you don't provide a name, Harness assumes that the Dockerfile is in the root folder of the codebase.
 
-#### Context
+### Context
 
-Context represents a directory containing a Dockerfile that kaniko uses to build your image. For example, a`COPY` command in your Dockerfile should refer to a file in the build context.
+Context represents a path to a directory containing a Dockerfile that kaniko uses to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
 
-#### Labels
+### Labels
 
- [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
+Specify [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
 
-#### Build Arguments
+### Build Arguments
 
-The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) (`--build-arg`).
+The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#build-arg). This is equivalent to the `--build-arg` flag.
 
 ![](./static/build-and-push-to-gcr-step-settings-23.png)
 
-#### Target
+### Target
 
-The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) (--target).
+The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-For example, `build-env`.
+### Remote Cache Image
 
-#### Remote Cache Image
-
-Harness enables remote Docker Layer Caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo.
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo.
 
 This is different from other CI vendors that are limited to local caching and persistent volumes.
 
-You can also specify the same Docker repo for multiple Build and Push steps, enabling them to share the same remote cache.
+In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
 
-Remote Docker Layer Caching can dramatically improve build time by sharing layers across Pipelines, Stages, and steps.
+Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
-Enter the name of the remote cache image (for example, `gcr.io/project-id/<image>`).
+Enter the name of the remote cache image, for example, `gcr.io/project-id/<image>`.
 
-The Remote Cache Repository must be in the same account and organization as the build image. For caching to work, the entered image name must exist.
+The remote cache repository must be in the same account and organization as the build image. For caching to work, the specified image name must exist.
 
-#### Run as User
+### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-#### Set container resources
+### Set container resources
 
-Maximum resources limit values for the resources used by the container at runtime.
+Set maximum resource limits for the resources used by the container at runtime:
 
-##### Limit Memory
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-##### Limit CPU
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
 
-##### Timeout
+## See also
 
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
+You can find the following settings on the **Advanced** tab in the step settings pane.
 
-### See Also
+### Conditional Execution
 
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
+* [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
+* 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -112,12 +112,9 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 * [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
 * [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
 
-## See also
+## Advanced settings
 
-You can find the following settings on the **Advanced** tab in the step settings pane.
-
-### Conditional Execution
+You can find the following settings on the **Advanced** tab in the step settings pane:
 
 * [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
 * [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
-* 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -56,7 +56,7 @@ Use the following settings to add additional configuration to the step. Settings
 
 ### Optimize
 
-Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can improve snapshot times. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
+Select this option to enable `--snapshotMode=redo`. This setting causes file metadata to be considered when creating snapshots, and it can reduce the time it takes to create snapshots. For more information, go to the kaniko documentation for the [snapshotMode flag](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---snapshotmode).
 
 ### Dockerfile
 
@@ -64,7 +64,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
+Enter a path to a directory containing files that make up the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings for the Build and Push to GCR Step, which builds an
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## GCP Connector
 
@@ -46,13 +46,13 @@ Add each tag separately.
 
 :::tip
 
-Harness expression are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `Build ID: 9`. You can use the same tag in another stage to reference the same build by its tag.
+s are a useful way to define tags. For example, `<+pipeline.sequenceId>` is a built-in Harness expression. It represents the Build ID number, such as `9`. You can use the same tag in another stage to reference the same build by its tag.
 
 :::
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Optimize
 
@@ -64,7 +64,7 @@ The name of the Dockerfile. If you don't provide a name, Harness assumes that th
 
 ### Context
 
-Context represents a path to a directory containing a Dockerfile that kaniko uses to build your image. For example, a `COPY` command in your Dockerfile should refer to a file in the build context.
+Enter a path to a directory containing files that makeup the [build's context](https://docs.docker.com/engine/reference/commandline/build/#description). When the pipeline runs, the build process can refer to any files found in the context. For example, a Dockerfile can use a `COPY` instruction to reference a file in the context.
 
 ### Labels
 
@@ -82,7 +82,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Enter the name of the remote cache image, for example, `gcr.io/project-id/<image>`.
+Enter the name of the remote cache image, such as `gcr.io/project-id/<image>`.
 
 The remote cache repository must be in the same account and organization as the build image. For caching to work, the specified image name must exist.
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -82,17 +82,11 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo.
-
-This is different from other CI vendors that are limited to local caching and persistent volumes.
-
-In addition, you can specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache.
-
-Remote Docker layer caching can dramatically improve build time by sharing layers across pipelines, stages, and steps.
-
 Enter the name of the remote cache image, for example, `gcr.io/project-id/<image>`.
 
 The remote cache repository must be in the same account and organization as the build image. For caching to work, the specified image name must exist.
+
+Harness enables remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 ### Run as User
 

--- a/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/build-and-push-to-gcr-step-settings.md
@@ -116,5 +116,5 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 You can find the following settings on the **Advanced** tab in the step settings pane:
 
-* [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
-* [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.
+* [Conditional Execution](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md): Set conditions to determine when/if the step should run.
+* [Failure Strategy](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md): Control what happens to your pipeline when a step fails.

--- a/docs/continuous-integration/ci-technical-reference/ci-git-clone-step.md
+++ b/docs/continuous-integration/ci-technical-reference/ci-git-clone-step.md
@@ -1,6 +1,6 @@
 ---
-title: Git Clone Step Settings
-description: A Git Clone step is useful when you want to include multiple repositories in your build. Each step clones its repo to the pipeline workspace along with the cloned codebase.
+title: Git Clone step settings
+description: The Git Clone step clones a repo to the pipeline workspace.
 sidebar_position: 70
 helpdocs_topic_id: nl3ixvew4o
 helpdocs_category_id: 4xo13zdnfx
@@ -8,81 +8,77 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings for the Git Clone step, which clones a repo to the pipeline workspace.
+This topic provides settings for the Git Clone step, which clones a repo to the pipeline workspace. This step is useful when you want to include multiple repositories in your build. For example, suppose you maintain your code files in one repo and your build files (such as Dockerfiles) in a separate repo. In this case, you can set up your pipeline's **Build** stage to [clone your code files](../use-ci/codebase-configuration/create-and-configure-a-codebase.md) and then add a Git Clone step to clone your build files into your pipeline workspace.
 
-This step is useful when you want to include multiple repositories in your build. For example, suppose you maintain your code files in one repo and your build files (such as Dockerfiles) in a separate repo. In this case, you can set up your Build stage to [clone your code files](../use-ci/codebase-configuration/create-and-configure-a-codebase.md) and add a Git Clone step to clone your build files into your pipeline workspace.
+:::info
 
-### Name
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-The unique name for this step.
+:::
 
-### Id
+## Name
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-### Connector
+## Connector
 
-The connector to your code repo. See [Code Repo Connectors](/docs/category/code-repo-connectors).
+The connector to the source control provider for the code repo you want the step to clone. For more information, go to [Code repo connectors](https://developer.harness.io/docs/category/code-repo-connectors).
 
-### Repository
+## Repository Name
 
-The code repo to add to the build. You need to specify this If the connector URL points to a Git account (such as `https://github.com/my-account/`) rather than to a repo within the account.
+The name of the code repo you want to clone into the pipeline workspace, if this is not already designated in the connector's configuration.
 
-### Build Type, Git Branch, Git Tag
+This setting is required if the connector uses a Git account URL, such as `https://github.com/my-account/`, rather than to a URL for a specific repo within that account.
 
-The branch or commit from the cloned repo that you want to include in the build.
+## Build Type
 
-These settings apply only to the repo specified in the Git Clone step. They are independent of the equivalent pipeline build settings, which apply to the Codebase object for the build stage.  
-To ensure that the repo in a Git Clone Step uses the same branch or commit as the main codebase, you use the run time variables `<+codebase.branch>` and `<+codebase.tag>`. See [Built-in CI Codebase Variables Reference](built-in-cie-codebase-variables-reference.md).
+Select **Git Branch** if you want the step to clone code from a specific branch with in the repo. Select **Git Tag** if you want the step to clone code from a specific commit tag. Based on your selection, specify a **Branch Name** or **Tag Name**. You can use fixed values, runtime input, and variable expressions for the branch and tag names.
 
-### Clone Directory
+This setting applies only to the repo specified in this **Git Clone** step. It is separate from the `codebase` object for the pipeline's **Build** stage. If you want this **Git Clone** step's repo to use the same branch or commit as the primary codebase, specify either `<+codebase.branch>` or `<+codebase.tag>` for **Branch Name** or **Tag Name**. Make sure to set the input type to **Expression**. These expressions pull runtime input from the pipeline; for example, if the pipeline's primary codebase uses the `development` branch, then the **Git Clone** step clones the `development` branch from its repo. For more information, go to [Built-in CI codebase variables reference](built-in-cie-codebase-variables-reference.md).
+
+## Clone Directory
 
 The target path in the pipeline workspace where you want to clone the repo.
 
-You cannot specify `/harness/` as a target for a Git Clone step because this folder is reserved for the repo defined in the Codebase object of the Build stage.You can set up your Build stage to use a custom workspace volume and share data across steps in your Build stage. See the Workspace section in [CI Build Stage Settings](ci-stage-settings.md).
+You can't specify `/harness/` as a target for a **Git Clone** step because this folder is reserved for the repo defined in the **Build** stage's `codebase` object. However, you can set up your **Build** stage to use a custom workspace volume and share data across steps in your **Build** stage. For more information, go to the **Workspace** section in [CI Build stage settings](ci-stage-settings.md).
 
-### Additional Configuration
+## Additional Configuration
 
-Configure the following options to add additional configuration for the Step.
+Use the following settings to add additional configuration to the step.
 
-#### Depth
+### Depth
 
-The number of commits to fetch when the clones the repo.
+The number of commits to fetch when the step clones the repo.
 
-For manual Triggers, the default Depth is 50 (each `git clone` operation fetches the most recent 50 commits). A setting of 0 fetches all commits in the branch. 
+For manually-triggered builds, the default depth is `50`. This means each `git clone` operation fetches the 50 most recent commits. For all other trigger types, the default depth is `0`, which fetches all commits from the relevant branch.
 
-For all other Trigger types, the default Depth is 0 (fetch all commits to the branch).
+For more information, go to [https://git-scm.com/docs/git-clone](https://git-scm.com/docs/git-clone).
 
-For details, see <https://git-scm.com/docs/git-clone>.
+### SSL Verify
 
-#### SSL Verify
+If **True**, which is the default value, the pipeline verifies your Git SSL certificates. The build fails if the certificate check fails. Set this to **False** only if you have a known issue with the certificate and you are willing to run your builds anyway.
 
-If **True** (the default), the Pipeline verifies your Git SSL certificates. The build fails if the certificate check fails. You should set this to **False** only if you have a known issue with the certificate and are willing to run your builds anyway.
+If you want to use self-signed certificates in your build infrastructure, go to [Configure a Kubernetes Build Farm to use Self-Signed Certificates](../use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md)
 
-If you want to use self-signed certificates in your build infrastructure, see [Configure a Kubernetes Build Farm to use Self-Signed Certificates](../use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md)
+### Run as User
 
-#### Run as User
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+### Set Container Resources
 
-#### Set container resources
+Set maximum resource limits for the resources used by the container at runtime:
 
-Maximum resources limit values for the resources used by the container at runtime.
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-##### Limit Memory
+### Timeout
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-##### Limit CPU
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.ACL
-
-### See Also
+## See also
 
 * [Create and Configure a Codebase](../use-ci/codebase-configuration/create-and-configure-a-codebase.md)
 * [Clone and Process Multiple Codebases in the Same Pipeline](../use-ci/run-ci-scripts/clone-and-process-multiple-codebases-in-the-same-pipeline.md)
-

--- a/docs/continuous-integration/ci-technical-reference/ci-git-clone-step.md
+++ b/docs/continuous-integration/ci-technical-reference/ci-git-clone-step.md
@@ -12,13 +12,13 @@ This topic provides settings for the Git Clone step, which clones a repo to the 
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Connector
 

--- a/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
@@ -56,7 +56,7 @@ This field is required for the Run Tests step to publish test results.
 
 Specify one or more paths to test report files. You can specify multiple paths, and [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported. Test reports must be in JUnit XML format.
 
-## Additional Configurations
+## Additional Configuration
 
 Use these optional settings to specify additional configurations.
 
@@ -129,7 +129,7 @@ Select an option to set the pull policy for the image:
 
 ### Run as User
 
-Set the value to specify the user ID for all processes in the pod running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use for all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
 ### Set Container Resources
 

--- a/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
@@ -12,7 +12,7 @@ This topic describes the Harness CI Run Tests step settings. The Run Tests step 
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id**.
 
 ## Description
 
@@ -58,7 +58,7 @@ Specify one or more paths to test report files. You can specify multiple paths, 
 
 ## Additional Configuration
 
-Use these optional settings to specify additional configurations.
+Use these optional settings to specify additional configurations. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Pre-Command
 

--- a/docs/continuous-integration/ci-technical-reference/configure-service-dependency-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/configure-service-dependency-step-settings.md
@@ -48,7 +48,7 @@ In a Kubernetes build infrastructure, all steps run in containers. In an AWS bui
 
 ### Name
 
-The unique name for this step.
+Enter a name summarizing the step's purpose.
 
 ### Id
 

--- a/docs/continuous-integration/ci-technical-reference/plugin-step-settings-reference.md
+++ b/docs/continuous-integration/ci-technical-reference/plugin-step-settings-reference.md
@@ -1,6 +1,6 @@
 ---
-title: Plugin Step Settings
-description: This topic provides settings for the CI Plugin step. Plugins are Docker containers that perform predefined tasks and are configured as steps in your stage. Plugins can be used to deploy code, publish…
+title: Plugin step settings
+description: Plugins are Docker containers that perform predefined tasks and are configured as steps.
 sidebar_position: 80
 helpdocs_topic_id: 8r5c3yvb8k
 helpdocs_category_id: 4xo13zdnfx
@@ -8,76 +8,66 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings for the CI Plugin step.
+This topic provides settings for the CI Plugin step. Plugins are Docker containers that perform predefined tasks and are configured as steps in your stage. Plugins can be used to deploy code, publish artifacts, send notifications, and more.
 
-Plugins are Docker containers that perform predefined tasks and are configured as steps in your stage. Plugins can be used to deploy code, publish artifacts, send notifications, and more.
+:::info
 
-### Name
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-The unique name for this step.
+:::
 
-### ID
+## Name
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-### Description
+## Description
 
-Text string.
+Optional text string describing the step's purpose.
 
-### Tags
+## Container Registry
 
-See [Tags Reference](../../platform/20_References/tags-reference.md).
+Harness connector for the container registry where the plugin image is located.
 
-### Container Registry
+## Image
 
-Harness Connector for the container registry where the plugin image is located.
-
-### Image
-
-The name of the Plugin Docker image. The image name should include the tag and will default to the latest tag if unspecified.
+The name of the plugin's Docker image. The image name should include the tag. If you don't include a tag, Harness uses the latest tag. For more information about tags, go to [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag).
 
 You can use any Docker image from any Docker registry, including Docker images from private registries.
 
-### Optional Configurations
+## Optional Configuration
 
-#### Privileged
+Use the following settings to add additional configuration to the step.
 
-Enable this option to run the container with escalated privileges. This is the equivalent of running a container with the Docker `--privileged` flag.
+### Privileged
 
-#### Settings
+Select this option to run the container with escalated privileges. This is the equivalent of running a container with the Docker `--privileged` flag.
 
-Plugin-specific settings. See [Drone plugins docs](http://plugins.drone.io/).
+### Settings
 
-#### Image Pull Policy
+Specify plugin-specific settings according to the plugin's documentation. For more information, go to the [Drone plugins documentation](http://plugins.drone.io/).
 
-Select an option to set the pull policy for the image.
+### Image Pull Policy
 
-* **Always**: The kubelet queries the container image registry to resolve the name to an image digest every time the kubelet launches a container. If the kubelet encounters an exact digest cached locally, it uses its cached image; otherwise, the kubelet downloads (pulls) the image with the resolved digest, and uses that image to launch the container.
-* **If Not Present**: The image is pulled only if it isn't already present locally.
-* **Never**: The kubelet assumes that the image exists locally and doesn't try to pull the image.
+Select an option to set the pull policy for the image:
 
-#### Run as User
+* **Always:** The kubelet queries the container image registry to resolve the name to an image digest every time the kubelet launches a container. If the kubelet encounters an exact digest cached locally, it uses its cached image; otherwise, the kubelet downloads (pulls) the image with the resolved digest, and uses that image to launch the container.
+* **If Not Present:** The image is pulled only if it isn't already present locally.
+* **Never:** The image is assumed to exist locally. No attempt is made to pull the image.
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+### Run as User
 
-#### Set container resources
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-These settings specify the maximum resources used by the container at runtime.
+### Set container resources
 
-##### Limit Memory
+Set maximum resource limits for the resources used by the container at runtime:
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-##### Limit CPU
+### Timeout
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/plugin-step-settings-reference.md
+++ b/docs/continuous-integration/ci-technical-reference/plugin-step-settings-reference.md
@@ -12,13 +12,13 @@ This topic provides settings for the CI Plugin step. Plugins are Docker containe
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Description
 

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Restore Cache from GCS Settings
-description: This topic provides settings for the Restore Cache from GCS step, which restores files and directories that were saved using the Save Cache to GCS step. Name. The unique name for this step. Id. See E…
+title: Restore Cache from GCS step settings
+description: This topic provides settings for the Restore Cache from GCS step.
 sidebar_position: 90
 helpdocs_topic_id: e2o4sektz1
 helpdocs_category_id: 4xo13zdnfx
@@ -10,69 +10,63 @@ helpdocs_is_published: true
 
 This topic provides settings for the Restore Cache from GCS step, which restores files and directories that were saved using the [Save Cache to GCS](save-cache-to-gcs-step-settings.md) step.
 
-### Name
+:::info
 
-The unique name for this step.
-
-### Id
-
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
-
-### GCP Connector
-
-The Harness connector for the GCP account where you saved the cache. This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
 :::
 
-### Bucket
+## Name
 
-GCS bucket name.
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-### Key
+## GCP Connector
 
-The key used to identify the cache.
+The Harness connector for the GCP account where you saved the cache.
 
-The backslash character isn't allowed as part of the checksum added here. This is a limitation of the Go language (golang) template. Use a forward slash instead. 
+This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
+
+## Bucket
+
+GCS bucket name where you saved the cache.
+
+## Key
+
+The key to identify the cache.
+
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead:
 
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Optional Configurations
+## Optional Configuration
 
-#### Archive Format
+Use the following settings to add additional configuration to the step.
 
-Select the archive format.
+### Archive Format
 
-The default archive format is Tar.
+Select the archive format. The default archive format is Tar.
 
-#### Fail if Key Doesn't Exist
+### Fail if Key Doesn't Exist
 
-Select this option to fail the step if the key doesn’t exist.
+Select this option to fail the step if the specified **Key** doesn't exist.
 
-By default, the Fail if Key Doesn't Exist option is set to False.
+By default, this option is set to false (unselected).
 
-#### Run as User
+### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-#### Set Container Resources
+### Set Container Resources
 
-Maximum resources limit values for the resources used by the container at runtime.
+Maximum resources limits for the resources used by the container at runtime:
 
-##### Limit Memory
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-##### Limit CPU
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-gcs-settings.md
@@ -12,13 +12,13 @@ This topic provides settings for the Restore Cache from GCS step, which restores
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## GCP Connector
 
@@ -41,7 +41,7 @@ The backslash character isn't allowed as part of the checksum value here. This i
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Archive Format
 

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Restore Cache from S3 Step Settings
-description: This topic provides settings for the Restore Cache from S3 step. Name. The unique name for this step. ID. See Entity Identifier Reference. AWS Connector. The Harness Connector to use when restoring t…
+title: Restore Cache from S3 step settings
+description: This topic provides settings for the Restore Cache from S3 step.
 sidebar_position: 100
 helpdocs_topic_id: zlpx6lli6d
 helpdocs_category_id: 4xo13zdnfx
@@ -10,19 +10,21 @@ helpdocs_is_published: true
 
 This topic provides settings for the Restore Cache from S3 step.
 
-### Name
+:::info
 
-The unique name for this step.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### ID
+:::
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## Name
 
-### AWS Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-The Harness Connector to use when restoring the cache from AWS S3. Typically, this is the same Connector used when you saved the cache. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).
+## AWS Connector
 
-The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to read from S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
+The Harness Connector to use when restoring the cache from AWS S3. Typically, this is the same connector used when you saved the cache in a previous [Save Cache to S3 step](save-cache-to-s-3-step-settings.md).
+
+The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to read from S3.
 
 :::note
 
@@ -31,69 +33,69 @@ This step supports AWS connectors using **AWS Access Key**, **Assume IAM role on
 This step doesn't support AWS connectors that have enabled cross account access (ARN/STS) for any authentication method.
 
 :::
-### Region
 
-An AWS region you used when you saved the cache. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).
+For more information about roles and permissions for AWS connectors, go to:
 
-### Bucket
+* [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
+* [AWS Connector settings reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
-The AWS S3 bucket you used when you saved the cache. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).
+## Region
 
-### Key
+The AWS region you used when you saved the cache in a previous [Save Cache to S3 step](save-cache-to-s-3-step-settings.md).
 
-The key you used to identify the cache when you saved it. See [Save Cache to S3 Step Settings](save-cache-to-s-3-step-settings.md).
+## Bucket
 
-The backslash character isn't allowed as part of the checksum added here. This is a limitation of the Go language (golang) template. Use a forward slash instead. 
+The AWS S3 bucket where you saved the cache in a previous [Save Cache to S3 step](save-cache-to-s-3-step-settings.md).
+
+## Key
+
+The key you used to identify the cache when you saved it in a previous [Save Cache to S3 step](save-cache-to-s-3-step-settings.md).
+
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead:
 
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Optional Configurations
+## Optional Configuration
 
-#### Endpoint URL
+Use the following settings to add additional configuration to the step.
 
-Endpoint URL for S3-compatible providers (not needed for AWS).
+### Endpoint URL
 
-#### Archive Format
+Endpoint URL for S3-compatible providers. This is not needed for AWS.
 
-Select the archive format.
+### Archive Format
 
-The default archive format is Tar.
+Select the archive format. The default archive format is Tar.
 
-#### Path Style
+### Path Style
 
-Select whether to use Virtual Hosted Style (http://bucket.host/key) or Path Style (http://host/bucket/key). For MinIO, use Path Style (True).
+If unselected, the step uses Virtual Hosted Style for paths, such as `http://bucket.host/key`. If selected, the step uses Path Style, such as `http://host/bucket/key`.
 
-By default, the Path Style option is set to False.
+For MinIO, you must use Path Style. Make sure **Path Style** is true (selected).
 
-#### Fail if Key Doesn't Exist
+By default, **Path Style** is false (unselected).
 
-Select this option to fail the step if the key doesn’t exist.
+### Fail if Key Doesn't Exist
 
-By default, the Fail if Key Doesn't Exist option is set to False.
+Select this option to fail the step if the specified **Key** doesn't exist.
 
-#### Run as User
+By default, this option is set to false (unselected).
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+### Run as User
 
-#### Set Container Resources
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-Maximum resources limit values for the resources used by the container at runtime.
+### Set Container Resources
 
-##### Limit Memory
+Maximum resources limits for the resources used by the container at runtime:
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-##### Limit CPU
+### Timeout
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings for the Restore Cache from S3 step.
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## AWS Connector
 
@@ -58,7 +58,7 @@ The backslash character isn't allowed as part of the checksum value here. This i
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Endpoint URL
 

--- a/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/restore-cache-from-s-3-step-settings.md
@@ -28,9 +28,9 @@ The AWS IAM roles and policies associated with the account used in the Harness A
 
 :::note
 
-This step supports AWS connectors using **AWS Access Key**, **Assume IAM role on Delegate**, and IRSA authentication methods *without* cross account access (ARN/STS).
+This step supports AWS connectors using **AWS Access Key**, **Assume IAM role on Delegate**, and IRSA authentication methods *without* cross-account access (ARN/STS).
 
-This step doesn't support AWS connectors that have enabled cross account access (ARN/STS) for any authentication method.
+This step doesn't support AWS connectors that have enabled cross-account access (ARN/STS) for any authentication method.
 
 :::
 

--- a/docs/continuous-integration/ci-technical-reference/run-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/run-step-settings.md
@@ -1,6 +1,6 @@
 ---
 title: CI Run step settings
-description: This topic provides settings and permissions for the Harness CI Run step. The Build stage Run step can be used to run scripts in your CI stages. The Run step pulls in a Docker image, such as a Docker…
+description: This topic provides settings and permissions for the Harness CI Run step.
 sidebar_position: 50
 helpdocs_topic_id: 1i1ttvftm4
 helpdocs_category_id: 4xo13zdnfx
@@ -8,40 +8,38 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings and permissions for the Harness CI Run step.
+This topic provides settings and permissions for the Harness CI Run step. In a **Build** stage, the **Run** step can be used to run scripts in your CI pipeline. The **Run** step pulls in a Docker image, such as a Docker image for Maven, and then runs a script with the tool, such as `mvn clean install`. You can use any Docker image from any public or private Docker registry.
 
-The Build stage **Run** step can be used to run scripts in your CI stages.
+:::info
 
-The **Run** step pulls in a Docker image, such as a Docker image for Maven, and then runs a script with the tool, like `mvn clean install`. Note that you may use any Docker image from any public or private Docker registry.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+
+:::
 
 ## Name
 
-The unique name for this step.
-
-## Id
-
-For information about this setting, go to [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Description
 
-Text string.
+Optional text string describing the step's purpose.
 
 ## Container Registry
 
-The Harness Connector for a container registry. This is the container registry for the image that you want Harness to run build commands on, such as DockerHub.
+A Harness container registry connector for the image that you want Harness to run build commands on, such as DockerHub.
 
 ## Image
 
-The FQN (fully-qualified name) of the Docker image to use when running build commands. For example: `us.gcr.io/playground-123/quickstart-image`.
+The FQN (fully-qualified name) of the Docker image to use when this step runs commands, for example `us.gcr.io/playground-123/quickstart-image`.
 
-The image name should include the tag, or it defaults to the latest tag if unspecified. You can use any Docker image from any Docker registry, including Docker images from private registries.
+The image name should include the tag. If you don't include a tag, Harness uses the latest tag.
 
-Different container registries require different name formats:
+You can use any Docker image from any Docker registry, including Docker images from private registries. Different container registries require different name formats:
 
 * **Docker Registry:** Input the name of the artifact you want to deploy, such as `library/tomcat`. Wildcards aren't supported.
 * **GCR:** Input the FQN (fully-qualified name) of the artifact you want to deploy. Images in repos must reference a path, for example: `us.gcr.io/playground-123/quickstart-image:latest`.
 
-![](./static/run-step-settings-03.png)
+   ![](./static/run-step-settings-03.png)
 
 * **ECR:** Input the FQN (fully-qualified name) of the artifact you want to deploy. Images in repos must reference a path, for example: `40000005317.dkr.ecr.us-east-1.amazonaws.com/todolist:0.2`.
 
@@ -67,11 +65,11 @@ You can reference services started in [Background steps](./background-step-setti
 
 ## Optional Configuration
 
-Use these settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step.
 
 ### Privileged
 
-Enable this option to run the container with escalated privileges. This is the equivalent of running a container with the Docker `--privileged` flag.
+Enable this option to run the container with escalated privileges. This is equivalent to running a container with the Docker `--privileged` flag.
 
 ### Report Paths
 
@@ -162,27 +160,18 @@ Select an option to set the pull policy for the image.
 
 ### Run as User
 
-Set the value to specify the user Id for all processes in the pod, running in containers. For more information about how to set the value, see [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
 ### Set Container Resources
 
-Set maximum resources limits for the resources used by the container at runtime.
+Maximum resources limits for the resources used by the container at runtime:
 
-#### Limit Memory
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You may also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-Do not include spaces when entering a fixed value. The default value, if unspecified, is `500Mi`.
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-#### Limit CPU
-
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed; you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-#### Timeout
-
-The timeout limit for the step. Once the timeout is reached, the step fails and pipeline execution continues.
-
-## See also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/run-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/run-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings and permissions for the Harness CI Run step. In a *
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Description
 
@@ -65,7 +65,7 @@ You can reference services started in [Background steps](./background-step-setti
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Privileged
 

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Save Cache to GCS Step Settings
-description: This topic provides settings and permissions for the Save Cache to GCS step, which preserves files and directories between builds. Name. The unique name for this step. ID. See Entity Identifier Refer…
+title: Save Cache to GCS step settings
+description: This topic provides settings and permissions for the Save Cache to GCS step.
 sidebar_position: 120
 helpdocs_topic_id: 11nzeuntrz
 helpdocs_category_id: 4xo13zdnfx
@@ -10,79 +10,71 @@ helpdocs_is_published: true
 
 This topic provides settings and permissions for the Save Cache to GCS step, which preserves files and directories between builds.
 
-### Name
+:::info
 
-The unique name for this step.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### ID
+:::
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## Name
 
-### GCP Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-The Harness Connector for the GCP account where you want to save the cache.
+## GCP Connector
+
+The Harness connector for the GCP account where you want to save the cache. For more information, go to [Google Cloud Platform (GCP) connector settings reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
 
 This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
 
-### Bucket
+## Bucket
 
-GCS bucket name.
+The GCS destination bucket name.
 
-### Key
+## Key
 
 The key to identify the cache.
 
-You can use the checksum macro to create a key based on a file's checksum. For example:
+You can use the checksum macro to create a key based on a file's checksum, for example: `myApp-{{ checksum filePath1 }}`
 
-`myApp-{{ checksum filePath1 }}`
+With this macro, Harness checks if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
 
-Harness checks to see if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
-
-The backslash character isn't allowed as part of the checksum added here. This is a limitation of the Go language (golang) template. Use a forward slash instead.
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead.
 
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Source Paths
+## Source Paths
 
 A list of the files/folders to cache. Add each file/folder separately.
 
-### Optional Configurations
+## Optional Configuration
 
-#### Archive Format
+Use the following settings to add additional configuration to the step.
 
-Select the archive format.
+### Archive Format
 
-The default archive format is TAR.
+Select the archive format. The default archive format is Tar.
 
-#### Override Cache
+### Override Cache
 
-Select this option to override the cache if the key already exists.
+Select this option if you want to override the cache if a cache with a matching **Key** already exists.
 
-By default, the **Override Cache** option is set to False (unchecked).
+By default, the **Override Cache** option is set to false (unselected).
 
-#### Run as User
+### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-#### Set container resources
+### Set Container Resources
 
-Maximum resources limit values for the resources used by the container at runtime.
+Maximum resources limits for the resources used by the container at runtime:
 
-##### Limit Memory
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-##### Limit CPU
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-gcs-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings and permissions for the Save Cache to GCS step, whi
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## GCP Connector
 
@@ -49,7 +49,7 @@ A list of the files/folders to cache. Add each file/folder separately.
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Archive Format
 

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
@@ -1,5 +1,5 @@
 ---
-title: Save Cache to S3 Step Settings
+title: Save Cache to S3 step settings
 description: This topic provides settings for the Save Cache to S3 step.
 sidebar_position: 130
 helpdocs_topic_id: qtvjvrp9sn
@@ -10,19 +10,21 @@ helpdocs_is_published: true
 
 This topic provides settings for the Save Cache to S3 step, which preserves files and directories between builds.
 
-To restore a saved cache, add a [Restore Cache from S3 Step](restore-cache-from-s-3-step-settings.md).
+To restore a saved cache, add a [Restore Cache from S3 step](restore-cache-from-s-3-step-settings.md) to your pipeline.
 
-### Name
+:::info
 
-The unique name for this step.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### ID
+:::
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## Name
 
-### AWS Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-The Harness Connector to use when saving the cache to an S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to write to S3. See [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
+## AWS Connector
+
+The Harness AWS connector to use when saving the cache to S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to write to S3.
 
 :::note
 
@@ -32,79 +34,79 @@ This step doesn't support AWS connectors that have enabled cross account access 
 
 :::
 
-### Region
+For more information about roles and permissions for AWS connectors, go to:
 
-An AWS region you selected when you created AWS S3 bucket. See [Creating and configuring an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-configure-bucket.html) in the AWS docs.
+* [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
+* [AWS connector settings reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
-### Bucket
+## Region
+
+Define the AWS region to use when saving the cache, such as the AWS region you selected when you created the AWS S3 bucket. For more information go to the AWS documentation:
+
+* [Creating and configuring an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-configure-bucket.html)
+* [Pushing a Docker image to an Amazon ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html)
+
+## Bucket
 
 The AWS S3 bucket where you want to save the cache.
 
-### Key
+## Key
 
 The key to identify the cache.
 
-You can use the checksum macro to create a key based on a file’s checksum. For example:
+You can use the checksum macro to create a key based on a file's checksum, for example: `myApp-{{ checksum filePath1 }}`
 
-`myApp-{{ checksum filePath1 }}`
+With this macro, Harness checks if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
 
-Harness checks to see if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
-
-The backslash character isn't allowed as part of the checksum added here. This is a limitation of the Go language (golang) template. Use a forward slash instead.
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead.
 
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Source Paths
+## Source Paths
 
 A list of the files/folders to cache. Add each file/folder separately.
 
-### Optional Configuration
+## Optional Configuration
 
-#### Endpoint URL
+Use the following settings to add additional configuration to the step.
 
-Endpoint URL for S3-compatible providers (not needed for AWS).
+### Endpoint URL
 
-#### Archive Format
+Endpoint URL for S3-compatible providers. This setting is not needed for AWS.
 
-Select the archive format.
+### Archive Format
 
-The default archive format is Tar.
+Select the archive format. The default archive format is Tar.
 
-#### Override Cache
+### Override Cache
 
-Select this option if you want to override the cache if the key already exists.
+Select this option if you want to override the cache if a cache with a matching **Key** already exists.
 
-By default, the **Override Cache** option is set to False (unchecked).
+By default, the **Override Cache** option is set to false (unselected).
 
-#### Path Style
+### Path Style
 
-Select whether to use Virtual Hosted Style (http://bucket.host/key) or Path Style (http://host/bucket/key). For MinIO, use Path Style (True).
+If unselected, the step uses Virtual Hosted Style for paths, such as `http://bucket.host/key`. If selected, the step uses Path Style, such as `http://host/bucket/key`.
 
-By default, the Path Style option is set to False.
+For MinIO, you must use Path Style. Make sure **Path Style** is true (selected).
 
-#### Run as User
+By default, **Path Style** is false (unselected).
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+### Run as User
 
-#### Set Container Resources
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-Maximum resources limit values for the resources used by the container at runtime.
+### Set Container Resources
 
-##### Limit Memory
+Maximum resources limits for the resources used by the container at runtime:
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-##### Limit CPU
+### Timeout
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
@@ -14,13 +14,13 @@ To restore a saved cache, add a [Restore Cache from S3 step](restore-cache-from-
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## AWS Connector
 
@@ -69,7 +69,7 @@ A list of the files/folders to cache. Add each file/folder separately.
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Endpoint URL
 

--- a/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/save-cache-to-s-3-step-settings.md
@@ -28,9 +28,9 @@ The Harness AWS connector to use when saving the cache to S3. The AWS IAM roles 
 
 :::note
 
-This step supports AWS connectors using **AWS Access Key**, **Assume IAM role on Delegate**, and IRSA authentication methods *without* cross account access (ARN/STS).
+This step supports AWS connectors using **AWS Access Key**, **Assume IAM role on Delegate**, and IRSA authentication methods *without* cross-account access (ARN/STS).
 
-This step doesn't support AWS connectors that have enabled cross account access (ARN/STS) for any authentication method.
+This step doesn't support AWS connectors that have enabled cross-account access (ARN/STS) for any authentication method.
 
 :::
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Upload Artifacts to GCS Step Settings
-description: This topic provides settings for the Upload Artifacts to GCS step, which uploads artifacts to Google Cloud Storage. See Uploads and downloads in the Google Cloud docs. Name. The unique name for this…
+title: Upload Artifacts to GCS step settings
+description: This topic provides settings for the Upload Artifacts to GCS step.
 sidebar_position: 140
 helpdocs_topic_id: 3qeqd8pls7
 helpdocs_category_id: 4xo13zdnfx
@@ -10,53 +10,50 @@ helpdocs_is_published: true
 
 This topic provides settings for the Upload Artifacts to GCS step, which uploads artifacts to Google Cloud Storage. See [Uploads and downloads](https://cloud.google.com/storage/docs/uploads-downloads) in the Google Cloud docs.
 
-### Name
+:::info
 
-The unique name for this Connector.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### ID
+:::
 
-See [Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md).
+## Name
 
-### GCP Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+
+## GCP Connector
 
 The Harness connector for the GCP account where you want to upload the artifact. For more information, go to [Google Cloud Platform (GCP) connector settings reference](../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md). This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
-### Bucket
 
-GCS destination bucket name.
+## Bucket
 
-### Source Path
+The GCS destination bucket name.
 
-Path to the artifact file/folder you want to upload. You can use regex to upload multiple files. Harness creates the compressed file automatically.
+## Source Path
 
-### Optional Configurations
+Path to the artifact file/folder you want to upload. You can use glob expressions to upload multiple files. For example, `src/js/**/*.js` uploads all Javascript files in `src/js/subfolder-1/`, `src/js/subfolder-2`, and so on. Harness creates the compressed file automatically.
 
-#### Target
+## Optional Configuration
 
-The name of the artifact file.
+Use the following settings to add additional configuration to the step.
 
-#### Run as User
+### Target
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+The path, relative to the **Bucket** where you want to store the cache. If no target path is provided, the cache is saved to `[bucket]/`.
 
-#### Set container resources
+### Run as User
 
-Maximum resources limit values for the resources used by the container at runtime.
+Specify the user ID to use to run all processes in the pod, if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-##### Limit Memory
+### Set container resources
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+Set maximum resource limits for the resources used by the container at runtime:
 
-##### Limit CPU
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+### Timeout
 
-##### Timeout
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.ACL
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-gcs-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings for the Upload Artifacts to GCS step, which uploads
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## GCP Connector
 
@@ -34,7 +34,7 @@ Path to the artifact file/folder you want to upload. You can use glob expression
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Target
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
@@ -1,6 +1,6 @@
 ---
-title: Upload Artifacts to JFrog Artifactory Step Settings
-description: This topic provides settings for the Upload Artifacts to JFrog Artifactory step. Name. The unique name for this Connector. Description. Text string. Artifactory Connector. Select the Harness Artifact…
+title: Upload Artifacts to JFrog Artifactory step settings
+description: This topic provides settings for the Upload Artifacts to JFrog Artifactory step.
 sidebar_position: 150
 helpdocs_topic_id: gjoggc66fy
 helpdocs_category_id: 4xo13zdnfx
@@ -10,55 +10,54 @@ helpdocs_is_published: true
 
 This topic provides settings for the Upload Artifacts to JFrog Artifactory step.
 
-### Name
+:::info
 
-The unique name for this Connector.
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
 
-### Description
+:::
 
-Text string.
+## Name
 
-### Artifactory Connector
+The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-Select the Harness Artifactory Connector to use for this upload.
+## Description
 
-See [Artifactory Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/artifactory-connector-settings-reference.md). This step supports Artifactory connectors that use either anonymous or username and password authentication.
+Text string describing the step's purpose.
 
-### Target
+## Artifactory Connector
+
+Select the Harness Artifactory connector to use for this upload. For more information, go to the [Artifactory connector settings reference](../../platform/7_Connectors/ref-cloud-providers/artifactory-connector-settings-reference.md).
+
+This step supports Artifactory connectors that use either anonymous or username and password authentication.
+
+## Target
 
 The target folder in the registry.
 
-### Source Path
+Target repository name relative to the server URL in the connector. If `pom.xml` is not present, then the **Target** must be a full path to an artifacts folder, such as `groupId/artifactId/version`.
 
-Path to the artifact file/folder you want to upload.
+## Source Path
 
-You can use regex to upload multiple files.
+Path to the artifact file/folder you want to upload. You can use glob expressions to upload multiple files. For example, `src/js/**/*.js` uploads all Javascript files in `src/js/subfolder-1/`, `src/js/subfolder-2`, and so on. Harness creates the compressed file automatically.
 
-Harness will automatically create the compressed file.
+## Optional Configuration
 
-### Optional Configurations
+Use the following settings to add additional configuration to the step.
 
-#### Run as User
+### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. See [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-#### Set container resources
+### Set container resources
 
-Maximum resources limit values for the resources used by the container at runtime.
+Set maximum resource limits for the resources used by the container at runtime:
 
-##### Limit Memory
+* **Limit Memory:** The maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+* * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`.
+### Timeout
 
-##### Limit CPU
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
-The maximum number of cores that the container can use. CPU limits are measured in cpu units. Fractional requests are allowed: you can specify one hundred millicpu as `0.1` or `100m`. See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-### See Also
-
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-jfrog-artifactory-step-settings.md
@@ -12,13 +12,13 @@ This topic provides settings for the Upload Artifacts to JFrog Artifactory step.
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
 ## Description
 
@@ -42,7 +42,7 @@ Path to the artifact file/folder you want to upload. You can use glob expression
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Run as User
 

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -10,17 +10,24 @@ helpdocs_is_published: true
 
 This topic provides details about the settings for the Upload Artifacts to S3 step, which uploads artifacts to AWS or other S3 providers such as [MinIo](https://docs.min.io/docs/minio-gateway-for-s3.html).
 
+:::info
+
+Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+
+:::
+
 ## Name
 
 The unique name for this step.
 
-An **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) is generated based on the name The **Id** can be edited.
+Harness generates an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id**.
 
 ## AWS Connector
 
 The Harness AWS connector to use when connecting to AWS S3.
 
 The AWS IAM roles and policies associated with the account connected to the Harness AWS connector must be able to push to S3. For more information about roles and permissions for AWS connectors, go to:
+
 * [Add an AWS connector](../../platform/7_Connectors/add-aws-connector.md)
 * [AWS Connector Settings Reference](../../platform/7_Connectors/ref-cloud-providers/aws-connector-settings-reference.md).
 
@@ -57,7 +64,7 @@ Define the AWS region to use when pushing the image.
 
 ## Bucket
 
-The S3 bucket name for the uploaded artifact.
+The name of the S3 bucket name where you want to upload the artifact.
 
 ## Source Path
 
@@ -71,17 +78,17 @@ Use the following settings to add additional configuration to the step.
 
 ### Endpoint URL
 
-Endpoint URL for S3-compatible providers. It is not needed for AWS.
+Endpoint URL for S3-compatible providers. This setting is not needed for AWS.
 
 ### Target
 
 The path, relative to the S3 **Bucket**, where you want to store the artifact. Do not include the bucket name; you specified this in **Bucket**.
 
-If unspecified, the cache is saved to `[bucket]/[key]`.
+If no path is specified, the cache is saved to `[bucket]/[key]`.
 
 ### Run as User
 
-Set the value to specify the user id for all processes in the pod, running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
 ### Set Container Resources
 
@@ -89,9 +96,10 @@ Maximum resources limits for the resources used by the container at runtime:
 
 * **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
 * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-* **Timeout:** Timeout limit for the step. Once the timeout is reached, the step fails and pipeline execution continues.
 
-## See Also
+### Timeout
 
-* [Step Skip Condition Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy Settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
+
+* [Step Skip Condition settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)

--- a/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/upload-artifacts-to-s-3-step-settings.md
@@ -12,15 +12,13 @@ This topic provides details about the settings for the Upload Artifacts to S3 st
 
 :::info
 
-Depending on the stage's build infrastructure, some settings may be unavailable. Not all settings are available for all build infrastructure options.
+Depending on the stage's build infrastructure, some settings may be unavailable.
 
 :::
 
 ## Name
 
-The unique name for this step.
-
-Harness generates an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id**.
+Enter a name summarizing the step's purpose. Harness generates an **Id** ([Entity Identifier Reference](../../platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id**.
 
 ## AWS Connector
 
@@ -74,7 +72,7 @@ You can use standard [glob expressions](https://en.wikipedia.org/wiki/Glob_(prog
 
 ## Optional Configuration
 
-Use the following settings to add additional configuration to the step.
+Use the following settings to add additional configuration to the step. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
 ### Endpoint URL
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic explains how to add a Build and Push to [Azure Container Registry](https://azure.microsoft.com/en-us/products/container-registry) (ACR) step to a CI pipeline.
 
-These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+These steps assume you're familiar with creating CI pipelines. If you haven't created a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
 ## Add the Build and Push to ACR step
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
@@ -1,0 +1,43 @@
+---
+title: Build and Push to ACR
+description: Use a CI pipeline to build and push an image to ACR.
+sidebar_position: 30
+helpdocs_topic_id: gstwrwjwgu
+helpdocs_category_id: mi8eo3qwxm
+helpdocs_is_private: false
+helpdocs_is_published: true
+---
+
+This topic explains how to add a Build and Push to [Azure Container Registry](https://azure.microsoft.com/en-us/products/container-registry) (ACR) step to a CI pipeline.
+
+These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+
+## Add the Build and Push to ACR step
+
+1. Go to **Pipelines** and create a new pipeline or edit an existing pipeline.
+2. If your pipeline doesn't already have a **Build** stage, select **Add Stage**, and then select **Build**.
+3. On the **Build** stage's **Infrastructure** tab, configure the build infrastructure.
+
+:::note
+
+The **Build and Push to ACR** step is only available for [Kubernetes cluster build infrastructure](../set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md). For other build infrastructures, you can use the [Build and Push and image to Docker Registry step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md) to [build and push an artifact](./build-and-upload-an-artifact.md) to ACR.
+
+:::
+
+4. In the **Build** stage's **Execution** tab, select **Add Step**, select **Add Step** again, and then select **Build and Push to ACR** from the Step Library.
+5. Configure the [Build and Push to ACR step settings](../../ci-technical-reference/build-and-push-to-acr-step-settings.md).
+6. Select **Apply Changes** to save the step, and then select **Save** to save the pipeline.
+
+## Run the pipeline
+
+Select **Run Pipeline** to run your pipeline. Depending on your pipeline's codebase configuration, you may need to select a Git branch or tag to use for the build.
+
+While the build runs, you can monitor the **Build and Push to ACR** step logs, and, if the build succeeds, you can find your pushed image on ACR.
+
+## See also
+
+* [Run step settings](../../ci-technical-reference/run-step-settings.md)
+* [CI pipeline quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
+* [Delegates overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md)
+* [CI stage settings](../../ci-technical-reference/ci-stage-settings.md)
+* [Harness key concepts](../../../getting-started/learn-harness-key-concepts.md)

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-acr.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic explains how to add a Build and Push to [Azure Container Registry](https://azure.microsoft.com/en-us/products/container-registry) (ACR) step to a CI pipeline.
 
-These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
 ## Add the Build and Push to ACR step
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
@@ -1,8 +1,6 @@
 ---
 title: Build and Push to GCR
-description: This topic provides settings to Build and Push an image to Google Container Registry (GCR).
-tags: 
-   - helpDocs
+description: Use a CI pipeline to build and push an image to GCR.
 sidebar_position: 30
 helpdocs_topic_id: gstwrwjwgu
 helpdocs_category_id: mi8eo3qwxm
@@ -10,157 +8,38 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic provides settings to Build and Push an image to [Google Container Registry](https://cloud.google.com/container-registry) (GCR).
+This topic explains how to add a Build and Push to [Google Container Registry](https://cloud.google.com/container-registry) (GCR) step to a CI pipeline.
 
-The following steps build an image and push it to GCR.
+These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
-### Before You Begin
+## Add the Build and Push to GCR step
 
-* [CI Pipeline Quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
-* [Delegates Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md)
-* [CI Stage Settings](../../ci-technical-reference/ci-stage-settings.md)
-* [Learn Harness' Key Concepts](../../../getting-started/learn-harness-key-concepts.md)
+1. Go to **Pipelines** and create a new pipeline or edit an existing pipeline.
+2. If your pipeline doesn't already have a **Build** stage, select **Add Stage**, and then select **Build**.
+3. On the **Build** stage's **Infrastructure** tab, configure the build infrastructure. For example, you can [Define a Kubernetes cluster build infrastructure](../set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md).
+4. In the **Build** stage's **Execution** tab, select **Add Step**, select **Add Step** again, and then select **Build and Push to GCR** from the Step Library.
+5. Configure the [Build and Push to GCR step settings](../../ci-technical-reference/build-and-push-to-gcr-step-settings.md).
+6. Select **Apply Changes** to save the step, and then select **Save** to save the pipeline.
 
-### Step 1: Create the CI Stage
+## Run the pipeline
 
-In your Harness Pipeline, click **Add Stage**, and then click CI.
+Select **Run Pipeline** to run your pipeline. Depending on your pipeline's codebase configuration, you may need to select a Git branch or tag to use for the build.
 
-### Step 2: Define the Build Farm Infrastructure
+![](./static/build-and-push-to-ecr-515.png)
 
-In the CI stage Infrastructure, define the build infrastructure for the Codebase.
-
-The following steps use a Kubernetes cluster build farm.
-
-See [Define Kubernetes Cluster Build Infrastructure](../set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md).
-
-
-### Step 3: Add the Build and Push Step
-
-In the stage's Execution, select **Build and Push to GCR**.
-
-#### Step Parameters
-
-##### Name
-
-The unique name for this Step.
-
-##### ID
-
-See [Entity Identifier Reference](../../../platform/20_References/entity-identifier-reference.md).
-
-##### GCP Connector
-
-The Harness GCP Connector to use to connect to GCR. GCP account associated with the GCP Connector needs specific roles.
-
-See [Google Cloud Platform (GCP) Connector Settings Reference](../../../platform/7_Connectors/ref-cloud-providers/gcs-connector-settings-reference.md).
-
-##### Host
-
-The GCR registry hostname. For example, us.gcr.io hosts images in data centers in the United States in a separate storage bucket from images hosted by gcr.io.
-
-##### Project ID
-
-The GCP [Resource Manager project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects).
-
-##### Image Name
-
-The name of the image you want to build.
-
-##### Tags
-
-The [Docker build tag](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) \(--target\).
-
-Each tag should be added separately.
-
-##### Option: Add a Tag using Harness Expression
-
-You can tag the image in any way, but a Harness expression can be very useful.
-
-The `<+pipeline.sequenceId>` is a built-in Harness variable. It represents the Build ID number, such as Build ID: 9. You can then use the same tag in another stage to reference the same build with its tag.
-
-##### Dockerfile
-
-Enter the path of the Dockerfile. If you don't provide a name, Harness assumes the Dockerfile is in the root folder of the codebase.
-
-##### Context
-
-Enter a path to a directory containing a Dockerfile.
-
-##### Labels
-
-[Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) to add metadata to the Docker image.
-
-##### Build Arguments
-
-The [Docker build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) (--build-arg).
-
-##### Target
-
-The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) (--target).
-
-For example, build-env.
-
-##### Remote Cache Image
-
-The remote cache repository and build image need to be created on the same host and project. The Build creates the repository automatically if it doesn’t exist.
-
-##### Set container resources
-
-Maximum resources limit values for the resources used by the container at runtime.
-
-##### Limit Memory
-
-Maximum memory that the container can use.
-
-You can express memory as a plain integer or as a fixed-point number using suffixes G or M. You can also use the power-of-two equivalents Gi or Mi.
-
-##### Limit CPU
-
-See [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-Limit the number of cores that the container can use.
-
-Limits for CPU resources are measured in CPU units.
-
-Fractional requests are allowed. The expression 0.1 is equivalent to the expression 100m, which can be read as one hundred millicpu.
-
-##### Timeout
-
-Timeout for the step. Once the timeout is reached, the step fails, and the Pipeline execution continues.
-
-#### Advanced Options
-
-##### Conditional Execution
-
-Set conditions to determine when the step should be executed. See [Conditional Execution](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md).
-
-##### Failure Strategy
-
-Define one or more failure strategies to control the behavior of your pipeline when your step execution encounters an error. See [Failure Strategy](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md). 
-
-### Step 4: Specify Codebase Branch or Tag at Pipeline Execution
-
-Select the Codebase Git Branch or Git Tag to use for the execution.
-
-Enter the branch or tag and click **Run Pipeline**.
-
-![](./static/build-and-push-to-ecr-515.png )
-
-###  Step 5: View the Results
-
-You can see the logs for the Build and Push step in the Pipeline as it runs.
+While the build runs, you can monitor the **Build and Push to GCR** step logs.
 
 ![](./static/build-and-push-to-ecr-516.png)
 
-In your Harness project's Builds, you can see the build listed.
-
-![](./static/build-and-push-to-ecr-517.png)
-
-On GCR, you can see the image that you pushed.
+If the build succeeds, you can find your pushed image on GCR.
 
 ![](./static/build-and-push-to-ecr-518.png)
 
-### See Also
+## See also
 
-* [Run Step Settings](../../ci-technical-reference/run-step-settings.md)
+* [Run step settings](../../ci-technical-reference/run-step-settings.md)
+* [CI pipeline quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
+* [Delegates overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md)
+* [CI stage settings](../../ci-technical-reference/ci-stage-settings.md)
+* [Harness key concepts](../../../getting-started/learn-harness-key-concepts.md)
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic explains how to add a Build and Push to [Google Container Registry](https://cloud.google.com/container-registry) (GCR) step to a CI pipeline.
 
-These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+These steps assume you're familiar with creating CI pipelines. If you haven't created a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
 ## Add the Build and Push to GCR step
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 This topic explains how to add a Build and Push to [Google Container Registry](https://cloud.google.com/container-registry) (GCR) step to a CI pipeline.
 
-These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+These steps assume you're familiar with creating CI pipelines. If you haven't create a pipeline before, try this tutorial to [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
 ## Add the Build and Push to GCR step
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
@@ -1,6 +1,6 @@
 ---
 title: Build and push an artifact
-description: Once you've defined a build farm in the CI stage's infrastructure, you can add a Build and Push step to build your codebase and push the artifact to a repo.
+description: Add a Build and Push step to build and push an artifact to a repo.
 sidebar_position: 20
 helpdocs_topic_id: 8l31vtr4hi
 helpdocs_category_id: mi8eo3qwxm
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Once you've defined a build farm in the CI stage's infrastructure, you can add a Build and Push step to build your codebase and push the artifact to a repo. The following repos are supported:
+Add a **Build and Push** step to your CI pipeline to build your codebase and then push the artifact to a repo. The following repos are supported:
 
 * Docker
 * Azure Container Registry (ACR)
@@ -17,9 +17,17 @@ Once you've defined a build farm in the CI stage's infrastructure, you can add a
 
 This topic describes a simple one-step build workflow that does not include testing. It builds the code in a build farm, and then pushes it to a repo.
 
-For details about Build and Push step settings, go to the [CI technical reference](/docs/category/ci-technical-reference).
+For details about various **Build and Push** step settings, go to the [CI technical reference](/docs/category/ci-technical-reference).
 
-### Before you begin
+For a visual overview of this process, watch the following video:
+
+<!-- Video:
+https://harness-1.wistia.com/medias/rpv5vwzpxz-->
+<docvideo src="https://www.youtube.com/embed/v3A4kF1Upqo?feature=oembed" />
+
+<!-- div class="hd--embed" data-provider="YouTube" data-thumbnail="https://i.ytimg.com/vi/v3A4kF1Upqo/hqdefault.jpg"><iframe width="200" height="150" src="https://www.youtube.com/embed/v3A4kF1Upqo?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div -->
+
+## Before you begin
 
 You should have an understanding of the following:
 
@@ -27,139 +35,40 @@ You should have an understanding of the following:
 * How to [Set up build infrastructure](/docs/category/set-up-build-infrastructure).
 * How to create pipelines. If you haven't created a pipeline before, try one of these tutorials:
   * [CI pipeline tutorial](../../ci-quickstarts/ci-pipeline-quickstart.md)
-  * [Get started for free with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+  * [Get started for free with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 * [CI stage settings](../../ci-technical-reference/ci-stage-settings.md)
 
-### Visual summary
+## Add the Build and Push step
 
-The following video shows how to set up a Build and Push step.
+1. Go to **Pipelines** and create a new pipeline or edit an existing pipeline.
+1. Configure the pipeline's codebase, if you have not already done so. For details, go to [Create and configure a codebase](../codebase-configuration/create-and-configure-a-codebase.md).
 
-<!-- Video:
-https://harness-1.wistia.com/medias/rpv5vwzpxz-->
-<docvideo src="https://www.youtube.com/embed/v3A4kF1Upqo?feature=oembed" />
+:::tip
 
+The codebase configuration specifies the repo to use for this pipeline. When you run the pipeline, you specify the specific branch or commit to use for that build.
 
-<!-- div class="hd--embed" data-provider="YouTube" data-thumbnail="https://i.ytimg.com/vi/v3A4kF1Upqo/hqdefault.jpg"><iframe width="200" height="150" src="https://www.youtube.com/embed/v3A4kF1Upqo?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div -->
+:::
 
-### Step 1: Create the CI stage
+2. If your pipeline doesn't already have a **Build** stage, select **Add Stage**, and then select **Build**.
+3. On the **Build** stage's **Infrastructure** tab, configure the build infrastructure. For example, you can [Define a Kubernetes cluster build infrastructure](../set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md).
+4. In the **Build** stage's **Execution** tab, select **Add Step**, select **Add Step** again, and then select a **Build and Push** step from the Step Library.
 
-In your Harness Pipeline, click **Add Stage**, and then click **Build**.
-
-
-### Step 2: Add the Codebase
-
-
-Do one of the following:
-
-
-* If this is the first CI stage in the pipeline, in the CI stage settings, enable **Clone Codebase**.
-* If you have an existing pipeline with a CI stage, click **Codebase** on the right.
-
-
-In **Connector**, select an existing Connector to your codebase repo, or create a new one. See [Code Repo Connectors](/docs/category/code-repo-connectors).
-
-
-You can see the URL for the repo account below **Repository Name**. Don't add the URL into **Repository Name**.
-
-
-In **Repository Name**, enter the name of the repo containing the codebase.
-
-
-For example, if the account URL is `https://github.com/mycompany` and the repo in that account is `myapp`, you can simply enter `myapp` in **Repository Name**.
-
-
-You specify the codebase repo here, but you enter the Git branch or tag when you deploy the Pipeline.
-
-
-### Step 3: Define the Build Farm Infrastructure
-
-
-In the CI stage **Infrastructure**, define the build farm for the codebase.
-
-
-The following example uses a Kubernetes cluster build farm.
-
-
-In **Select a Kubernetes Cluster**, select or create a Kubernetes Connector. This Connector connects Harness to the cluster to use as the build farm. See [Kubernetes Cluster Connector Settings Reference](../../../platform/7_Connectors/ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md).
-
-
-In **Namespace**, enter the Kubernetes namespace to use. You can use a text string, a Runtime Input (`<+input>`), or an expression. See [Runtime Inputs](../../../platform/20_References/runtime-inputs.md).
-
-
-See [Define Kubernetes Cluster Build Infrastructure](../set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md).
-
-
-### Step 4: Add the Build and Push Step
-
-
-In the stage's **Execution**, add a Build and Push step. For all Build and Push steps, you select or create a connector for the target repo, add repo-specific information, and specify Dockerfile information. For information about the Build and Push step settings, go to the reference topic that corresponds with your registry provider:
+For all Build and Push steps, you select or create a connector for the target repo, add repo-specific information, and specify Dockerfile information. For information about each **Build and Push** step's settings, go to the reference topic that corresponds with your registry provider:
 
 * Docker: [Build and Push to Docker Registry Step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
 * Azure Container Registry (ACR): Use [Build and Push to Docker Registry Step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
 * Google Container Registry (GCR): [Build and Push to GCR Step](../../ci-technical-reference/build-and-push-to-gcr-step-settings.md)
 * Amazon Elastic Container Registry (ECR): [Build and Push to ECR Step Settings](../../ci-technical-reference/build-and-push-to-ecr-step-settings.md)
 
-<details>
-<summary>Optional: Add a tag using Harness Expression</summary>
+6. Select **Apply Changes** to save the step, and then select **Save** to save the pipeline.
 
-When you push the image to a repo, you tag the image so you can identify it later.
+## Run the pipeline
 
-For example, in one stage you push the image, and, in a later stage, you use the image name and tag to pull it and run integration tests on it.
-
-You can tag the image in any way, but a Harness expression can be very useful.
-
-Here's an example:
-
-![](./static/build-and-upload-an-artifact-10.png)
-
-The `<+pipeline.sequenceId>` provides a variable tags you can use to reference this image in future stages by using syntax such as: `harnessdev/ciquickstart:<+pipeline.sequenceId>`.
-
-If you have a [Background step](../../ci-technical-reference/background-step-settings.md) in a later stage in your pipeline, you can use the `<+pipeline.sequenceId>` variable to identify the image without needing a fixed value.
-
-![](./static/build-and-upload-an-artifact-11.png)
-
-The `<+pipeline.sequenceId>` is a built-in Harness variable that represents the **Build Id** number, for example `Build Id: 9`.
-
-After the pipeline runs, you can see the Build Id:
-
-![](./static/build-and-upload-an-artifact-15.png)
-
-This Build Id tags the image you push in one stage of your Pipeline, and pulls the image in future stages of your pipeline.
-
-You'll also see the Id as the tag on the image in your repo:
-
-![](./static/build-and-upload-an-artifact-12.png)
-
-</details>
-
-<details>
-<summary>Optional: Build a Docker image without pushing</summary>
-
-Suppose you want to test the Dockerfile used in your Codebase and verify that the resulting image is correct, before you push it to your Docker repository. To enable this in your Pipeline, do the following.
-
-1. In your CI Pipeline, go to the Build Stage that includes the Build and Push an Image to Docker Repository step that you want to customize.
-2. In the Build Stage Overview, expand the Advanced pane.
-3. Click Add Variable and enter the following:
-	1. NAME = **PLUGIN\_NO\_PUSH**
-	2. TYPE = **String**
-	3. VALUE = **true**
-4. Save and run the Pipeline.
-
-</details>
-
-### Step 5: Specify Codebase Branch or Tag at Pipeline Execution
-
-Once you click **Run Pipeline**, provide the Git branch or tag to use for the execution.
+Select **Run Pipeline** to run your pipeline. Depending on your pipeline's codebase configuration, you may need to select a Git branch or tag to use for the build.
 
 ![](./static/build-and-upload-an-artifact-13.png)
 
-Enter the branch or tag and click **Run Pipeline**.
-
-### Step 6: View the Results
-
-You can see the logs for the Build and Push Step in the Pipeline as it runs.
-
-Here's an example that pushes to a Docker repository:
+While the build runs, you can monitor the **Build and Push** step logs. For example, these are the logs for a step that pushed to a Docker repo:
 
 ```
 /kaniko/executor --dockerfile=Dockerfile --context=dir://. --destination=cretzman/ciquickstart:13
@@ -182,17 +91,65 @@ Taking snapshot of files...
 ENTRYPOINT ["/bin/go-sample-app"]
 ```
 
-On Docker Hub, you can see the image that you pushed.
+If the build succeeds, you can find the pushed image in your image repo:
 
 ![](./static/build-and-upload-an-artifact-14.png)
 
-In your Harness project's **Builds**, you can see the build listed.
+The build is also listed in your Harness project's **Builds**.
 
-### YAML example
+## Useful techniques
 
-Here's an example of the YAML for a pipeline that has a stage with a Build and Push step:
+Here are some interesting ways you can use **Build and Push** steps.
 
-```
+<details>
+<summary>Use Harness expressions for tags</summary>
+
+When you push an image to a repo, you tag the image so you can identify it later. For example, in one pipeline stage, you push the image, and, in a later stage, you use the image name and tag to pull it and run integration tests on it.
+
+There are several ways to tag images, but Harness expressions can be useful.
+
+![](./static/build-and-upload-an-artifact-10.png)
+
+For example, `<+pipeline.sequenceId>` is a built-in Harness expression that represents the **Build Id** number, for example `Build Id: 9`.
+
+After the pipeline runs, you can see the `Build Id` in the output.
+
+![](./static/build-and-upload-an-artifact-15.png)
+
+The ID also appears as an image tag in your target image repo:
+
+![](./static/build-and-upload-an-artifact-12.png)
+
+The `Build Id` tags an image that you pushed in an earlier stage of your pipeline. You can use the `Build Id` to pull the same image in later stages of the same pipeline. By using a variable expression, rather than a fixed value, you don't have to use the same image name every time.
+
+For example, you can use the `<+pipeline.sequenceId>` expression as a variable tag to reference images in future pipeline stages by using syntax such as: `harnessdev/ciquickstart:<+pipeline.sequenceId>`.
+
+As a more specific example, if you have a [Background step](../../ci-technical-reference/background-step-settings.md) in a later stage in your pipeline, you can use the `<+pipeline.sequenceId>` variable to identify the image without needing to call on a fixed value.
+
+![](./static/build-and-upload-an-artifact-11.png)
+
+</details>
+
+<details>
+<summary>Build a Docker image without pushing</summary>
+
+You can use your CI pipeline to test a Dockerfile used in your codebase and verify that the resulting image is correct before you push it to your Docker repository.
+
+1. In your CI pipeline, go to the **Build** stage that includes the **Build and Push an image to Docker Registry** step.
+2. In the **Build** stage's **Overview** tab, expand the **Advanced** section.
+3. Click **Add Variable** and enter the following:
+	1. Name: **PLUGIN\_NO\_PUSH**
+	2. Type: **String**
+	3. Value: **true**
+4. Save and run the pipeline.
+
+</details>
+
+## YAML example
+
+Here's a YAML example for a CI pipeline that has a **Build** stage with a **Build and Push** step:
+
+```yaml
 pipeline:
   name: CI Quickstart
   identifier: CI_Quickstart
@@ -228,12 +185,8 @@ pipeline:
           serviceDependencies: []
   projectIdentifier: CI_Quickstart
   orgIdentifier: default
-
 ```
 
+## See also
 
-### See also
-
-* [Run Step Settings](../../ci-technical-reference/run-step-settings.md)
-
-
+* [Run step settings](../../ci-technical-reference/run-step-settings.md)

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
@@ -110,7 +110,7 @@ There are several ways to tag images, but Harness expressions can be useful.
 
 ![](./static/build-and-upload-an-artifact-10.png)
 
-For example, `<+pipeline.sequenceId>` is a built-in Harness expression that represents the **Build Id** number, for example `Build Id: 9`.
+For example, `<+pipeline.sequenceId>` is a built-in Harness expression that represents the **Build Id** number, for example `9`.
 
 After the pipeline runs, you can see the `Build Id` in the output.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md
@@ -55,10 +55,10 @@ The codebase configuration specifies the repo to use for this pipeline. When you
 
 For all Build and Push steps, you select or create a connector for the target repo, add repo-specific information, and specify Dockerfile information. For information about each **Build and Push** step's settings, go to the reference topic that corresponds with your registry provider:
 
-* Docker: [Build and Push to Docker Registry Step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
-* Azure Container Registry (ACR): Use [Build and Push to Docker Registry Step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
-* Google Container Registry (GCR): [Build and Push to GCR Step](../../ci-technical-reference/build-and-push-to-gcr-step-settings.md)
-* Amazon Elastic Container Registry (ECR): [Build and Push to ECR Step Settings](../../ci-technical-reference/build-and-push-to-ecr-step-settings.md)
+* Docker: [Build and Push an image to Docker registry step settings](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
+* Azure Container Registry (ACR): [Build and Push to ACR step settings](../../ci-technical-reference/build-and-push-to-acr-step-settings.md) or [Build and Push an image to Docker registry step settings](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md)
+* Google Container Registry (GCR): [Build and Push to GCR step settings](../../ci-technical-reference/build-and-push-to-gcr-step-settings.md)
+* Amazon Elastic Container Registry (ECR): [Build and Push to ECR step settings](../../ci-technical-reference/build-and-push-to-ecr-step-settings.md)
 
 6. Select **Apply Changes** to save the step, and then select **Save** to save the pipeline.
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -33,7 +33,7 @@ Test Intelligence is available for the following codebases:
 
 Make sure you have a CI pipeline with a **Build** stage that is connected to your codebase.
 
-If you haven't created a pipeline before, [Get started with the fasted CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
+If you haven't created a pipeline before, [Get started with the fastest CI on the planet](https://developer.harness.io/tutorials/build-code/fastest-ci).
 
 To add a **Build** stage to an existing pipeline:
 1. Go to the pipeline you want to edit.


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [x] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* CI-5125: All topics with the Remote Cache Repo/Image field have the same language. Most have an example. Waiting for Hemanth to clarify if further examples are needed.
* DOC-2502: Added two topics: **Build and Push to ACR step settings** reference and **Build and push to ACR** task.
* DOC-1815: Originally, this ticket asked for more explanation of the Optimize setting. However, it was discovered that this setting only appears for K8s build infras. It is too much effort at this time to check every field for every step with every build infra; instead, I added a note at the top of most of the CI step settings reference topics to clarify that some settings wont be available for all build infras. I also improved the Optimize description.
* I standardized the language across the step settings reference topics. For ex. "Name" has the same text on all of the topics.
* I removed setting explanations from some "task" topics, and I replaced these descriptions with links to the relevant reference topics. This reduces bloat in tasks.
* CI-7162: Added a yaml sample and some guidance for using CI pipelines to build multi-arch images. I had already edited the "Build and push an artifact" topic in this PR, so I added this small change here to avoid a conflict.

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 

## Peer review context

Style changes: 
* Attempted to standardize the language used in the CI step settings reference topics. Ex. All steps have a Name, so I copied the same Name setting description to all topics. Where applicable, I preserved step-specific information while standardizing the generic description. **I reused text when describing settings common to multiple steps. Only comment on one instance, and I will make changes throughout as needed. No need to read every line, for example, Set Container Resources text is the same in all topics where those settings exist.** 
* Reduced bloat by removing step setting descriptions from some "task" topics. Replaced descriptions with links to relevant reference topics.
* General style improvements revisions to reduce the number of headings, correct heading levels, use accordions, etc.

The following changes required tech review (refer to Issues listed above for more context): 
* **Partially passed tech review.** Two new topics (Build and push to ACR step settings reference / Build and push to ACR task): Already had some degree of tech review and SME discussion. Should not be many (if any) additional technical changes.
* **Passed tech review.** Improved the description of the Optimize setting and added it to a couple reference topics that it was missing from.
* **Passed tech review.** Added an :::info to the top of most CI step settings reference topics clarifying that some settings won't be visible for certain build infrastructures.
* **In tech review.** Enhance description of the Remote Cache Repo/Image setting.
