### PR TITLE
[CI-7494] Add mount cert command and break into tabs

### DIFF
--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -8,7 +8,9 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-You can define a CI build infrastructure on any Linux or macOS host by installing a Harness Delegate and local runner. This is recommended for small, limited builds, such as a one-off build on your local machine. Consider [other build infrastructure options](/docs/category/set-up-build-infrastructure) for builds-at-scale.
+You can define a CI build infrastructure on a Linux, macOS, or Windows host by installing a Harness Delegate and local Drone Runner. When the pipeline runs, the Drone Runners runs the build actions in the environment where it is installed. The Delegate handles communication between Harness and the Drone Runner.
+
+Local runner build infrastructure is recommended for small, limited builds, such as a one-off build on your local machine. Consider [other build infrastructure options](/docs/category/set-up-build-infrastructure) for builds-at-scale.
 
 The Docker Delegate is limited by the total amount of memory and CPU on the local host. Builds can fail if the host runs out of CPU or memory when running multiple builds. The Docker Delegate has the following system requirements:
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -43,17 +43,17 @@ docker run --cpus=1 --memory=2g --net=host \
   -e MANAGER_HOST_AND_PORT=https://app.harness.io harness/delegate:23.02.78306
 ```
 
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+Make sure to create the Delegate at the appropriate scope, such as the project level or account level.
 
 ## Install the Drone Runner
 
 The Drone Runner service performs the build work. The Delegate needs the Runner to run CI builds.
 
 1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
-2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
-   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
+   export CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/ca-certificates.crt,[path/to/local/cert2]:/etc/ssl/certs/cacerts.pem"
    ```
 
 3. Enable execution permissions for the Runner. For example:
@@ -68,10 +68,10 @@ The Drone Runner service performs the build work. The Delegate needs the Runner 
    sudo ./drone-docker-runner-linux-arm64 server
    ```
 
-Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+Here is an example of the three commands to install the Linux arm64 Drone Runner with self-signed certificates:
 
 ```
-export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
+export CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/cacerts.pem"
 sudo chmod +x drone-docker-runner-linux-arm64
 ./drone-docker-runner-linux-arm64 server
 ```
@@ -101,17 +101,17 @@ docker run --cpus=1 --memory=2g \
   -e MANAGER_HOST_AND_PORT=https://app.harness.io harness/delegate:23.02.78306
 ```
 
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+Make sure to create the Delegate at the appropriate scope, such as the project level or account level.
 
 ## Install the Drone Runner
 
 The Drone Runner service performs the build work. The Delegate needs the Runner to run CI builds.
 
 1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
-2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
-   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
+   export CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/ca-certificates.crt,[path/to/local/cert2]:/etc/ssl/certs/cacerts.pem"
    ```
 
 3. Enable execution permissions for the Runner. For example:
@@ -128,10 +128,10 @@ The Drone Runner service performs the build work. The Delegate needs the Runner 
 
    You might have modify **Security and Privacy** settings to allow this app to run.
 
-Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+Here is an example of the three commands to install the Darwin amd64 Drone Runner with self-signed certificates:
 
 ```
-export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
+export CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/cacerts.pem"
 sudo chmod +x drone-docker-runner-darwin-arm64
 ./drone-docker-runner-darwin-arm64 server
 ```
@@ -140,14 +140,28 @@ sudo chmod +x drone-docker-runner-darwin-arm64
   </TabItem>
   <TabItem value="windows" label="Windows">
 ```
+
+## Prepare machines
+
+To configure a local runner build infrastructure for Windows, you need two machines:
+
+* A Windows machine where the Drone Runner will run.
+* A Linux machine where the Delegate will run.
+
 ## Install the Delegate
 
-Use the following modifications along with the **Docker environment** instructions in [Install a Delegate](/docs/platform/Delegates/install-delegates/install-a-delegate):
+On the Linux machine where you want to run the Delegate, use the following modifications along with the **Docker environment** instructions in [Install a Delegate](/docs/platform/Delegates/install-delegates/install-a-delegate):
 
 * Add `-e DELEGATE_TAGS="windows-amd64"`.
-* Add `-e RUNNER_URL=http://[windows_machine_hostname_or_ip]:3000`. The Drone Runner must run on a separate machine than the one that your Delegate runs on. The `RUNNER_URL` must point to the Drone Runner's machine.
+* Add `-e RUNNER_URL=http://[windows_machine_hostname_or_ip]:3000`.
 
-Here's an example of an install script for Windows:
+:::caution
+
+The `RUNNER_URL` must point to the Windows machine where the Drone Runner will run.
+
+:::
+
+Here's an example of the Delegate install script for a local runner Windows build infrastructure:
 
 ```
 docker run --cpus=1 --memory=2g \
@@ -161,7 +175,7 @@ docker run --cpus=1 --memory=2g \
   -e MANAGER_HOST_AND_PORT=https://app.harness.io harness/delegate:23.02.78306
 ```
 
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+Make sure to create the Delegate at the appropriate scope, such as the project level or account level.
 
 ## Install the Drone Runner
 
@@ -169,22 +183,16 @@ The Drone Runner service performs the build work. The Delegate needs the Runner 
 
 :::caution
 
-You must run the Drone Runner executable from a separate machine than the one that your Delegate is running on. Make sure to run these commands on the appropriate machine.
+Run the Drone Runner executable on the Windows machine that you specified in the Delegate's `RUNNER_URL`.
 
 :::
 
-1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
+1. On the target Windows machine where you want to run the Drone Runner, download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
 2. Open a terminal with Administrator privileges.
-2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+3. To use self-signed certificates, set `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
-   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
-   ```
-
-3. Run the following command to enable execution permissions for the Runner:
-
-   ```
-   chmod +x drone-docker-runner-windows-amd64
+   SET CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/ca-certificates.crt,[path/to/local/cert2]:/etc/ssl/certs/cacerts.pem"
    ```
 
 4. Run the following command to start the runner binary:
@@ -192,13 +200,11 @@ You must run the Drone Runner executable from a separate machine than the one th
    ```
    drone-docker-runner-windows-amd64.exe server
    ```
-   You must run the Drone Runner `.exe` from a separate machine than the one that your Delegate is running on. Make sure to run this command on the appropriate machine.
 
-Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+Here is an example of the two commands to install the Windows amd64 Drone Runner with self-signed certificates:
 
 ```
-export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
-chmod +x drone-docker-runner-windows-amd64
+SET CI_MOUNT_VOLUMES="[path/to/local/cert]:/etc/ssl/certs/cacerts.pem"
 ./drone-docker-runner-windows-amd64 server
 ```
 
@@ -209,7 +215,7 @@ chmod +x drone-docker-runner-windows-amd64
 
 ## Set the pipeline's build infrastructure
 
-Update the pipeline where you want to use the Docker delegate. You can use either the Visual or YAML pipeline editor.
+Update the pipeline where you want to use the Docker Delegate. You can use either the Visual or YAML pipeline editor.
 
 ```mdx-code-block
 import Tabs2 from '@theme/Tabs';
@@ -255,7 +261,7 @@ In the pipeline's `Build` (`type: CI`) stage, replace the `infrastructure` line 
 
 ## Troubleshooting
 
-The delegate should connect to your instance after you finish the installation workflow above. If the delegate does not connect after a few minutes, run the following commands to check the status:
+The Delegate should connect to your instance after you finish the installation workflow above. If the Delegate does not connect after a few minutes, run the following commands to check the status:
 
 ```
 docker ps

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -15,16 +15,22 @@ The Docker Delegate is limited by the total amount of memory and CPU on the loca
 * Default 0.5 CPU.
 * Default 1.5GB. Ensure that you provide the minimum memory for the Delegate and enough memory for the host/node system.
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+```mdx-code-block
+<Tabs>
+  <TabItem value="Linux" label="Linux" default>
+```
 ## Install the Delegate
 
 Use the following modifications along with the **Docker environment** instructions in [Install a Delegate](/docs/platform/Delegates/install-delegates/install-a-delegate):
 
-* Add `-e DELEGATE_TAGS="<delegate-tag>"`. Use one of the following tags: `macos-amd64`, `macos-arm64`, `windows-amd64`, `linux-amd64`, `linux-arm64`.
-* For macOS, add `-e RUNNER_URL=http://host.docker.internal:3000`.
-* For Linux, add `--net=host` to the first line.
-* For Windows, add `-e RUNNER_URL=http://<windows-machine-hostname-or-ip>:3000`. For Windows, the Drone Runner must run on a separate machine than the one that your Delegate runs on. This variable must point to the Drone Runner's machine.
+* Add `--net=host` to the first line.
+* Add `-e DELEGATE_TAGS="<delegate-tag>"`. Use one of the following tags: `linux-amd64` or `linux-arm64`.
 
-Here's an example of an install script for Linux:
+Here's an example of an install script for Linux amd64:
 
 ```
 docker run --cpus=1 --memory=2g --net=host \
@@ -44,29 +50,174 @@ Make sure to create the delegate at the appropriate scope, such as the project l
 The Drone Runner service performs the build work. The Delegate needs the Runner to run CI builds.
 
 1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
-2. Enable execution permissions for the Runner. For example, on macOS you can run the following command:
+2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+
+   ```
+   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
+   ```
+
+3. Enable execution permissions for the Runner. For example:
+
+   ```
+   sudo chmod +x drone-docker-runner-linux-arm64
+   ```
+
+4. Start the runner binary. For example:
+
+   ```
+   sudo ./drone-docker-runner-linux-arm64 server
+   ```
+
+Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+
+```
+export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
+sudo chmod +x drone-docker-runner-linux-arm64
+./drone-docker-runner-linux-arm64 server
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="macOS" label="macOS">
+```
+## Install the Delegate
+
+Use the following modifications along with the **Docker environment** instructions in [Install a Delegate](/docs/platform/Delegates/install-delegates/install-a-delegate):
+
+* Add `-e DELEGATE_TAGS="<delegate-tag>"`. Use one of the following tags: `macos-amd64` or `macos-arm64`.
+* Add `-e RUNNER_URL=http://host.docker.internal:3000`.
+
+Here's an example of an install script for macOS amd64:
+
+```
+docker run --cpus=1 --memory=2g \
+  -e DELEGATE_NAME=docker-delegate \
+  -e NEXT_GEN="true" \
+  -e DELEGATE_TYPE="DOCKER" \
+  -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
+  -e DELEGATE_TOKEN=ZWYzMjFmMzNlN2YxMTExNzNmNjk0NDAxOTBhZTUyYzU= \
+  -e DELEGATE_TAGS="macos-amd64" \
+  -e RUNNER_URL=http://host.docker.internal:3000 \
+  -e MANAGER_HOST_AND_PORT=https://app.harness.io harness/delegate:23.02.78306
+```
+
+Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+
+## Install the Drone Runner
+
+The Drone Runner service performs the build work. The Delegate needs the Runner to run CI builds.
+
+1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
+2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+
+   ```
+   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
+   ```
+
+3. Enable execution permissions for the Runner. For example:
 
    ```
    sudo chmod +x drone-docker-runner-darwin-amd64
    ```
 
-3. Start the runner binary according to the OS:
+4. To start the runner binary. For example:
 
-   * On macOS, run `./drone-docker-runner-darwin-amd64 server`. You might have modify **Security and Privacy** settings to allow this app to run.
-   * On Linux, run as `sudo`: `sudo ./drone-docker-runner-darwin-amd64 server`
-   * On Windows, run `drone-docker-runner-windows-amd64.exe server`. You must run the Drone Runner `.exe` from a separate machine than the one that your Delegate is running on. Make sure to run this command on the appropriate machine.
+   ```
+   ./drone-docker-runner-darwin-amd64 server
+   ```
+
+   You might have modify **Security and Privacy** settings to allow this app to run.
+
+Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+
+```
+export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
+sudo chmod +x drone-docker-runner-darwin-arm64
+./drone-docker-runner-darwin-arm64 server
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+```
+## Install the Delegate
+
+Use the following modifications along with the **Docker environment** instructions in [Install a Delegate](/docs/platform/Delegates/install-delegates/install-a-delegate):
+
+* Add `-e DELEGATE_TAGS="windows-amd64"`.
+* Add `-e RUNNER_URL=http://[windows_machine_hostname_or_ip]:3000`. The Drone Runner must run on a separate machine than the one that your Delegate runs on. The `RUNNER_URL` must point to the Drone Runner's machine.
+
+Here's an example of an install script for Windows:
+
+```
+docker run --cpus=1 --memory=2g \
+  -e DELEGATE_NAME=docker-delegate \
+  -e NEXT_GEN="true" \
+  -e DELEGATE_TYPE="DOCKER" \
+  -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
+  -e DELEGATE_TOKEN=ZWYzMjFmMzNlN2YxMTExNzNmNjk0NDAxOTBhZTUyYzU= \
+  -e DELEGATE_TAGS="windows-amd64" \
+  `-e RUNNER_URL=http://[windows_machine_hostname_or_ip]:3000` \
+  -e MANAGER_HOST_AND_PORT=https://app.harness.io harness/delegate:23.02.78306
+```
+
+Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+
+## Install the Drone Runner
+
+The Drone Runner service performs the build work. The Delegate needs the Runner to run CI builds.
+
+:::caution
+
+You must run the Drone Runner executable from a separate machine than the one that your Delegate is running on. Make sure to run these commands on the appropriate machine.
+
+:::
+
+1. Download a [Drone Runner executable](https://github.com/harness/drone-docker-runner/releases).
+2. Open a terminal with Administrator privileges.
+2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `source_path:destination_path`, for example:
+
+   ```
+   export CI_MOUNT_VOLUMES=[path_to_cert_on_local]:/etc/ssl/certs/ca-certificats.crt, [source_path_2]:[destination_path_2]
+   ```
+
+3. Run the following command to enable execution permissions for the Runner:
+
+   ```
+   chmod +x drone-docker-runner-windows-amd64
+   ```
+
+4. Run the following command to start the runner binary:
+
+   ```
+   drone-docker-runner-windows-amd64.exe server
+   ```
+   You must run the Drone Runner `.exe` from a separate machine than the one that your Delegate is running on. Make sure to run this command on the appropriate machine.
+
+Here is an example of all three commands to install the Drone Runner with self-signed certificates:
+
+```
+export CI_MOUNT_VOLUMES=<path-to-cert-on-local>:/etc/ssl/certs/ca-certificates.crt
+chmod +x drone-docker-runner-windows-amd64
+./drone-docker-runner-windows-amd64 server
+```
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```
 
 ## Set the pipeline's build infrastructure
 
 Update the pipeline where you want to use the Docker delegate. You can use either the Visual or YAML pipeline editor.
 
 ```mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs2 from '@theme/Tabs';
+import TabItem2 from '@theme/TabItem';
 ```
 ```mdx-code-block
-<Tabs>
-  <TabItem value="Visual" label="Visual" default>
+<Tabs2>
+  <TabItem2 value="Visual" label="Visual" default>
 ```
 
 1. In the pipeline's **Build** stage, select the **Infrastructure** tab.
@@ -75,8 +226,8 @@ import TabItem from '@theme/TabItem';
 4. Save your pipeline.
 
 ```mdx-code-block
-  </TabItem>
-  <TabItem value="YAML" label="YAML">
+  </TabItem2>
+  <TabItem2 value="YAML" label="YAML">
 ```
 
 In the pipeline's `Build` (`type: CI`) stage, replace the `infrastructure` line with specifications for `platform` and `runtime`, for example:
@@ -98,8 +249,8 @@ In the pipeline's `Build` (`type: CI`) stage, replace the `infrastructure` line 
   * `spec`: `{}`
 
 ```mdx-code-block
-  </TabItem>
-</Tabs>
+  </TabItem2>
+</Tabs2>
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Preview site menu path: Documentation > Continuous Integration > Use CI > Set Up Build Infrastructure > Set up a local runner build infrastructure

* Added step for self-signed certs command
* Created three tabs containing the separate Delegate and Drone Runner instructions for Linux, macOS, and Windows.

Menu cascade for preview site: Documentation > Continuous Integration > Use CI > Set up Build Infrastructure > Set up a local runner build infrastructure
https://642324e7534eae00a330676b--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure 
