### PR TITLE
Rename the FF to point to the correct FF

### DIFF
--- a/docs/platform/11_Triggers/triggering-pipelines.md
+++ b/docs/platform/11_Triggers/triggering-pipelines.md
@@ -117,7 +117,7 @@ Now all Github webhooks for this project must be authenticated. All Github trigg
 
 
 :::note
-Currently, this feature is behind the feature flag `GIT_WEBHOOK_POLLING`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.By default, Harness Git-based triggers listen to Git events using webhooks. 
+Currently, this feature is behind the feature flag `CD_GIT_WEBHOOK_POLLING`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.By default, Harness Git-based triggers listen to Git events using webhooks. 
 
 :::
 


### PR DESCRIPTION
GIT_WEBHOOK_POLLING has to be renamed to CD_GIT_WEBHOOK_POLLING . This has been marked with this change

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *FF Name has been renamed

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
