### PR TITLE
CDS-47304-default-delegate-proxy-support

### DIFF
--- a/docs/continuous-delivery/cd-technical-reference/cd-gen-ref-category/http-step.md
+++ b/docs/continuous-delivery/cd-technical-reference/cd-gen-ref-category/http-step.md
@@ -125,6 +125,10 @@ In **Advanced**, you can use the following options:
 * [Step Failure Strategy Settings](../../../platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
 * [Select Delegates with Selectors](/docs/platform/2_Delegates/manage-delegates/select-delegates-with-selectors.md)
 
+## Delegate proxy
+
+HTTP step supports delegate proxy settings by default. For more information, go to [Delegate Proxy Settings](../../../platform/2_Delegates/configure-delegates/configure-delegate-proxy-settings.md).
+
 ## Header capability check
 
 When Harness runs an HTTP step and connects to a service, it checks to make sure that an HTTP connection can be established.


### PR DESCRIPTION
Mentioned explicitly that NG supports delegate proxy settings support by default

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
