### PR TITLE
Update ci-build-image-updates.md

### DIFF
--- a/docs/continuous-integration/ci-technical-reference/ci-build-image-updates.md
+++ b/docs/continuous-integration/ci-technical-reference/ci-build-image-updates.md
@@ -32,7 +32,7 @@ Harness CI includes an `execution-config` API that enables you to update the ima
 1. Send a `get-default-config` request to get a list of the latest Harness CI build images and tags. You can use the `infra` parameter to get `k8` images or `VM` images.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'Authorization: Bearer $API_KEY'
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY'
    ```
 
    The response payload shows the latest supported images and their tags, for example:
@@ -62,7 +62,7 @@ Harness CI includes an `execution-config` API that enables you to update the ima
 2. Send a `get-customer-config` request to get the build images that your CI pipelines currently use. When `overridesOnly` is `true`, which is the default value, this endpoint returns the non-default images that your pipeline uses.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?accountIdentifier=$ACCOUNT_ID&infra=K8&overridesOnly=true" --header 'Authorization: Bearer $API_KEY'
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?accountIdentifier=$ACCOUNT_ID&infra=K8&overridesOnly=true" --header 'X-API-KEY: $API_KEY'
    ```
 
    If the response contains `null`, your pipeline is using all default images, for example:
@@ -79,7 +79,7 @@ Harness CI includes an `execution-config` API that enables you to update the ima
 3. Send an `update-config` (POST) request with a list of the images you want to update and the new tags to apply.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'Authorization: Bearer $API_KEY' --header 'Content-Type: application/json'
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY' --header 'Content-Type: application/json'
    --data-raw '[
        {
            "field": "gitCloneTag",
@@ -95,7 +95,7 @@ Harness CI includes an `execution-config` API that enables you to update the ima
 4. To reset one or more images to their defaults, send a`reset-config` (POST) request with a list of the images to reset.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'Authorization: Bearer $API_KEY' --header 'Content-Type: application/json'
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY' --header 'Content-Type: application/json'
    --data-raw '[
        {
            "field": "gitCloneTag"


### PR DESCRIPTION
Updated the Authorization Header details from the Bearer token to use the X-API-KEY header as it appears the Bearer Token is deprecated

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ X ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* Invalid Authentication model listed in the documentation.  The Bearer Token method appears to be deprecated at this time in favor of the standard X-API-KEY model

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ X ] Tested Locally
- [ ] *Optional* Screen Shoot. 
