### PR TITLE
SPG-2501 clarify multiple paths for Report Paths

### DIFF
--- a/docs/continuous-integration/ci-technical-reference/background-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/background-step-settings.md
@@ -76,9 +76,9 @@ Select this option to run the container with escalated privileges. This is the e
 
 ### Report Paths
 
-The path to the file(s) that store results in JUnit XML format. You can add multiple paths. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+The path to the file(s) that store results in JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
-This setting is required for the Background step to be able to publish test results.
+This setting is required for commands run in the Background step to be able to publish test results.
 
 ### Environment Variables
 

--- a/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/configure-run-tests-step-settings.md
@@ -59,9 +59,9 @@ Enter the arguments for the build tool. These are used as input for the chosen b
 
 ## Report Paths
 
-This field is required for the Run Tests step to publish test results.
+The path to the file(s) that store test results in the JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
-Specify one or more paths to test report files. You can specify multiple paths, and [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported. Test reports must be in JUnit XML format.
+This field is required for the Run Tests step to publish test results.
 
 ## Additional Configuration
 

--- a/docs/continuous-integration/ci-technical-reference/run-step-settings.md
+++ b/docs/continuous-integration/ci-technical-reference/run-step-settings.md
@@ -79,7 +79,7 @@ Enable this option to run the container with escalated privileges. This is equiv
 
 ### Report Paths
 
-The path to the file(s) that store test results in the JUnit XML format. You can add multiple paths. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+The path to the file(s) that store test results in the JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
 This setting is required for the Run step to be able to publish test results.
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
@@ -12,7 +12,13 @@ Your pipelines can run tests in **Run** and **Run Tests** steps.
 
 To publish test results, set the **Report Paths** setting in the relevant [Run](../../ci-technical-reference/run-step-settings.md) or [Run Tests](../../ci-technical-reference/configure-run-tests-step-settings.md) step.
 
-If the test reports are in JUnit XML format, you can review test reports on the **Tests** tab on the [Build details page](../view-your-builds/viewing-builds.md). Test reports must be in JUnit XML format to appear on the **Tests** tab. Harness parses test reports that are in JUnit XML format only.
+If the test reports are in JUnit XML format, you can review test reports on the **Tests** tab on the [Build details page](../view-your-builds/viewing-builds.md).
+
+:::info
+
+Test reports must be in JUnit XML format to appear on the **Tests** tab. Harness parses test reports that are in JUnit XML format only.
+
+:::
 
 ![](./static/viewing-tests-533.png)
 


### PR DESCRIPTION
SPG-2501 - If there are multiple paths in Report Paths, make sure they are unique to avoid duplicate results/tests.
