### PR TITLE
[DOC-2599] Remove anti-hosted language, correct technical issues

### DIFF
--- a/docs/continuous-integration/troubleshoot/troubleshooting-ci.md
+++ b/docs/continuous-integration/troubleshoot/troubleshooting-ci.md
@@ -42,7 +42,7 @@ For more information about self-signed certificates, delegates, and delegate env
 
 * [Delegate environment variables](../../platform/2_Delegates/delegate-reference/delegate-environment-variables.md)
 * [Docker delegate environment variables](../../platform/2_Delegates/delegate-reference/docker-delegate-environment-variables.md)
-* [Define a Docker build infrastructure](../use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md)
+* [Use local runner build infrastructure](../use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md)
 * [Install delegates](https://developer.harness.io/docs/category/install-delegates)
 * [Configure a Kubernetes build farm to use self-signed certificates](../use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md)
 

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
@@ -10,17 +10,17 @@ helpdocs_is_published: true
 
 :::tip
 
-Docker-in-Docker (DinD) with Privileged mode is necessary only when using Kubernetes build infrastructure. For other infrastructure types, you can run Docker commands directly on the host.
+Docker-in-Docker (DinD) with privileged mode is necessary only when using a Kubernetes build infrastructure. For other infrastructure types, you can run Docker commands directly on the host.
 
 :::
 
-CI pipelines that use Kubernetes build infrastructure need Docker-in-Docker (**DinD**) if you need to run Docker commands as part of the build process. For example, you can build images from two separate codebases in the same pipeline: One with a [Build and Push an Image to Docker Registry step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md) and another with Docker commands in a [Run step](../../ci-technical-reference/run-step-settings.md).
+CI pipelines that use a Kubernetes build infrastructure need Docker-in-Docker (**DinD**) if you need to run Docker commands as part of the build process. For example, you can build images from two separate codebases in the same pipeline: One with a [Build and Push an Image to Docker Registry step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md) and another with Docker commands in a [Run step](../../ci-technical-reference/run-step-settings.md).
 
-This topic illustrates a simple build-and-push workflow using Docker-in-Docker in a pipeline that uses Kubernetes build infrastructure.
+This topic illustrates a simple build-and-push workflow using Docker-in-Docker for a pipeline that uses a Kubernetes build infrastructure.
 
 ## Before You Begin
 
-Docker-in-Docker must run in privileged mode to work properly. Use caution because this provides full access to the host environment. For more information, go to the Docker documentation for [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). You can't use Docker-in-Docker on platforms that don't support Privileged mode, such as those running Windows containers.
+Docker-in-Docker must run in privileged mode to work properly. Use caution because this provides full access to the host environment. For more information, go to the Docker documentation for [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). You can't use Docker-in-Docker on platforms that don't support privileged mode, such as those that run containers on Windows.
 
 These steps assume you are familiar with the following concepts:
 

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
@@ -8,23 +8,27 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-You can run Docker-in-Docker (**DinD**) in a CI stage. This is useful whenever you need to run Docker commands as part of your build process. For example, you can build images from two separate codebases in the same pipeline: one using a step such as [Build and Push an Image to Docker Registry](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md), and another using Docker commands in a Run step.
+CI pipelines that use Kubernetes build infrastructure can run Docker-in-Docker (**DinD**) in CI stages. This is useful whenever you need to run Docker commands as part of your build process. For example, you can build images from two separate codebases in the same pipeline: one using a step such as [Build and Push an Image to Docker Registry](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md), and another using Docker commands in a [Run step](../../ci-technical-reference/run-step-settings.md).
 
-This topic illustrates a simple build-and-push workflow using Docker-in-Docker.
+:::tip
 
-Docker-in-Docker must run in privileged mode to work properly. You need to be careful because this provides full access to the host environment. See [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) in the Docker docs. Docker-in-Docker is not supported in Harness-hosted build infrastructures or on platforms (such as those running Windows containers) that don't support Privileged mode.
+This Docker-in-Docker configuration only applies to Kubernetes build infrastructure. You don't need this Docker-in-Docker setup for Harness Cloud, local runner, or VM build infrastructures. With Harness Cloud and other build infrastructures, you can run Docker commands directly in your pipeline stages.
 
-### Before You Begin
+:::
 
-To go through this workflow, you need the following:
+This topic illustrates a simple build-and-push workflow using Docker-in-Docker in a pipeline that uses Kubernetes build infrastructure.
 
-* A familiarity with basic Harness CI concepts:
-	+ [CI Pipeline Quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
-	+ [Learn Harness' Key Concepts](../../../getting-started/learn-harness-key-concepts.md)
-* A familiarity with Build Stage settings:
-	+ [CI Build Stage Settings](../../ci-technical-reference/ci-stage-settings.md)
+## Before You Begin
 
-### Step 1: Set Up the CI Stage
+Docker-in-Docker must run in privileged mode to work properly. Use caution because this provides full access to the host environment. For more information, go to the Docker documentation for [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). You can't use Docker-in-Docker not supported on platforms that don't support Privileged mode, such as those running Windows containers.
+
+These steps assume you are familiar with the following concepts:
+
+* Pipeline configuration, such as the [CI Pipeline quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
+* [Harness key concepts](../../../getting-started/learn-harness-key-concepts.md)
+* [CI Build Stage Settings](../../ci-technical-reference/ci-stage-settings.md)
+
+## Step 1: Set Up the CI Stage
 
 In your Harness Pipeline, click **Add Stage**. Then click **Build**.
 
@@ -36,11 +40,11 @@ In the Overview tab for the new Build Stage, configure the Stage as follows:
 	+ `/var/lib/docker`
 * Under Advanced, add Stage Variables for your Docker Hub Personal Access Token and any other fields you want to parameterize. For passwords and Personal Access Tokens, select Secret as the variable type.
 
-### Step 2: Define the Build Farm Infrastructure
+## Step 2: Define the Build Farm Infrastructure
 
 In the CI Build stage > **Infrastructure** tab, define the build infrastructure for the codebase. See [Set Up Build Infrastructure](/docs/category/set-up-build-infrastructure).
 
-### Step 3: Add a DinD Background step
+## Step 3: Add a DinD Background step
 
 In the Execution tab, add a [Background step](../../ci-technical-reference/background-step-settings.md) and configure it as follows:
 
@@ -49,7 +53,7 @@ In the Execution tab, add a [Background step](../../ci-technical-reference/backg
 * **Image:** The image you want to use, such as [docker:dind](https://hub.docker.com/_/docker).
 * **Optional Configuration:** Select **Privileged**. This is required for Docker-in-Docker.
 
-### Step 4: Configure the Run Step
+## Step 4: Configure the Run Step
 
 In the Execution tab, add a [Run Step](../../ci-technical-reference/run-step-settings.md) and configure it as follows:
 
@@ -85,7 +89,7 @@ docker build -t $DOCKER_IMAGE_LABEL .
 docker tag $DOCKER_IMAGE_LABEL $DOCKERHUB_USERNAME/$DOCKER_IMAGE_LABEL:<+pipeline.sequenceId>  
 docker push $DOCKERHUB_USERNAME/$DOCKER_IMAGE_LABEL:<+pipeline.sequenceId>
 ```
-### Step 5: Run the Pipeline
+## Step 5: Run the Pipeline
 
 Now you can run your Pipeline. You simply need to select the codebase.
 
@@ -94,10 +98,9 @@ Now you can run your Pipeline. You simply need to select the codebase.
 3. If prompted, specify a Git branch, tag, or PR number.
 4. Click **Run Pipeline** and check the console output to verify that the Pipeline runs as intended.
 
-### Configure As Code: YAML
+## Configure As Code: YAML
 
-To configure your pipeline as YAML in CI, go to Harness **Pipeline Studio**, click **YAML**. Here’s is a working example of the workflow described in this topic. Modify the YAML attributes such as name, identifiers, codebase, connector refs, and variables as needed.
-
+To configure your pipeline as YAML in CI, go to Harness **Pipeline Studio** and select **YAML**. Here is an example of a pipeline that uses the workflow described in this topic. Modify the YAML attributes, such as `name`, `identifiers`, `codebase`, connector refs, and variables, as needed.
 
 ```
 pipeline:
@@ -188,8 +191,7 @@ pipeline:
             value: dind-w-bg-step
 
 ```
-### See Also
+
+## See also
 
 * [Run a Drone Plugin in CI](../use-drone-plugins/run-a-drone-plugin-in-ci.md)
-* [CI Run Step Settings](../../ci-technical-reference/run-step-settings.md)
-

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
@@ -20,7 +20,7 @@ This topic illustrates a simple build-and-push workflow using Docker-in-Docker i
 
 ## Before You Begin
 
-Docker-in-Docker must run in privileged mode to work properly. Use caution because this provides full access to the host environment. For more information, go to the Docker documentation for [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). You can't use Docker-in-Docker not supported on platforms that don't support Privileged mode, such as those running Windows containers.
+Docker-in-Docker must run in privileged mode to work properly. Use caution because this provides full access to the host environment. For more information, go to the Docker documentation for [Runtime Privilege and Linux Capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities). You can't use Docker-in-Docker on platforms that don't support Privileged mode, such as those running Windows containers.
 
 These steps assume you are familiar with the following concepts:
 

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md
@@ -8,13 +8,13 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-CI pipelines that use Kubernetes build infrastructure can run Docker-in-Docker (**DinD**) in CI stages. This is useful whenever you need to run Docker commands as part of your build process. For example, you can build images from two separate codebases in the same pipeline: one using a step such as [Build and Push an Image to Docker Registry](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md), and another using Docker commands in a [Run step](../../ci-technical-reference/run-step-settings.md).
-
 :::tip
 
-This Docker-in-Docker configuration only applies to Kubernetes build infrastructure. You don't need this Docker-in-Docker setup for Harness Cloud, local runner, or VM build infrastructures. With Harness Cloud and other build infrastructures, you can run Docker commands directly in your pipeline stages.
+Docker-in-Docker (DinD) with Privileged mode is necessary only when using Kubernetes build infrastructure. For other infrastructure types, you can run Docker commands directly on the host.
 
 :::
+
+CI pipelines that use Kubernetes build infrastructure need Docker-in-Docker (**DinD**) if you need to run Docker commands as part of the build process. For example, you can build images from two separate codebases in the same pipeline: One with a [Build and Push an Image to Docker Registry step](../../ci-technical-reference/build-and-push-to-docker-hub-step-settings.md) and another with Docker commands in a [Run step](../../ci-technical-reference/run-step-settings.md).
 
 This topic illustrates a simple build-and-push workflow using Docker-in-Docker in a pipeline that uses Kubernetes build infrastructure.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -1,6 +1,6 @@
 ---
-title: Define a Docker Build Infrastructure
-description: You can define a CI build infrastructure on any Linux or macOS host. This is the simplest build infrastructure to set up and is well suited to developers who want to build on their laptops.
+title: Use local runner build infrastructure
+description: You can define a CI build infrastructure on any Linux or macOS host.
 sidebar_position: 15
 helpdocs_topic_id: xd8u17be5h
 helpdocs_category_id: rg8mrhqm95
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-You can define a CI build infrastructure on any Linux or macOS host. This is the simplest build infrastructure to set up, and is well-suited for developers who want to run builds on a local host such as a laptop.
+You can define a CI build infrastructure on any Linux or macOS host. This is recommended for small, limited builds, such as a one-off build on your local machine. Consider [other build infrastructure options](/docs/category/set-up-build-infrastructure) for builds-at-scale.
 
 ### Important Notes
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
@@ -11,45 +11,28 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic describes how to set up a Kubernetes cluster build infrastructure for a Harness CI stage.
+This topic describes how you can use Kubernetes cluster build infrastructure for a Harness CI pipeline stage. With Kubernetes build infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
 
-The codebase and tests you add to a Harness CI Stage are built and run using a build infrastructure in your environment.
-
-Some CI providers use in-house orchestration systems for build farms like Docker Machine ([deprecated since 2019](https://docs.docker.com/machine/)). With these systems, outages and backlogs can occur in their infrastructure. Often, the backlogs occur because they do not have enough capacity to cover the backlog that accrued during the outage.
-
-Harness build farms run on your infrastructure using battle-tested platforms for large container workloads (Kubernetes, AWS VMs). This enables you to build software and run tests, repeatedly and automatically, on a scalable platform with no outages.
-
-Once you set up the Kubernetes cluster to use as your build infrastructure, you connect Harness to it using a Harness Kubernetes Cluster Connector and Harness Delegate.
+Once you set up the Kubernetes cluster to use as your build infrastructure, you connect Harness to it with a Harness [Kubernetes cluster connector](../../../platform/7_Connectors/add-a-kubernetes-cluster-connector.md) and Harness Delegate.
 
 You can also set up build infrastructures using VMs. See [Set Up Build Infrastructure](/docs/category/set-up-build-infrastructure).
 
-### Limitations
+## GKE Autopilot is not recommended
 
-#### GKE Autopilot is Not Supported
+We don't recommend using Harness CI with GKE Autopilot due to Docker-in-Docker limitations and potential cloud cost increases.
 
+Autopilot clusters do not allow Privileged pods. This means you can't use [Docker-in-Docker](../run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md) to run Docker commands, since these require Privileged mode.
 
-Harness CI doesn't support GKE Autopilot for the following reasons.
+Additionally, GKE Autopilot sets resource limits equal to resource requests for each container. This can cause your builds to allocate more resources than they need, resulting in higher cloud costs with no added benefit.
 
-##### Cannot use Docker-in-Docker
+<details>
+<summary>GKE Autopilot cloud cost demonstration</summary>
 
-
-Autopilot clusters do not allow Privileged pods. Thus you cannot use [Docker-in-Docker](../run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md) to run Docker commands, since these require Privileged mode.
-
-
-##### GKE Autopilot Can Result in Higher Cloud Costs
-
-
-GKE Autopilot sets resource limits = resource requests for each container. This can cause your Builds to allocate more resources than they need. The result is higher cloud costs with no added benefit. 
-
-
-Consider the following CI Stage:
-
+Consider the following CI stage:
 
 ![](./static/set-up-a-kubernetes-build-infrastructure-530.png)
 
-
-  Assume that you configure your Stage resources as follows:
-
+Assume that you configure your stage resources as follows:
 
 * redis (service dependency in Background step): 5GB, 2 cpu
 * s1 step: 2GB, 2 cpu
@@ -58,33 +41,28 @@ Consider the following CI Stage:
 * s4 step: 2GB, 1 cpu
 * s5 step: 2GB, 1 cpu
 
-
-Kubernetes will allocate the pod based on the maximum requirements for the overall Stage — in this case, when the s3, s4, and s5 steps run in parallel. The pod also needs to run the Redis service at the same time. The requirements are the sum of Redis + s3 + s4 + s5: 
-
+Kubernetes would allocate the pod based on the maximum requirements for the overall stage. In this example, the peak requirement is when the s3, s4, and s5 steps run in parallel. The pod also needs to run the Redis service at the same time. The total maximum requirements are the sum of Redis + s3 + s4 + s5:
 
 * 5 + 4 + 2 + 2 = **13GB Memory**
 * 2 + 1 + 1 + 1 = **5 CPUs**
 
-
-GKE Autopilot calculates resource requirements differently. For containers, it sets resource limits to the same as resource requests. For pods, it sums all Step requirements in the Stage, whether they’re running in parallel or not. In this case, the requirements are the sum of Redis + s1 + s2 + s3 + s4 + s5:
-
+GKE Autopilot calculates resource requirements differently. For containers, it sets resource limits equivalent to resource requests. For pods, it sums all step requirements in the stage, whether they're running in parallel or not. In this example, the total maximum requirements are the sum of Redis + s1 + s2 + s3 + s4 + s5:
 
 * 5 + 2 + 2+ 4 + 4 + 4 = **17GB Memory**
 * 2 + 1 + 1+ 1 + 1 + 1 = **7 CPUs**
 
+Autopilot might be cheaper than standard Kubernetes if you only run builds occasionally. This can result in cost savings because some worker nodes are always running in a standard Kubernetes cluster. If you're running builds more often, Autopilot can increase costs unnecessarily.
 
-Autopilot might be cheaper than standard Kubernetes if you only run builds occasionally. This can result in cost savings because some worker nodes are always running in a standard Kubernetes cluster. 
+</details>
 
-
-
-### Before You Begin
+## Before You Begin
 
 * [CI Pipeline Quickstart](../../ci-quickstarts/ci-pipeline-quickstart.md)
 * [Delegates Overview](/docs/platform/2_Delegates/get-started-with-delegates/delegates-overview.md)
 * [CI Stage Settings](../../ci-technical-reference/ci-stage-settings.md)
 * [Learn Harness' Key Concepts](../../../getting-started/learn-harness-key-concepts.md)
 
-### Visual Summary
+## Visual Summary
 
 Here's a short video that walks you through adding a Harness Kubernetes Cluster Connector and Harness Kubernetes Delegate. The Delegate is added to the target cluster, then the Kubernetes Cluster Connector uses the Delegate to connect to the cluster.
 
@@ -95,9 +73,9 @@ https://harness-1.wistia.com/medias/rpv5vwzpxz-->
 <!-- div class="hd--embed" data-provider="YouTube" data-thumbnail="https://i.ytimg.com/vi/wUC23lmqfnY/hqdefault.jpg"><iframe width=" 200" height="150" src="https://www.youtube.com/embed/wUC23lmqfnY?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen"></iframe></div -->
 
 
-### Step 1: Create a Kubernetes Cluster
+## Step 1: Create a Kubernetes Cluster
 
-#### Prerequisites
+### Prerequisites
 
 * Ensure your Kubernetes cluster meets the build infrastructure requirements in [CI Cluster Requirement](../../../platform/7_Connectors/ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md#harness-ci-cluster-requirements).
 * For Harness-specific permission requirements, see [permission required](../../../platform/7_Connectors/ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md#permissions-required) for CI.
@@ -108,7 +86,7 @@ To create a new Kubernetes cluster, see:
 * [Creating a cluster in Kubernetes](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/)
 * [Creating a cluster in GKE (Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster))
 
-### Step 2: Add Kubernetes Cluster Connector and Delegate in Harness
+## Step 2: Add Kubernetes Cluster Connector and Delegate in Harness
 
 * In your **Project**, click **Project Setup**.
 * Click **Connectors**.
@@ -116,23 +94,23 @@ To create a new Kubernetes cluster, see:
 
 Set up the Connector as follows.
 
-#### Connector Overview
+### Connector Overview
 
 * Enter a unique name for the Connector.
 
-#### Connector Details
+### Connector Details
 
 You can select Master URL and Credentials or Use the credentials of a specific Harness Delegate. 
 
 In this example, click Use the credentials of a specific Harness Delegate and click **Continue**.
 
-#### Delegate Setup
+### Delegate Setup
 
 You should now be in the Delegates Setup screen of the GitHub Connector wizard. Click **Install new Delegate**.
 
 ![](./static/set-up-a-kubernetes-cluster-build-infrastructure-01.png)
 
-#### Delegate Location
+### Delegate Location
 
 You can install the Delegate in different locations. Usually it makes sense to install and run the Delegate on a pod in your Kubernetes build infrastructure. You'll do this in the next steps.
 
@@ -140,7 +118,7 @@ You can install the Delegate in different locations. Usually it makes sense to i
 
 ![](./static/set-up-a-kubernetes-cluster-build-infrastructure-02.png)
 
-#### Delegate Details
+### Delegate Details
 
 Now you specify the Delegate name, size, and permissions.
 
@@ -152,7 +130,7 @@ Now you specify the Delegate name, size, and permissions.
 
 ![](./static/set-up-a-kubernetes-cluster-build-infrastructure-03.png)
 
-#### Delegate Install
+### Delegate Install
 
 Harness now generates and displays a workspace-definition YAML file that you can install in your build infrastructure.
 
@@ -175,7 +153,7 @@ statefulset.apps/ci-quickstart created
 service/delegate-service created
 ```
 
-#### Connect to the Delegate
+### Connect to the Delegate
 
 * Return to the Harness UI. It might take a few minutes to verify the Delegate. Once it is verified, close the wizard.
 * Back in **Delegates Setup**, you can select the new Delegate:
@@ -194,26 +172,26 @@ In Namespace, enter the Kubernetes namespace to use.
 
 You can use a Runtime Input (`<+input>`) or expression also. See [Runtime Inputs](../../../platform/20_References/runtime-inputs.md).
 
-### Option: Service Account Name
+## Option: Service Account Name
 
 The Kubernetes service account name. You must set this field in the following cases:
 
 * Your build infrastructure runs on EKS, you have an IAM role associated with the service account, and a CI step uses an AWS Connector with IRSA. See [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) in the AWS docs.
 * You have a CI Build stage with Steps that communicate with any external services using a service account other than default. See [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) in the Kubernetes docs.
 
-### Option: Run as User
+## Option: Run as User
 
 You can override the default Linux user ID for containers running in the build infrastructure. This is useful if your organization requires containers to run as a specific user with a specific set of permissions. See [Configure a security context for a Pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) in the Kubernetes docs. 
 
-### Option: Init Timeout
+## Option: Init Timeout
 
 If you use large images in your Build Steps, you might find that the initialization step times out and the build fails when the Pipeline runs. In this case, you can increase the default init time window (10 minutes). 
 
-### Option: Add Annotations
+## Option: Add Annotations
 
 You can add Kubernetes annotations to the pods in your infrastructure. An annotation can be small or large, structured or unstructured, and can include characters not permitted by labels. See [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) in the Kubernetes docs. 
 
-### Option: Add Labels
+## Option: Add Labels
 
 You can add Kubernetes labels (key-value pairs) to the pods in your infrastructure. Labels are useful for searching, organizing, and selecting objects with shared metadata. See [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) in the Kubernetes docs. 
 
@@ -235,7 +213,7 @@ Harness adds the following labels automatically:
 
 `https://app.harness.io/ng/#/account/myaccount/ci/orgs/myusername/projects/myproject/pipelines/mypipeline/executions/__PIPELINE_EXECUTION-ID__/pipeline`
 
-### Configure As Code
+## Configure As Code
 
 When configuring your Pipeline in YAML, you add the Kubernetes Cluster CI infrastructure using the infrastructure of type KubernetesDirect:
 
@@ -256,9 +234,3 @@ pipeline:
           ...
 ```
 Once the build infrastructure is set up, you can now add CI stages to execute your Run steps to build, deploy your code.
-
-### See Also
-
-* [Add a Kubernetes Cluster Connector](../../../platform/7_Connectors/add-a-kubernetes-cluster-connector.md)
-* [Kubernetes Cluster Connector Settings](../../../platform/7_Connectors/ref-cloud-providers/kubernetes-cluster-connector-settings-reference.md)
-

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
@@ -11,7 +11,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic describes how you can use Kubernetes cluster build infrastructure for a Harness CI pipeline stage. With Kubernetes build infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
+This topic describes how you can use Kubernetes cluster build infrastructure for a Harness CI pipeline stage.
 
 Once you set up the Kubernetes cluster to use as your build infrastructure, you connect Harness to it with a Harness [Kubernetes cluster connector](../../../platform/7_Connectors/add-a-kubernetes-cluster-connector.md) and Harness Delegate.
 
@@ -34,14 +34,14 @@ Consider the following CI stage:
 
 Assume that you configure your stage resources as follows:
 
-* redis (service dependency in Background step): 5GB, 2 cpu
-* s1 step: 2GB, 2 cpu
-* s2 step: 3GB, 1 cpu
-* s3 step: 4GB, 1 cpu
-* s4 step: 2GB, 1 cpu
-* s5 step: 2GB, 1 cpu
+* Redis (service dependency in Background step): 5GB, 2 CPU
+* s1 step: 2GB, 2 CPU
+* s2 step: 3GB, 1 CPU
+* s3 step: 4GB, 1 CPU
+* s4 step: 2GB, 1 CPU
+* s5 step: 2GB, 1 CPU
 
-Kubernetes would allocate the pod based on the maximum requirements for the overall stage. In this example, the peak requirement is when the s3, s4, and s5 steps run in parallel. The pod also needs to run the Redis service at the same time. The total maximum requirements are the sum of Redis + s3 + s4 + s5:
+Kubernetes would allocate a pod based on the maximum requirements for the overall stage. In this example, the peak requirement is when the s3, s4, and s5 steps run in parallel. The pod also needs to run the Redis service at the same time. The total maximum requirements are the sum of Redis + s3 + s4 + s5:
 
 * 5 + 4 + 2 + 2 = **13GB Memory**
 * 2 + 1 + 1 + 1 = **5 CPUs**

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
@@ -16,8 +16,6 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up a CI build infrastructure in Microsoft Azure. You will create a VM and install a CI Delegate and Drone Runner on it. The Delegate creates VMs dynamically in response to CI build requests.
 
-By running builds in your Azure build infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
-
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).
 
 The following diagram illustrates a build farm. The [​Harness Delegate](../../../../platform/2_Delegates/install-delegates/install-a-delegate.md) communicates directly with your Harness instance. The [VM Runner](https://docs.drone.io/runner/vm/overview/) maintains a pool of VMs for running builds. When the Delegate receives a build request, it forwards the request to the Runner, which runs the build on an available VM.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
@@ -16,7 +16,7 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up a CI build infrastructure in Microsoft Azure. You will create a VM and install a CI Delegate and Drone Runner on it. The Delegate creates VMs dynamically in response to CI build requests.
 
-Running builds in your infrastructure, rather than in a vendor's cloud, has significant benefits. Vendor clouds often experience outages that can result in backlogs and delayed builds. You can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
+By running builds in your Azure build infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
 
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
@@ -15,8 +15,6 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up a CI build infrastructure in Google Cloud Platform. You will create an Ubuntu VM and install a CI Delegate and Drone Runner on it. The Delegate creates VMs dynamically in response to CI build requests.
 
-By running builds in your GCP infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
-
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).
 
 The following diagram illustrates a build farm. The [​Harness Delegate](/docs/platform/2_Delegates/install-delegates/install-a-delegate.md) communicates directly with your Harness instance. The [VM Runner](https://docs.drone.io/runner/vm/overview/) maintains a pool of VMs for running builds. When the Delegate receives a build request, it forwards the request to the Runner, which runs the build on an available VM.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
@@ -15,7 +15,7 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up a CI build infrastructure in Google Cloud Platform. You will create an Ubuntu VM and install a CI Delegate and Drone Runner on it. The Delegate creates VMs dynamically in response to CI build requests.
 
-Running builds in your infrastructure, rather than in a vendor's cloud, has significant benefits. Vendor clouds often experience outages that can result in backlogs and delayed builds. You can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
+By running builds in your GCP infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
 
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
@@ -17,7 +17,7 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up and use AWS VMs as build infrastructures for running builds and tests in a CI Stage. You will create an Ubuntu VM and install a Delegate on it. This Delegate will create new VMs dynamically in response to CI build requests. You can also configure the Delegate to hibernate AWS Linux and Windows VMs when they aren't needed.
 
-Running builds in your infrastructure, rather than in a vendor's cloud, has significant benefits. Vendor clouds often experience outages that can result in backlogs and delayed builds. AWS has been battle-tested for large container workloads. You can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
+By running builds in your AWS VM infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
 
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).The following diagram illustrates an AWS build farm. The [Harness Delegate](/docs/platform/2_Delegates/install-delegates/install-a-delegate.md) communicates directly with your Harness instance. The [VM Runner](https://docs.drone.io/runner/vm/overview/) maintains a pool of VMs for running builds. When the Delegate receives a build request, it forwards the request to the Runner, which runs the build on an available VM.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
@@ -17,8 +17,6 @@ Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Conta
 
 This topic describes how to set up and use AWS VMs as build infrastructures for running builds and tests in a CI Stage. You will create an Ubuntu VM and install a Delegate on it. This Delegate will create new VMs dynamically in response to CI build requests. You can also configure the Delegate to hibernate AWS Linux and Windows VMs when they aren't needed.
 
-By running builds in your AWS VM infrastructure, you can build software and run tests, repeatedly and automatically, on a scalable platform with no outages or backlogs.
-
 For information on using Kubernetes as a build farm, see [Define Kubernetes Cluster Build Infrastructure](../set-up-a-kubernetes-cluster-build-infrastructure.md).The following diagram illustrates an AWS build farm. The [Harness Delegate](/docs/platform/2_Delegates/install-delegates/install-a-delegate.md) communicates directly with your Harness instance. The [VM Runner](https://docs.drone.io/runner/vm/overview/) maintains a pool of VMs for running builds. When the Delegate receives a build request, it forwards the request to the Runner, which runs the build on an available VM.
 
 ![](../static/set-up-an-aws-vm-build-infrastructure-12.png)


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* DOC-2599: Remove anti-hosted language.
* DOC-2499 (partial): Technical inaccuracy: DinD w/ Privileged mode is necessary for K8s infra only. Other infras don't need it because you can run Docker commands directly. Previously, the DinD topic said DinD wasn't **supported** for other infras - this is not true. It doesn't matter if it's supported, you don't need it.
* DOC-2499 (partial): Three changes to the "Define a Docker build infra" topic. 1) Renamed to "Use local runner build infrastructure"  because the previous name was misleading and unclear. 2) Clarified that local runner is best for small builds - use other infra for builds-at-scale. 3) Removed language implying local runner is the simplest infra to set up; it's not because Hosted is.
* DOC-2499 (partial): Define a K8s Cluster Build Infra - Revised "Limitations" section to "GKE Autopilot is not recommended". It wasn't a limitation and GKE Autopilot is supported, just discouraged.

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
