### PR TITLE
Updated the landing page

### DIFF
--- a/src/components/Docs/CloudCostManagement.tsx
+++ b/src/components/Docs/CloudCostManagement.tsx
@@ -15,7 +15,7 @@ export default function CCM() {
         <div className={styles.spaceBetween}>
           <div className={styles.moduleTitle}>
             <img src={`${baseUrl}img/icon_ccm.svg`} />
-            <h1>Cloud Cost Management</h1>
+            <h1>Cloud Cost Management Documentation</h1>
           </div>
           <div className={styles.btnContainer}>
             <Link href="/tutorials/cloud-costs">

--- a/src/components/Docs/data/cloudCostManagementData.ts
+++ b/src/components/Docs/data/cloudCostManagementData.ts
@@ -24,12 +24,19 @@ import {
     // Docs
     export const docsCards: CardSections = [
       {
-        name: "Documentation topics",
+        name: "Get started with Cloud Cost Management",
         description:
           "",
         list: [
           {
-            title: "Get started with Cloud Cost Management",
+            title: "CCM Tutorials",
+            module: MODULES.ccm,
+            description:
+              "Learn how to manage and optimize the costs associated with your cloud resources.",
+            link: "/tutorials/cloud-costs",
+          },
+          {
+            title: "Get started",
             module: MODULES.ccm,
             description:
               "Learn the basic concepts of Harness Cloud Cost Management and how to set up CCM for your cloud accounts.",


### PR DESCRIPTION
- Changed the title from Cloud Cost Management to Cloud Cost Management Documentation
- Changed the heading "Documentation topics" to "Get started" - I know Sid told a few people that he didn't want us to use Get started in the module docs, but he has come around on that.
- Under "Get started" - added a tile for tutorials. 