### PR TITLE
Updates version nums in sdk refs

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/flutter-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/flutter-sdk-reference.md
@@ -23,7 +23,7 @@ You should read and understand the following:
 
 ## Version
 
-The current version of this SDK is **1.0.8.**
+The current version of this SDK is **1.0.10.**
 
 ## Requirements
 

--- a/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
@@ -30,7 +30,7 @@ Make sure you read and understand:
 
 ## Version
 
-The current version of this SDK is **1.1.6.**
+The current version of this SDK is **1.1.7.**
 
 If you are using an older version of the .NET Framework, it may not default the security protocol to TLS 1.2. For compatibility with this SDK, set the protocol to TLS 1.2 by using the following:
 

--- a/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
@@ -23,7 +23,7 @@ You should read and understand the following:
 
 ## Version
 
-The current version of this SDK is **1.1.6.**
+The current version of this SDK is **1.1.9.**
 
 ## Requirements
 


### PR DESCRIPTION
Version numbers in some SDK reference topics were out of date compared to the release notes. This catches them up.
