### PR TITLE
FFM-7317: adds target expiry section

### DIFF
--- a/docs/feature-flags/ff-using-flags/ff-target-management/add-target-groups.md
+++ b/docs/feature-flags/ff-using-flags/ff-target-management/add-target-groups.md
@@ -16,69 +16,67 @@ import target_group_4 from './static/2-add-target-groups-09.png'
 import target_group_5 from './static/2-add-target-groups-10.png' 
 ```
 
-:::note
- While we refer to targeting users, when you create a Target you give it a name and a unique identifier, so a Target can be anything that can be uniquely identified. For example, a Target can be a user, an application, a system, a machine, or any resource uniquely identified by an IP address, email ID, user ID, etc.
+:::info note
+ While targets are often users, a target can be anything that can be uniquely identified. For example, a target can be a user, an application, a system, a machine, or any resource uniquely identified by an IP address, email ID, user ID, etc.
 :::
 
-Target Groups are a collection of [Targets](add-targets.md) that allow you to serve Feature Flag Variations to a list of users in bulk. You can group Targets into a group either by picking individual Targets or by defining rules that automatically map Targets to a Target Group. For example, you can add individual Targets `joe@harness.io` and `jane@harness.io` to the QA internal users group or you can define a rule that all the emails ending with `@harness.io` are added to the QA internal users group.
+Target groups are a collection of [targets](add-targets.md) that allow you to serve Feature Flag Variations to a list of users in bulk. You can group targets into a group either by picking individual targets or by defining rules that automatically map targets to a target group. For example, you can add individual targets `joe@harness.io` and `jane@harness.io` to the QA internal users group or you can define a rule that all the emails ending with `@harness.io` are added to the QA internal users group.
 
-You can also do the opposite and exclude specific Targets from a Target Group.  
+You can also do the opposite and exclude specific targets from a target group.  
 
-This topic describes how to add a Target Group to your Environment, add Targets to the group, and apply the Target Group to a Feature Flag. 
+This topic describes how to add a target group to your Environment, add targets to the group, and apply the target group to a Feature Flag. 
 
 ## Before you begin
 
-Make sure you've [created Targets to add to the Target Group](add-targets.md).
+Make sure you've [created targets to add to the target group](add-targets.md).
 
-## Create a Target Group and add Targets
+## Create a target group
 
-To create a Target Group:
+To create a target group:
 
 1. In **Feature Flags**, click **Target Management**, then click **Target Groups**.
 2. Click **+ New Target Group**.
 3. In **Create a Target Group**, enter a Name for your group and click **Create**.
 4. (Optional) In **Description**, add a description of the group.
 
-After you have created a Target Group, you need to add Targets to it. You can add Targets to a Target Group by selecting them individually or by setting conditions to add all Targets that meet those criteria. 
+After you have created a target group, you need to add targets to it. You can add targets to a target group by selecting them individually or by setting conditions to add all targets that meet those criteria. 
 
-### Add Targets from the Target Group page
+## Add targets from the Target Groups page
 
-You can add individual Targets from the Targets page or the Target Groups page. 
+You can add individual targets from the Targets page or the Target Groups page. 
 
-1. In **Target Management**, in **Target Groups**, select the Target Group you want to add Targets to.
+1. In **Target Management**, in **Target Groups**, select the target group you want to add targets to.
 
-![A screenshot of the Target Management page with a Target Group highlighted](./static/2-add-target-groups-05.png)*Figure 1: The Target Management page with the Target Groups tab selected*
+    ![A screenshot of the Target Management page with a target group highlighted](./static/2-add-target-groups-05.png)
 
-2. In **Criteria**, click **Edit**.
+1. In **Criteria**, click **Edit**.
 
-```mdx-code-block
-<img src={target_group_1} alt="The edit button next to Criteria." height="500" width="400" />
-```
-*Figure 2: Editing a Target Group*
+    ```mdx-code-block
+    <img src={target_group_1} alt="The edit button next to Criteria." height="500" width="400" />
+    ```
 
-You can include or exclude specific Targets, or you can set rules to add Targets based on conditions you set. 
+1. From here, you can [**include or exclude specific targets**](#add-or-exclude-specific-targets), or you can set rules to [**add targets based on conditions**](#add-targets-based-on-conditions) you set. 
 
-#### Add or exclude specific Targets
+### Include or exclude specific targets
 
-* To add specific Targets, in **Include the following**, select the Targets.
-* To exclude Targets, in **Exclude the following**, select the Targets.
+* To add specific targets, in **Include the following**, select the targets.
+* To exclude targets, in **Exclude the following**, select the targets.
 
-```mdx-code-block
-<img src={target_group_2} alt="A screenshot of Targets added to the Target Group Criteria." height="500" width="400" />
-```
-*Figure 3: Adding Targets to a Target Group*
+    ```mdx-code-block
+    <img src={target_group_2} alt="A screenshot of targets added to the Target Group Criteria." height="500" width="400" />
+    ```
 
-#### Add Targets based on conditions
+### Add targets based on conditions
 
-:::note 
-When you create a Target based on Conditions, on the Target overview page the Group isn't displayed under the **Target Groups** column.
+:::info note 
+When you create a target based on Conditions, on the target overview page the group isn't displayed under the **Target Groups** column.
 :::
 
 In addition to targeting individual users, Harness Feature Flags also allows you to target a group based on the conditions you set. You can add conditions by constructing rules using the following:
 
-* The name or identifier of the Target.
+* The name or identifier of the target.
 * An operator.
-* Text that must match the Target name or identifier.
+* Text that must match the target name or identifier.
 
 The following operators are supported:
 
@@ -94,46 +92,48 @@ The following operators are supported:
 
  
 
-For example, you could set a rule to add all Targets whose identifiers end in `@harness.io`. 
+For example, you could set a rule to add all targets whose identifiers end in `@harness.io`. 
 
-To add Targets based on conditions:
+To add targets based on conditions:
 
 1. In **Target Group Criteria**, click **+ Add Rule**.
 2. In the first drop-down menu, select whether the condition applies to the Target Name or Identifier.
 3. In the second drop-down menu, select the operator to apply to the Target Name or Identifier.
-4. In the search bar, enter the value you want the Target Name or Identifier to match and click the **+** button to add it. The following shows an example of a rule that adds all Targets with a Target Identifier ending in harness.io to the Target Group.
+4. In the search bar, enter the value you want the Target Name or Identifier to match and click the **+** button to add it. The following shows an example of a rule that adds all targets with a Target Identifier ending in harness.io to the target group.
 
-```mdx-code-block
-<img src={target_group_3} alt="An example of the Target Group Criteria page with a condition added." height="500" width="400" />
-```
+    ```mdx-code-block
+    <img src={target_group_3} alt="An example of the target group Criteria page with a condition added." height="500" width="400" />
+    ```
 
-*Figure 5: Adding Targets based on a condition*
+5. Click **Save**. Targets that meet the criteria are now included in the target group.
 
-5. Click **Save**. Targets that meet the criteria are now included in the Target Group.
+    ```mdx-code-block
+    <img src={target_group_4} alt="The Target Groups page with the new condition displayed." height="500" width="400" />
+    ```
 
-```mdx-code-block
-<img src={target_group_4} alt="The Target Group page with the new condition displayed." height="500" width="400" />
-```
-*Figure 6: Viewing the condition for adding a Target*
+When you add targets based on conditions, on the **Target Management:Targets** page, the target group is **not**displayed in the **Target Groups** column.
 
-When you add Targets based on conditions, on the **Target Management:Targets** page, the Target Group is **not** displayed in the **Target Groups** column.
+## Add or exclude targets from target settings
 
-### Add or exclude Targets from Target settings
+You can use Target Settings to include or exclude targets from a target group. Complete the following steps to include or exclude targets using the Target Settings:
 
-You can use Target Settings to include or exclude Targets from a Target Group. Complete the following steps to include or exclude Targets using the Target Settings:
+1. Go to **Target Management > Targets**, and then click the target you want to add to a group.
+2. Click **Target Groups**, and then select either or both of the following:
 
-1. In **Target Management**, in **Targets**, click the Target you want to add to a group.
-2. Click **Target Groups**, then **Add to Target Groups** to add a specific Target, or click **Exclude from Target Groups** to exclude a specific Target. You can add or exclude the Target to multiple groups at once.
+    * **Add to Target Groups** to add a this target to groups 
+    * **Exclude from Target Groups** to exclude a specific target 
 
-```mdx-code-block
-<img src={target_group_5} alt="A screenshot of a Target with the Target Groups tab opened." height="500" width="400" />
-```
-*Figure 7: Adding and excluding Targets from the Target's settings*
+        ```mdx-code-block
+        <img src={target_group_5} alt="A screenshot of a target with the Target Groups tab opened." height="500" width="400" />    
+        ```
 
-3. Select the Group(s) to add the Target to or to exclude a Target from, then click **Add to (1) Target Group**, or **Exclude from (1) Target Group**.
-4. The Targets are now added to the Target Group.
+    You can add or exclude the target to multiple groups at once.
+
+3. Select the group(s) to add or exclude a target to/from, then click **Add to Target Group**, or **Exclude from Target Group**.
+
+4. The targets are now added to, or excluded from, the target groups.
 
 ## Next step
 
-After you have added the Targets and Target Groups, you can then [use them on your Feature Flags.](targeting-users-with-flags.md)
+After you have added the targets and target groups, you can then [use them on your Feature Flags.](targeting-users-with-flags.md)
 

--- a/docs/feature-flags/ff-using-flags/ff-target-management/add-targets.md
+++ b/docs/feature-flags/ff-using-flags/ff-target-management/add-targets.md
@@ -13,25 +13,22 @@ import add_target_1 from './static/1-add-targets-00.png'
 import add_target_2 from './static/1-add-targets-01.png'
 ```
 
-Targets are used to control which users see which Variation of a Feature Flag, for example, if you want to do internal testing or a beta program before a broader roll out, you can enable the Flag for some users and not others. While we refer to targeting users, when you create a Target you give it a name and a unique identifier, so a Target can be anything that can be uniquely identified. For example, a Target can be a user, an application, a system, a machine, or any resource uniquely identified by an IP address, email ID, user ID, etc.
+Targets are used to control which users see which variation of a Feature Flag, for example, if you want to do internal testing or a beta program before a broader roll out, you can enable the flag for some users and not others. While we refer to targeting users, when you create a target you give it a name and a unique identifier, so a target can be anything that can be uniquely identified. For example, a target can be a user, an application, a system, a machine, or any resource uniquely identified by an IP address, email ID, user ID, etc.
 
-
-This topic describes how to add Targets to an Environment. After you’ve added the Target, you can add it to a [Target Group](add-target-groups.md) or to a [Feature Flag](targeting-users-with-flags.md 
-
-
-
-:::note
- You can add a Target using Harness UI. Alternatively, you can add a Target and define its attributes in your application's code directly [using a Feature Flag SDK](https://docs.harness.io/category/rtce97j1wu-ff-sdks). The Targets added in your code are discovered automatically and populated in the Harness UI.
+:::info note
+ You can add a target using Harness UI. Alternatively, you can add a target and define its attributes in your application's code directly [using a Feature Flag SDK](https://docs.harness.io/category/rtce97j1wu-ff-sdks). The targets added in your code are discovered automatically and populated in the Harness UI.
 :::
 
-
-### Regex requirements for Target names and identifiers
-
-
-A Target is identified by a name and an identifier. The name and identifier you enter must conform to the following regex:
+This topic describes how to add targets to an Environment in the Harness UI. After you’ve added the target, you can add it to a [Target Group](add-target-groups.md) or to a [Feature Flag](targeting-users-with-flags.md 
 
 
-##### **Name**
+## Regex requirements for target names and identifiers
+
+
+A target is identified by a name and an identifier. The name and identifier you enter must conform to the following regex:
+
+
+**Name**
 
 
 Regex: `[\\p{L}\\d .@_-]`
@@ -49,7 +46,7 @@ Must consist of only alphabetical characters, numbers, and the following symbols
 The characters can be lowercase or uppercase and can include accented letters, for example `Café_123`.
 
 
-##### **Identifier**
+**Identifier**
 
 
 Regex: `[A-Za-z0-9.@_-]`
@@ -69,34 +66,31 @@ The characters can be lowercase or uppercase but cannot include accented letters
 For more information, go to [Entity Identifier Reference](/docs/platform/references/entity-identifier-reference).
 
 
-### Add a Target
+## Add a target
 
 
-A Target is identified by a name and an identifier. Make sure your Target names and identifiers conform to the regex explained in [Review Regex Requirements for Target Names and Identifiers](add-targets.md#review-regex-requirements-for-target-names-and-identifiers).
-To add a Target:
+A target is identified by a name and an identifier. Make sure your target names and identifiers conform to the regex explained in [Review Regex Requirements for target Names and Identifiers](add-targets.md#review-regex-requirements-for-target-names-and-identifiers).
+To add a target:
 
 
 1. In **Feature Flags**, in **Target Management**, select **Targets**.
 2. Click **+ Target**.
 3. In **Add Target(s)**, select **Add a Target**.
-4. In **Name**, enter the name that will appear in the Target Management page so you can identify this Target.
-5. In **Identifier**, enter a unique identifier for your Target. When [Targeting Users with Flags](targeting-users-with-flags.md) or [Managing Target Groups](add-target-groups.md), the Targets are identified by the identifier you give them.
-6. You can add multiple Targets. Click **+** to add more Targets.
+4. In **Name**, enter the name that will appear in the Target Management page so you can identify this target.
+5. In **Identifier**, enter a unique identifier for your target. When [Targeting Users with Flags](targeting-users-with-flags.md) or [Managing Target Groups](add-target-groups.md), the targets are identified by the identifier you give them.
+6. You can add multiple targets. Click **+** to add more targets.
 
-```mdx-code-block
-<img src={add_target_1} alt="Adding Targets" height="500" width="500" />
-```
+    ```mdx-code-block
+    <img src={add_target_1} alt="Adding Targets" height="500" width="500" />    
+    ```
 
-*Figure 1: Adding Targets*
-
-
-7. When you’ve added all the Targets, Click **Add**.
+7. When you’ve added all the targets, Click **Add**.
 
 
-### Upload a List of Targets
+## Upload a list of targets
 
 
-This option allows you to import a list of Targets in CSV format. To do this:
+This option allows you to import a list of targets in CSV format. To do this:
 
 
 1. In **Feature Flags**, in **Target Management**, select **Targets**.
@@ -104,38 +98,39 @@ This option allows you to import a list of Targets in CSV format. To do this:
 3. In **Add Target(s)**, select **Upload a list of Targets**.
 4. Upload your CSV file as per the template below. The CSV file must have only the Name and Identifier; do not include any headings, for example:
 
-
-
-
-| | | 
-| --- | --- |
-| Target\_4 | T4 |
-| Target\_5 | T5 |
-| Target\_6 | T6 |
-
+    | | | 
+    | --- | --- |
+    | Target\_4 | T4 |
+    | Target\_5 | T5 |
+    | Target\_6 | T6 |
 
 5. Click **Add**.
 
-```mdx-code-block
-<img src={add_target_1} alt="A screenshot of the Add Target screen that highlights the radio button for uploading a list of Targets." height="500" width="500" />
-``` 
-*Figure 2: Adding Targets from a CSV file*
+    ```mdx-code-block
+    <img src={add_target_1} alt="A screenshot of the Add Target screen that highlights the radio button for uploading a list of Targets." height="500" width="500" />
+    ``` 
 
+6. The list of targets is added.
 
-6. The list of Targets is added.
+    ![A screenshot of the Target Management page with a list of all the targets.](./static/1-add-targets-02.png)
 
+## How targets expire
 
-![A screenshot of the Target Management page with a list of all the Targets.](./static/1-add-targets-02.png)
-*Figure 3: The list of Targets added to the Harness Platform*
+Targets are automatically created when an SDK authenticates or pushes metric data to the Feature Flag Service.  A target is updated when it's modified via the API, or is used by an SDK in a request. 
 
+Going forward, all targets that are not updated in 60 days expire, and are removed from the data store, unless either of the following is true:
 
-### Next steps
+* The target is named in an explicit target rule in a flag.
 
+* The target is named in a group's included/excluded list.
 
-After your have created a Target, you can:
+If an SDK makes a new request with a previously expired target, that target is inserted into the database again.
 
+## Next steps
 
-* [Add them to Target Groups](add-target-groups.md)
+After your have created a target, you can:
+
+* [Add or Exclude a Target in a Target Group](add-target-groups.md)
 * [Target Users with Flags](targeting-users-with-flags.md)
 
 

--- a/docs/feature-flags/ff-using-flags/ff-target-management/targeting-users-with-flags.md
+++ b/docs/feature-flags/ff-using-flags/ff-target-management/targeting-users-with-flags.md
@@ -13,27 +13,27 @@ import target_users_1 from './static/3-targeting-users-with-flags-03.png'
 import target_users_2 from './static/3-targeting-users-with-flags-04.png' 
 ```
 
-Feature Flag Targeting allows you to serve a particular Variation of a Flag to specific Target when the Flag is enabled. Targets are anything that can be uniquely identified, we refer to these Targets as users, but they could also be apps, machines, resources, emails etc. 
+Feature Flag targeting allows you to serve a particular Variation of a flag to specific target when the flag is enabled. Targets are anything that can be uniquely identified, we refer to these Targets as users, but they could also be apps, machines, resources, emails etc. 
 
 For example:
 
 1. You have a new feature you want your QA team to test before a general roll-out.
 2. You create a Boolean Feature Flag for the new feature.
-3. You add Targeting to the Flag so that the QA team are served the True Variation when the Flag is enabled, and the Non-QA team are served the False Variation.
+3. You add Targeting to the flag so that the QA team are served the True Variation when the flag is enabled, and the Non-QA team are served the False Variation.
 4. You enable the Feature Flag.
 5. The feature is available to the QA team but is not available to the Non-QA team.
 
-:::note
- A Flag can have values in each Environment. For example, if you have a QA Environment and a Production Environment within a single Project on the Harness Platform, the Flag could be toggled ON in QA but toggled OFF in Production. 
+:::info note
+ A flag can have values in each Environment. For example, if you have a QA Environment and a Production Environment within a single Project on the Harness Platform, the flag could be toggled ON in QA but toggled OFF in Production. 
 :::
 
 This topic describes how to set up Targeting for a Feature Flag you’ve created. 
 
-:::note
+:::info note
  To edit the default Variations that are served to Targets, go to [Changing the Variations of Your Flags](../update-feature-flags/manage-variations.md).
 :::
 
-## Important things to consider
+## How Harness prioritizes targets and target groups
 
 You should understand how the Harness Platform prioritizes targets and target groups during evaluations, so that you know which variation of a flag you can expect. The prioritization rules are as follows: 
 
@@ -46,47 +46,39 @@ You should understand how the Harness Platform prioritizes targets and target gr
    - You added `Target_1` to `Group_A`, then `Group_B`, then `Group_C`.
    - You create a rule that enables a flag for all targets in `Group_C`, but disables that same flag for `Group_A`. 
    - As the target group prioritization of `Group_A` is `0`, and the target group prioritization of `Group_C` is `2`, the flag is disabled for `Target_1`. This is because the lower-numbered target group priority, `0`, takes precedence. 
-   
-:::note
+
+:::info note
 If you have Git Experience set up with Feature Flags, you can manually edit the `priority` field of a flag via your YAML file. For more information about this, go to [Manage Your Flags Using Git Experience](../manage-featureflags-in-git-repos.md).
 :::
 
-## Target specific users or Target Groups when a Flag is enabled
+## Target specific users or target groups when a flag is enabled
 
-To target specific users, you first need to add them as a Target or Target Group on the Harness platform. To do this, go to [Adding Targets](add-targets.md) and [Managing Target Groups](add-target-groups.md). 
+To target specific users, you first need to add them as a target or target group on the Harness platform. To do this, go to [Adding Targets](add-targets.md) and [Managing Target Groups](add-target-groups.md). 
 
-After you have added the Target or Target Group, you can then choose the Variation to serve them when the Feature Flag is Enabled:
+After you have added the target or target group, you can then choose the Variation to serve them when the Feature Flag is Enabled:
 
 * **True**: The Targets are served the default True variation.
 * **False**: The Targets are served the default False variation.
-* **Percentage rollout**: You select a percentage of Targets to be served each Variation. For example, to increment how many users a feature is available for over time, you could use a percentage roll out to give 10% of users access to a feature, then 50%, then 100%. The users are selected randomly from the Target Group you target, and when you increase the percentage, all original users maintain their access to the feature. We can only ensure that identifiable Targets maintain their access, we can't maintain access for anonymous users.
+* **Percentage rollout**: You select a percentage of Targets to be served each Variation. For example, to increment how many users a feature is available for over time, you could use a percentage roll out to give 10% of users access to a feature, then 50%, then 100%. The users are selected randomly from the target group you target, and when you increase the percentage, all original users maintain their access to the feature. We can only ensure that identifiable Targets maintain their access, we can't maintain access for anonymous users.
 
 To add specific Targets: 
 
 1. Go to the Feature Flag you want to add Targets for and in the **Targeting** tab, under **Specific Targeting**, click **+ Add Targeting**.
 2. Select which Variation you want to serve to the Target.
 
-If you select one of the default Variations, for example, True or False:
+   * If you select one of the default Variations, for example, True or False, select the Target(s) or target group(s), then Click **Save**.
 
-* Select the Target(s) or Target Group(s), then Click **Save**.
+      ```mdx-code-block
+      <img src={target_users_1} alt="The Targeting Tab of a Flag with the dropdown menus for adding a target highlighted." height="500" width="500" />
+      ```
 
-```mdx-code-block
-<img src={target_users_1} alt="The Targeting Tab of a Flag with the dropdown menus for adding a Target highlighted." height="500" width="500" />
-```
+   * If you want to use a Percentage Rollout, select the target group, enter the percentage of each Variation you want to serve, then click **Save**.
 
-*Figure 1: Adding Targets and Target Groups to serve a Variation to*
+      ```mdx-code-block
+      <img src={target_users_2} alt="The Targeting Tab of a Flag with percentage roll out applied." height="500" width="500" /><br /><br />
+      ```
 
-If you want to use a Percentage Rollout:
-
-1. Select the Target Group.
-
-You can only use Percentage Rollouts on a single Target Group for each Flag. 
-
-2. Enter the percentage of each Variation you want to serve, then click **Save**.
-
-```mdx-code-block
-<img src={target_users_2} alt="The Targeting Tab of a Flag with percentage roll out applied." height="500" width="500" />
-```
-
-*Figure 2: Using a percentage rollout for the Target Group*
+   :::info note
+   You can only use Percentage Rollouts on a single target group for each flag.
+   :::
 


### PR DESCRIPTION
The only addition is the small section **How targets expire**, lines 117 - 127 in **add-targets.md**. 
[**Link to section in preview**](https://642432fb29d9280618c7dc31--harness-developer.netlify.app/docs/feature-flags/ff-using-flags/ff-target-management/add-targets#how-targets-expire).

The rest is just some opportunistic cleanup for style/clarity.