### PR TITLE
Ffm4195 erlang tech changes

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
@@ -272,13 +272,21 @@ To close the SDK, run one of the following commands.
 * **For Erlang applications:**
 
   ```
+  %% Close the default instance
   cfclient:close().
+  
+  %% Close a named instance
+  cfclient:close(instance_name_1).
   ```
 
 * **For Elixir applications:**
 
   ```
+  # Close the default instance
   :cfclient:close()
+  
+  # Close a named instance
+  :cfclient:close(:instance_name_1)
   ```
 
 ## Additional Options

--- a/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
@@ -49,7 +49,7 @@ To install the SDK for Erlang based applications:
 1. Add the SDK as a dependency to your `rebar.config` file:
 
   ```
-  {deps, [{cfclient, {git, "https://github.com/harness/ff-erlang-server-sdk", {tag, "1.0.0"}}}]}.
+  {deps, [{cfclient, "1.0.0", {pkg, harness_ff_erlang_server_sdk}}]}.
   ```
 
 2. Add the dependency to your project's `app.src`.
@@ -69,7 +69,7 @@ To install the SDK for Elixir based applications:
   ```
     defp deps do
       [
-          {:cfclient, github: "harness/ff-erlang-server-sdk", tag: "1.0.0"}
+          {:cfclient, "~> 1.0.0", hex: :harness_ff_erlang_server_sdk}
       ]
   ```
 


### PR DESCRIPTION
# What
Updates installation steps to align with 1.0.0 release

Updates the code for closing the SDK to align with the 1.0.0 release