### PR TITLE
feat: embed auto-generated card list to docs landing pages [HDH-110]

### DIFF
--- a/docs/feature-flags.mdx
+++ b/docs/feature-flags.mdx
@@ -1,0 +1,14 @@
+---
+hide_table_of_contents: true
+hide_title: true
+title: Feature Flags
+# id: feature-flags
+---
+
+<!-- # Feature Flags -->
+
+<!-- Custom component -->
+
+import FeatureFlags from "@site/src/components/Docs/FeatureFlags";
+
+<FeatureFlags />

--- a/sidebars.js
+++ b/sidebars.js
@@ -80,12 +80,12 @@ const sidebars = {
           type: "category",
           label: "Feature Flags",
           link: {
-            type: "generated-index",
-            slug: "/feature-flags",
-            /* Uncomment this block while we have a landing page for module docs
+            /* type: "generated-index",
+            slug: "/feature-flags", */
+            /* Uncomment this block while we have a landing page for module docs */
             type: "doc",
             id: "feature-flags",
-            */
+            /**/
           },
           collapsed: true,
           items: [

--- a/src/components/Docs/FeatureFlags.tsx
+++ b/src/components/Docs/FeatureFlags.tsx
@@ -1,33 +1,46 @@
-import React from "react";
+import React, { useContext } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Link from "@docusaurus/Link";
 import clsx from "clsx";
+import DocCardList from "@theme/DocCardList";
+import { useCurrentSidebarCategory } from "@docusaurus/theme-common";
 import styles from "./styles.module.scss";
-import TutorialCard, {
-  TutorialCards,
-} from "@site/src/components/LandingPage/TutorialCard";
+import TutorialCard, { TutorialCards } from "../LandingPage/TutorialCard";
 // Define the cards in "***Data.ts"
-import { featuredTutorials, docsCards } from "./data/continuousDeliveryData";
+import { featuredTutorials } from "./data/featureFlagsData";
 
-export default function CD() {
+export default function FF() {
   const { siteConfig: { baseUrl = "/" } = {} } = useDocusaurusContext();
+  // console.log("...category > useCurrentSidebarCategory...", {
+  //   useCurrentSidebarCategory,
+  //   props,
+  //   docusaurusContext: useDocusaurusContext(),
+  // });
+  const category = useCurrentSidebarCategory();
+  // const sidebar = useDocsSidebar();
+  console.log("...category...", {
+    useCurrentSidebarCategory,
+    // useDocsSidebar,
+    // sidebar,
+    category,
+  });
   return (
     <div className="container">
       <div className={styles.topSection}>
         <div className={styles.spaceBetween}>
           <div className={styles.moduleTitle}>
-            <img src={`${baseUrl}img/icon_cd.svg`} />
-            <h1>Continuous Delivery & GitOps Docs</h1>
+            <img src={`${baseUrl}img/icon_ff.svg`} />
+            <h1>Feature Flags</h1>
           </div>
           <div className={styles.btnContainer}>
-            <Link href="/tutorials/deploy-services">
+            <Link href="/tutorials/manage-feature-flags">
               <button className={styles.btn}>
                 {/* <i className="fa-regular fa-file"></i> */}
                 <img src={`${baseUrl}img/icon_tutorials.svg`} />
                 Tutorials
               </button>
             </Link>
-            <Link href="/release-notes/continuous-delivery">
+            <Link href="/release-notes/feature-flags">
               <button className={styles.btn}>
                 {/* <i className="fa-regular fa-file"></i> */}
                 <img src={`${baseUrl}img/icon_release_notes.svg`} />
@@ -39,15 +52,19 @@ export default function CD() {
         <div className={styles.spaceBetween}>
           <div className={styles.content}>
             <p>
-              Continuous Delivery focuses on delivery and deployment of any sort
-              of change or new feature in a safe and sustainable way. Your
-              Continuous Delivery Pipeline focuses on all of the steps to get
-              your changes into production.
+              Harness Feature Flags (FF) is a feature management solution that
+              lets you change your software's functionality without deploying
+              new code. It does this by allowing you to hide code or behavior
+              without having to ship new versions of the software. A feature
+              flag is like a powerful if statement.
             </p>
           </div>
         </div>
       </div>
-      <TutorialCards data={docsCards} sectionClass={styles.subSection} />
+      {/* <TutorialCards data={docsCards} sectionClass={styles.subSection} /> */}
+      <article className="margin-top--lg">
+        <DocCardList items={category.items} />
+      </article>
       <div className={styles.sectionDivider}></div>
       <div className={styles.subSection}>
         <h3>Featured Tutorials</h3>

--- a/src/components/Docs/data/continuousDeliveryData.ts
+++ b/src/components/Docs/data/continuousDeliveryData.ts
@@ -1,9 +1,10 @@
+// import React from "react";
 import {
   CardItem,
   CardSections,
   docType,
-} from "../../LandingPage/TutorialCard";
-import { MODULES } from "../../../constants"
+} from "@site/src/components/LandingPage/TutorialCard";
+import { MODULES } from "@site/src/constants"
 
 /* Define the cards - start */
 // Featured Tutorials

--- a/src/components/Docs/data/featureFlagsData.ts
+++ b/src/components/Docs/data/featureFlagsData.ts
@@ -1,0 +1,21 @@
+import {
+  CardItem,
+  docType,
+} from "@site/src/components/LandingPage/TutorialCard";
+import { MODULES } from "@site/src/constants"
+
+/* Define the cards - start */
+// Featured Tutorials
+export const featuredTutorials: CardItem[] = [
+    {
+      title: "Add feature flags to JavaScript app",
+      module: MODULES.ff,
+      icon: "img/icon_ff.svg",
+      description: "It takes two things to build software; teamwork and iteration.",
+      newDoc: true,
+      type: [docType.Documentation],
+      time: "8min",
+      link: "/tutorials/manage-feature-flags/typescript-react-first-feature-flag",
+    },
+  ];
+  /* Define the cards - end */

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -79,6 +79,7 @@ function CardCategory({
     return null;
   }
 
+  const customPropsDesc = item.customProps && item.customProps.description;
   return (
     <CardLayout
       href={href}
@@ -86,7 +87,9 @@ function CardCategory({
       title={item.label}
       description={translate(
         {
-          message: "{count} items",
+          message: customPropsDesc
+            ? `${customPropsDesc} ({count} items)`
+            : "{count} items",
           id: "theme.docs.DocCard.categoryDescription",
           description:
             "The default description for a category card in the generated index about how many items this category includes",

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -20,6 +20,7 @@
 }
 .cardContainer h2 {
   font-size: var(--ifm-h4-font-size);
+  color: var(--primary);
 }
 
 .cardContainer:hover {


### PR DESCRIPTION
used Feature Flags Docs landing page as a sample

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [x] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [x] *Optional* Screen Shoot. 
<img width="1543" alt="Screen Shot 2023-04-13 at 3 12 46 PM" src="https://user-images.githubusercontent.com/75070418/231788384-502c4080-0a39-42f5-aca8-9355f4e5f157.png">
<img width="682" alt="Screen Shot 2023-04-13 at 3 12 16 PM" src="https://user-images.githubusercontent.com/75070418/231788416-3ff74dfa-9bf3-4b6a-81ad-7ee850b04093.png">

