### PR TITLE
[DOC-2720] Fixed error in the probePollingInterval field

### DIFF
--- a/docs/chaos-engineering/technical-reference/probes/cmd-probe.md
+++ b/docs/chaos-engineering/technical-reference/probes/cmd-probe.md
@@ -278,7 +278,7 @@ Probe run properties for CMD Probe.
   <tr>
    <td>probePollingInterval
    </td>
-   <td>Flag to hold the polling interval for the probes(applicable for <code>Continuous</code> mode only)
+   <td>Flag to hold the polling interval for the probes (applicable for all modes)
    </td>
    <td>Optional
    </td>

--- a/docs/chaos-engineering/technical-reference/probes/http-probe.md
+++ b/docs/chaos-engineering/technical-reference/probes/http-probe.md
@@ -306,7 +306,7 @@ Probe run properties for HTTP Probe.
   <tr>
    <td>probePollingInterval
    </td>
-   <td>Flag to hold the polling interval for the probes(applicable for <code>Continuous</code> mode only)
+   <td>Flag to hold the polling interval for the probes (applicable for all modes)
    </td>
    <td>Optional
    </td>

--- a/docs/chaos-engineering/technical-reference/probes/k8s-probe.md
+++ b/docs/chaos-engineering/technical-reference/probes/k8s-probe.md
@@ -193,7 +193,7 @@ Probe run properties for K8s Probe.
   <tr>
    <td>probePollingInterval
    </td>
-   <td>Flag to hold the polling interval for the probes(applicable for <code>Continuous</code> mode only)
+   <td>Flag to hold the polling interval for the probes (applicable for all modes)
    </td>
    <td>Optional
    </td>

--- a/docs/chaos-engineering/technical-reference/probes/prom-probe.md
+++ b/docs/chaos-engineering/technical-reference/probes/prom-probe.md
@@ -235,7 +235,7 @@ Probe run properties for PROM Probe.
   <tr>
    <td>probePollingInterval
    </td>
-   <td>Flag to hold the polling interval for the probes(applicable for <code>Continuous</code> mode only)
+   <td>Flag to hold the polling interval for the probes (applicable for all modes)
    </td>
    <td>Optional
    </td>


### PR DESCRIPTION
probePollingInterval field applies to all modes, not just continuous
Signed-off-by: Smriti S <smriti.satyanarayana@harness.io>