### PR TITLE
DOC-2588: Removes links to QA environment from ff proxy config

### DIFF
--- a/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
+++ b/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
@@ -198,7 +198,7 @@ baseURL:   https://config.ff.harness.io/api/1.0
 ```
 eventsURL: https://events.ff.harness.io/api/1.0
 ```
-But if you have a proxy running locally on localhost:7000 and it’s connected to Harness, then pass the following URLs to the SDK:
+But if you have the proxy running locally on localhost:7000 and it’s connected to Harness, then pass the following URLs to the SDK:
 
 
 ```

--- a/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
+++ b/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
@@ -186,19 +186,19 @@ The following are the required configuration variables to connect to the Feature
 
 ## Configure SDKs to Work With the Relay Proxy
 
-The SDKs do not require any additional configuration to work with the proxy. The only difference is that instead of supplying the Feature Flags URL when starting up an SDK, you should pass the proxy URL.
+The SDKs do not require any additional configuration to work with the proxy. The only difference is that instead of supplying the Feature Flags URL when starting up an SDK, you supply the proxy URL.
 
-For example, if you wanted your SDK to go via QA without the Proxy, you'd give it the following URLs:
+For example, if you wanted your SDK to work without the proxy, you'd give it the following URLs (if using the default URLs):
 
-
-```
-baseURL:   http://config.feature-flags.qa.harness.io/api/1.0
-```
 
 ```
-eventsURL: http://event.feature-flags.qa.harness.io/api/1.0
+baseURL:   http://config.ff.harness.io/
 ```
-But if you have a Proxy running locally on localhost:7000 and it’s connected to QA then pass the following URLs to the SDK:
+
+```
+eventsURL: http://event.ff.harness.io/
+```
+But if you have a proxy running locally on localhost:7000 and it’s connected to Harness, then pass the following URLs to the SDK:
 
 
 ```

--- a/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
+++ b/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy.md
@@ -73,7 +73,7 @@ bypass-auth
 ```
 client-service string
 ```
- The URL of the ff client service (default `https://config.ff.harness.io/`).
+ The URL of the ff client service (default `https://config.ff.harness.io/api/1.0`).
 
 
 ```
@@ -121,13 +121,13 @@ redis-password string
 ```
 sdk-base-url string
 ```
- URL for the SDK to connect to (default `https://config.ff.harness.io/`).
+ URL for the SDK to connect to (default `https://config.ff.harness.io/api/1.0`).
 
 
 ```
 sdk-events-url string
 ```
- URL for the SDK to send metrics to (default `https://events.ff.harness.io/`).
+ URL for the SDK to send metrics to (default `https://events.ff.harness.io/api/1.0`).
 
 
 ```
@@ -192,11 +192,11 @@ For example, if you wanted your SDK to work without the proxy, you'd give it the
 
 
 ```
-baseURL:   http://config.ff.harness.io/
+baseURL:   https://config.ff.harness.io/api/1.0
 ```
 
 ```
-eventsURL: http://event.ff.harness.io/
+eventsURL: https://events.ff.harness.io/api/1.0
 ```
 But if you have a proxy running locally on localhost:7000 and it’s connected to Harness, then pass the following URLs to the SDK:
 

--- a/docs/feature-flags/ff-using-flags/relay-proxy/relay-proxy.md
+++ b/docs/feature-flags/ff-using-flags/relay-proxy/relay-proxy.md
@@ -28,9 +28,9 @@ If you decide to use the Relay Proxy, make sure it has a good place in your netw
 
 The Proxy creates an instance of the Go SDK for each API key that’s passed to it as a part of the [Proxy Configuration](relay-proxy.md#configuration-variables), and each instance of the SDK uses the Cache implementation. The Go SDK then takes care of populating this cache on startup and keeping it up to current whenever the remote service changes. When the Go SDK starts up, it retrieves all of the Features and Segments and then sends a request to the remote server to listen for any updates. Whenever there is an update in the remote service, it sends out an event, and when the embedded SDK sees one of these events, it sends a request to the remote service to get the most recent flag values and save them to the cache.
 
-The Proxy can also use streaming functionality if it is configured with Redis. To view the variables that you need to configure for Redis, go to [Proxy Configuration](relay-proxy.md#configuration-variables) .
+The Proxy can also use streaming functionality if it is configured with Redis. To view the variables that you need to configure for Redis, go to [Proxy configuration variables](relay-proxy.md#configuration-variables) .
 
-### Configuration variables
+### Proxy Configuration variables
 
 The configuration variables used in the proxy are listed in the following table:
 
@@ -44,8 +44,8 @@ The configuration variables used in the proxy are listed in the following table:
 | ADMIN\_SERVICE | string | -admin-service | https://harness.io/gateway/cf | Used for creating the Client that interacts with the FeatureFlags Admin Service to retrieve Target and AuthConfig |
 | SERVICE\_TOKEN | string | -service-token | ZHNvdWZoNjczMjR0aGZiLWk1NC0tMGRzZg== | Token that the Proxy can use to authenticate with the Admin service |
 | AUTH\_SECRET | string | -auth-secret | somethingSecret | To authenticate the connection between your SDK and the Proxy, the Proxy generates an authentication token (JWT) that is signed with the AUTH\_SECRET you set in your configuration. When the Proxy receives the authentication token, it verifies that it is signed using the AUTH\_SECRET. If it isn’t, the token is rejected as invalid. |
-| SDK\_BASE\_URL | string | -sdkBaseUrl | https://config.feature-flags.harness.io/api/1.0 | The Base URL that the internal Go SDK connects to (the default is https://config.ff.harness.io/) |
-| SDK\_EVENTS\_URL | string | -sdkEventsUrl | https://events.feature-flags.harness.io/api/1.0 | The Event URL that the internal Go SDK connects to (the default is https://events.ff.harness.io/) |
+| SDK\_BASE\_URL | string | -sdkBaseUrl | https://config.ff.harness.io/api/1.0 (default)| The Base URL that the internal Go SDK connects to |
+| SDK\_EVENTS\_URL | string | -sdkEventsUrl | https://events.ff.harness.io/api/1.0 (default) | The Event URL that the internal Go SDK connects to |
 | API\_KEYS | string | -apiKey | 5ecb5049-e071-4beb-ae43-381aa8f0d3a2, a7cb7fc6-c4fa-4ecb-b01f-068456f3e500 | The API Keys of the environments you want to configure the Proxy to work with.For example, create an SDK key called Proxy Key in your Environment and pass it in via the `API_KEYS` env. Then all the other applications in that Environment would be able to use the Proxy. |
 | TARGET\_POLL\_DURATION | int | target-poll-duration | 30 | Time in seconds that determines how frequently the Proxy polls Feature Flags to get the latest Targets |
 | REDIS\_ADDRESS | string | redis-address | localhost:6379 | Configures the Proxy to use Redis rather than an in-memory cache.Configuring the Proxy with Redis also enables streaming |

--- a/docs/feature-flags/ff-using-flags/relay-proxy/relay-proxy.md
+++ b/docs/feature-flags/ff-using-flags/relay-proxy/relay-proxy.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-This topic describes what is Relay Proxy and how to use it with Harness Feature Flags (FF).
+This topic describes Relay Proxy and how to use it with Harness Feature Flags (FF).
 
 The Relay Proxy enables your apps to connect directly to Feature Flag services without having to make a significant number of outbound connections to FF services. The Relay Proxy establishes a connection to the Feature Flags configuration data and relays that connection to clients in an organization's network.
 
@@ -41,11 +41,11 @@ The configuration variables used in the proxy are listed in the following table:
 | **Environment Variable** | **Type** | **Flag** | **Example** | **Usage** |
 | ACCOUNT\_IDENTIFIER | string | -account-identifier | zAbbD-FLS425IEO7OLzXYz | The Account that you want the Proxy to pull down and load config for |
 | ORG\_IDENTIFIER | string | -org-identifier | featureflagsqa | The Organization that you want the Proxy to pull down and load config for |
-| ADMIN\_SERVICE | string | -admin-service | https://qa/harness.io/gateway/cf | Used for creating the Client that interacts with the FeatureFlags Admin Service to retrieve Target and AuthConfig |
+| ADMIN\_SERVICE | string | -admin-service | https://harness.io/gateway/cf | Used for creating the Client that interacts with the FeatureFlags Admin Service to retrieve Target and AuthConfig |
 | SERVICE\_TOKEN | string | -service-token | ZHNvdWZoNjczMjR0aGZiLWk1NC0tMGRzZg== | Token that the Proxy can use to authenticate with the Admin service |
 | AUTH\_SECRET | string | -auth-secret | somethingSecret | To authenticate the connection between your SDK and the Proxy, the Proxy generates an authentication token (JWT) that is signed with the AUTH\_SECRET you set in your configuration. When the Proxy receives the authentication token, it verifies that it is signed using the AUTH\_SECRET. If it isn’t, the token is rejected as invalid. |
-| SDK\_BASE\_URL | string | -sdkBaseUrl | https://config.feature-flags-qa.harness.io/api/1.0 | The Base URL that the internal Go SDK connects to |
-| SDK\_EVENTS\_URL | string | -sdkEventsUrl | https://event.feature-flags.qa.harness.io/api/1.0 | The Event URL that the internal Go SDK connects to |
+| SDK\_BASE\_URL | string | -sdkBaseUrl | https://config.feature-flags.harness.io/api/1.0 | The Base URL that the internal Go SDK connects to (the default is https://config.ff.harness.io/) |
+| SDK\_EVENTS\_URL | string | -sdkEventsUrl | https://events.feature-flags.harness.io/api/1.0 | The Event URL that the internal Go SDK connects to (the default is https://events.ff.harness.io/) |
 | API\_KEYS | string | -apiKey | 5ecb5049-e071-4beb-ae43-381aa8f0d3a2, a7cb7fc6-c4fa-4ecb-b01f-068456f3e500 | The API Keys of the environments you want to configure the Proxy to work with.For example, create an SDK key called Proxy Key in your Environment and pass it in via the `API_KEYS` env. Then all the other applications in that Environment would be able to use the Proxy. |
 | TARGET\_POLL\_DURATION | int | target-poll-duration | 30 | Time in seconds that determines how frequently the Proxy polls Feature Flags to get the latest Targets |
 | REDIS\_ADDRESS | string | redis-address | localhost:6379 | Configures the Proxy to use Redis rather than an in-memory cache.Configuring the Proxy with Redis also enables streaming |


### PR DESCRIPTION
These 2 pages were changed as requested in [DOC-2588](https://harness.atlassian.net/browse/DOC-2588):

1) On this page: /docs/feature-flags/ff-using-flags/relay-proxy/ 
In the proxy **configuration variables** table, made the **base** and **events** URLs match the defaults on page 2 below.

2) On this page: /docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy
Also changed the example in "Configure SDKs to Work With the Relay Proxy" to remove references to our QA environment.

[DOC-2588]: https://harness.atlassian.net/browse/DOC-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ