### PR TITLE
[DOC-2956] CI tutorial - Node

### DIFF
--- a/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
@@ -188,6 +188,18 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 </details>
 
+#### Stage setting: Shared paths
+
+Pipeline steps within a stage share the same [workspace](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#workspace). You can optionally [share paths](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages#share-data-between-steps-in-a-stage) outside the workspace between steps in your stage by setting `spec.sharedPaths`.
+
+```yaml
+  stages:
+    - stage:
+        spec:
+          sharedPaths:
+            - /example/path # directory outside workspace to share between steps
+```
+
 ### Restore Cache from GCS step settings
 
 <details>
@@ -285,7 +297,7 @@ The cache key and paths differ by language.
 <TabItem value="Node.js">
 ```
 
-[Npm](https://www.npmjs.com/) pipelines must reference `package-lock.json` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
+[npm](https://www.npmjs.com/) pipelines must reference `package-lock.json` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
 
 ```yaml
                   spec:

--- a/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
@@ -115,6 +115,223 @@ Here is an example of the YAML for a **Restore Cache from GCS** step.
 </Tabs>
 ```
 
+### Save Cache to GCS step settings
+
+<details>
+<summary>Save Cache to GCS step settings</summary>
+
+:::info
+
+Depending on the stage's build infrastructure, some settings may be unavailable or located under **Optional Configuration** in the visual pipeline editor. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
+
+:::
+
+#### Name
+
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+
+#### GCP Connector
+
+The Harness connector for the GCP account where you want to save the cache. For more information, go to [Google Cloud Platform (GCP) connector settings reference](/docs/platform/Connectors/Cloud-providers/ref-cloud-providers/gcs-connector-settings-reference).
+
+This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
+
+#### Bucket
+
+The GCS destination bucket name.
+
+#### Key
+
+The key to identify the cache.
+
+You can use the checksum macro to create a key based on a file's checksum, for example: `myApp-{{ checksum filePath1 }}`
+
+With this macro, Harness checks if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
+
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead.
+
+* Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
+* Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
+
+#### Source Paths
+
+A list of the files/folders to cache. Add each file/folder separately.
+
+#### Archive Format
+
+Select the archive format. The default archive format is Tar.
+
+#### Override Cache
+
+Select this option if you want to override the cache if a cache with a matching **Key** already exists.
+
+By default, the **Override Cache** option is set to false (unselected).
+
+#### Run as User
+
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+
+#### Set Container Resources
+
+Maximum resources limits for the resources used by the container at runtime:
+
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+
+#### Timeout
+
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
+
+* [Step Skip Condition settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
+
+</details>
+
+### Restore Cache from GCS step settings
+
+<details>
+<summary>Restore Cache from GCS step settings</summary>
+
+:::info
+
+Depending on the stage's build infrastructure, some settings may be unavailable or located under **Optional Configuration** in the visual pipeline editor. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
+
+:::
+
+#### Name
+
+Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
+
+#### GCP Connector
+
+The Harness connector for the GCP account where the cache is saved.
+
+This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
+
+#### Bucket
+
+The name of the GCS bucket containing the target cache.
+
+#### Key
+
+The key identifying the cache to restore.
+
+You can use the checksum macro to restore a key based on a file's checksum, for example `myApp-{{ checksum "path/to/file" }}` or `gcp-{{ checksum "package.json" }}`. The result of the checksum macro is concatenated to the leading string.
+
+The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead, for example:
+
+* Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }}`
+* Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
+
+#### Archive Format
+
+Select the archive format. The default archive format is Tar.
+
+#### Fail if Key Doesn't Exist
+
+Select this option to fail the step if the specified **Key** doesn't exist.
+
+By default, this option is set to false (unselected).
+
+#### Run as User
+
+Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+
+#### Set Container Resources
+
+Maximum resources limits for the resources used by the container at runtime:
+
+* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
+* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
+
+#### Timeout
+
+Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
+
+* [Step Skip Condition settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
+* [Step Failure Strategy settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
+
+</details>
+
+### Language-specific requirements
+
+Cache key and paths differ by language.
+
+```mdx-code-block
+<Tabs>
+<TabItem value="Go">
+```
+
+[Go](https://go.dev/) pipelines must reference `go.sum` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
+
+```yaml
+                  spec:
+                    key: cache-{{ checksum "go.sum" }}
+```
+
+`spec.sourcePaths` must include `/go/pkg/mod` and `/root/.cache/go-build` in the **Save Cache to GCS** step, for example:
+
+```yaml
+                  spec:
+                    sourcePaths:
+                    - /go/pkg/mod
+                    - /root/.cache/go-build
+```
+
+```mdx-code-block
+</TabItem>
+
+<TabItem value="Node.js">
+```
+
+[Npm](https://www.npmjs.com/) pipelines must reference `package-lock.json` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
+
+```yaml
+                  spec:
+                    key: cache-{{ checksum "package-lock.json" }}
+```
+
+[Yarn](https://yarnpkg.com/) pipelines must reference `yarn.lock` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
+
+```yaml
+                  spec:
+                    key: cache-{{ checksum "yarn.lock" }}
+```
+
+`spec.sourcePaths` must include `node_modues` in the **Save Cache to GCS** step, for example:
+
+```yaml
+                  spec:
+                    sourcePaths:
+                    - node_modules
+```
+
+```mdx-code-block
+</TabItem>
+
+<TabItem value="Maven">
+```
+
+[Maven](https://maven.apache.org/) pipelines must reference `pom.xml` for `spec.key` in **Save Cache to GCS** and **Restore Cache From GCS** steps, for example:
+
+```yaml
+                  spec:
+                    key: cache-{{ checksum "pom.xml" }}
+```
+
+`spec.sourcePaths` must include `/root/.m2` in the **Save Cache to GCS** step, for example:
+
+```yaml
+                  spec:
+                    sourcePaths:
+                    - /root/.m2
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
 ## Placement of save and restore cache steps
 
 The placement and sequence of the save and restore cache steps depends on how you're using caching in a pipeline.
@@ -246,134 +463,6 @@ This YAML example includes two stages. The first stage creates a cache bucket an
 ```
 
 </details>
-
-## Save Cache to GCS step settings
-
-:::info
-
-Depending on the stage's build infrastructure, some settings may be unavailable or located under **Optional Configuration** in the visual pipeline editor. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
-
-:::
-
-### Name
-
-Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
-
-### GCP Connector
-
-The Harness connector for the GCP account where you want to save the cache. For more information, go to [Google Cloud Platform (GCP) connector settings reference](/docs/platform/Connectors/Cloud-providers/ref-cloud-providers/gcs-connector-settings-reference).
-
-This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
-
-### Bucket
-
-The GCS destination bucket name.
-
-### Key
-
-The key to identify the cache.
-
-You can use the checksum macro to create a key based on a file's checksum, for example: `myApp-{{ checksum filePath1 }}`
-
-With this macro, Harness checks if the key exists and compares the checksum. If the checksum matches, then Harness doesn't save the cache. If the checksum is different, then Harness saves the cache.
-
-The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead.
-
-* Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
-* Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
-
-### Source Paths
-
-A list of the files/folders to cache. Add each file/folder separately.
-
-### Archive Format
-
-Select the archive format. The default archive format is Tar.
-
-### Override Cache
-
-Select this option if you want to override the cache if a cache with a matching **Key** already exists.
-
-By default, the **Override Cache** option is set to false (unselected).
-
-### Run as User
-
-Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
-
-### Set Container Resources
-
-Maximum resources limits for the resources used by the container at runtime:
-
-* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
-* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-### Timeout
-
-Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
-
-* [Step Skip Condition settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
-
-## Restore Cache from GCS step settings
-
-:::info
-
-Depending on the stage's build infrastructure, some settings may be unavailable or located under **Optional Configuration** in the visual pipeline editor. Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
-
-:::
-
-### Name
-
-Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
-
-### GCP Connector
-
-The Harness connector for the GCP account where the cache is saved.
-
-This step supports GCP connectors that use access key authentication. It does not support GCP connectors that inherit delegate credentials.
-
-### Bucket
-
-The name of the GCS bucket containing the target cache.
-
-### Key
-
-The key identifying the cache to restore.
-
-You can use the checksum macro to restore a key based on a file's checksum, for example `myApp-{{ checksum "path/to/file" }}` or `gcp-{{ checksum "package.json" }}`. The result of the checksum macro is concatenated to the leading string.
-
-The backslash character isn't allowed as part of the checksum value here. This is a limitation of the Go language (golang) template. You must use a forward slash instead, for example:
-
-* Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }}`
-* Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
-
-### Archive Format
-
-Select the archive format. The default archive format is Tar.
-
-### Fail if Key Doesn't Exist
-
-Select this option to fail the step if the specified **Key** doesn't exist.
-
-By default, this option is set to false (unselected).
-
-### Run as User
-
-Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
-
-### Set Container Resources
-
-Maximum resources limits for the resources used by the container at runtime:
-
-* **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
-* **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
-
-### Timeout
-
-Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
-
-* [Step Skip Condition settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-skip-condition-settings.md)
-* [Step Failure Strategy settings](/docs/platform/8_Pipelines/w_pipeline-steps-reference/step-failure-strategy-settings.md)
 
 ## Cache step logs
 

--- a/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
@@ -83,9 +83,10 @@ Here is an example of the YAML for a **Save Cache to GCS** step.
                   spec:
                     connectorRef: account.gcp
                     bucket: ci_cache
-                    key: gcp-{{ checksum "package.json" }}
+                    key: gcs-{{ checksum filePath1 }} # example cache key based on file checksum
                     sourcePaths:
-                      - /harness/node_modules
+                      - directory1 # example first directory to cache
+                      - directory2 # example second directory to cache
                     archiveFormat: Tar
 ```
 
@@ -106,7 +107,7 @@ Here is an example of the YAML for a **Restore Cache from GCS** step.
                   spec:
                     connectorRef: account.gcp
                     bucket: ci_cache
-                    key: gcp-{{ checksum "package.json" }}
+                    key: gcs-{{ checksum filePath1 }} # example cache key based on file checksum
                     archiveFormat: Tar
 ```
 
@@ -255,7 +256,7 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 ### Language-specific requirements
 
-Cache key and paths differ by language.
+The cache key and paths differ by language.
 
 ```mdx-code-block
 <Tabs>
@@ -274,8 +275,8 @@ Cache key and paths differ by language.
 ```yaml
                   spec:
                     sourcePaths:
-                    - /go/pkg/mod
-                    - /root/.cache/go-build
+                      - /go/pkg/mod
+                      - /root/.cache/go-build
 ```
 
 ```mdx-code-block
@@ -298,12 +299,12 @@ Cache key and paths differ by language.
                     key: cache-{{ checksum "yarn.lock" }}
 ```
 
-`spec.sourcePaths` must include `node_modues` in the **Save Cache to GCS** step, for example:
+`spec.sourcePaths` must include `node_modules` in the **Save Cache to GCS** step, for example:
 
 ```yaml
                   spec:
                     sourcePaths:
-                    - node_modules
+                      - node_modules
 ```
 
 ```mdx-code-block
@@ -324,7 +325,7 @@ Cache key and paths differ by language.
 ```yaml
                   spec:
                     sourcePaths:
-                    - /root/.m2
+                      - /root/.m2
 ```
 
 ```mdx-code-block

--- a/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
@@ -111,6 +111,8 @@ Here is a YAML example of a **Save Cache to S3** step.
 ...
 ```
 
+### Save Cache to S3 step settings
+
 <details>
 <summary>Save Cache to S3 step settings</summary>
 
@@ -120,11 +122,11 @@ Depending on the stage's build infrastructure, some settings may be unavailable 
 
 :::
 
-### Name
+#### Name
 
 Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-### AWS Connector
+#### AWS Connector
 
 The Harness AWS connector to use when saving the cache to S3. The AWS IAM roles and policies associated with the account used in the Harness AWS Connector must be able to write to S3.
 
@@ -141,18 +143,18 @@ For more information about roles and permissions for AWS connectors, go to:
 * [Add an AWS connector](/docs/platform/Connectors/Cloud-providers/add-aws-connector)
 * [AWS connector settings reference](/docs/platform/Connectors/Cloud-providers/ref-cloud-providers/aws-connector-settings-reference).
 
-### Region
+#### Region
 
 Define the AWS region to use when saving the cache, such as the AWS region you selected when you created the AWS S3 bucket. For more information go to the AWS documentation:
 
 * [Creating, configuring, and working with Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-configure-bucket.html)
 * [Pushing a Docker image to an Amazon ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html)
 
-### Bucket
+#### Bucket
 
 The AWS S3 bucket where you want to save the cache.
 
-### Key
+#### Key
 
 The key to identify the cache.
 
@@ -165,25 +167,25 @@ The backslash character isn't allowed as part of the checksum value here. This i
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Source Paths
+#### Source Paths
 
 A list of the files/folders to cache. Add each file/folder separately.
 
-### Endpoint URL
+#### Endpoint URL
 
 Endpoint URL for S3-compatible providers. This setting is not needed for AWS.
 
-### Archive Format
+#### Archive Format
 
 Select the archive format. The default archive format is Tar.
 
-### Override Cache
+#### Override Cache
 
 Select this option if you want to override the cache if a cache with a matching **Key** already exists.
 
 By default, the **Override Cache** option is set to false (unselected).
 
-### Path Style
+#### Path Style
 
 If unselected, the step uses Virtual Hosted Style for paths, such as `http://bucket.host/key`. If selected, the step uses Path Style, such as `http://host/bucket/key`.
 
@@ -191,18 +193,18 @@ For MinIO, you must use Path Style. Make sure **Path Style** is true (selected).
 
 By default, **Path Style** is false (unselected).
 
-### Run as User
+#### Run as User
 
 Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-### Set Container Resources
+#### Set Container Resources
 
 Maximum resources limits for the resources used by the container at runtime:
 
 * **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
 * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-### Timeout
+#### Timeout
 
 Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
@@ -211,7 +213,7 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 </details>
 
-### Stage setting: Shared paths
+#### Stage setting: Shared paths
 
 Pipeline steps within a stage share the same [workspace](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#workspace). You can optionally [share paths](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#shared-paths) outside the workspace between steps in your stage by setting `spec.sharedPaths`.
 
@@ -257,6 +259,8 @@ The `key` value in this step must match the `key` value in your **Save Cache to 
 
 :::
 
+### Restore Cache from S3 step settings
+
 <details>
 <summary>Restore Cache from S3 step settings</summary>
 
@@ -266,11 +270,11 @@ Depending on the stage's build infrastructure, some settings may be unavailable 
 
 :::
 
-### Name
+#### Name
 
 Enter a name summarizing the step's purpose. Harness automatically assigns an **Id** ([Entity Identifier Reference](/docs/platform/20_References/entity-identifier-reference.md)) based on the **Name**. You can change the **Id**.
 
-### AWS Connector
+#### AWS Connector
 
 The Harness Connector to use when restoring the cache from AWS S3. If your pipeline also has a **Save Cache to S3** step, these steps typically use the same connector.
 
@@ -289,15 +293,15 @@ For more information about roles and permissions for AWS connectors, go to:
 * [Add an AWS connector](/docs/platform/Connectors/Cloud-providers/add-aws-connector)
 * [AWS connector settings reference](/docs/platform/Connectors/Cloud-providers/ref-cloud-providers/aws-connector-settings-reference)
 
-### Region
+#### Region
 
 The relevant AWS region. If your pipeline also has a **Save Cache to S3** step, the region is typically the same for both steps.
 
-### Bucket
+#### Bucket
 
 The AWS S3 bucket where the target cache is saved. If your pipeline also has a **Save Cache to S3** step, the bucket is typically the same for both steps.
 
-### Key
+#### Key
 
 The key identifying the cache that you want to retrieve. If your pipeline also has a **Save Cache to S3** step, the key value must be the same to restore the previously-saved cache.
 
@@ -306,15 +310,15 @@ The backslash character isn't allowed as part of the checksum value here. This i
 * Incorrect format: `cache-{{ checksum ".\src\common\myproj.csproj" }`
 * Correct format: `cache-{{ checksum "./src/common/myproj.csproj" }}`
 
-### Endpoint URL
+#### Endpoint URL
 
 Endpoint URL for S3-compatible providers. This is not needed for AWS.
 
-### Archive Format
+#### Archive Format
 
 Select the archive format. The default archive format is Tar.
 
-### Path Style
+#### Path Style
 
 If unselected, the step uses Virtual Hosted Style for paths, such as `http://bucket.host/key`. If selected, the step uses Path Style, such as `http://host/bucket/key`.
 
@@ -322,24 +326,24 @@ For MinIO, you must use Path Style. Make sure **Path Style** is true (selected).
 
 By default, **Path Style** is false (unselected).
 
-### Fail if Key Doesn't Exist
+#### Fail if Key Doesn't Exist
 
 Select this option to fail the step if the specified **Key** doesn't exist.
 
 By default, this option is set to false (unselected).
 
-### Run as User
+#### Run as User
 
 Specify the user ID to use to run all processes in the pod if running in containers. For more information, go to [Set the security context for a pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
-### Set Container Resources
+#### Set Container Resources
 
 Maximum resources limits for the resources used by the container at runtime:
 
 * **Limit Memory:** Maximum memory that the container can use. You can express memory as a plain integer or as a fixed-point number with the suffixes `G` or `M`. You can also use the power-of-two equivalents, `Gi` or `Mi`. Do not include spaces when entering a fixed value. The default is `500Mi`.
 * **Limit CPU:** The maximum number of cores that the container can use. CPU limits are measured in CPU units. Fractional requests are allowed. For example, you can specify one hundred millicpu as `0.1` or `100m`. For more information, go to [Resource units in Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-### Timeout
+#### Timeout
 
 Set the timeout limit for the step. Once the timeout limit is reached, the step fails and pipeline execution continues. To set skip conditions or failure handling for steps, go to:
 
@@ -349,7 +353,7 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 </details>
 
 
-## Language-dependent requirements
+## Language-specific requirements
 
 Cache key and paths differ by language.
 

--- a/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
@@ -215,7 +215,7 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 #### Stage setting: Shared paths
 
-Pipeline steps within a stage share the same [workspace](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#workspace). You can optionally [share paths](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#shared-paths) outside the workspace between steps in your stage by setting `spec.sharedPaths`.
+Pipeline steps within a stage share the same [workspace](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#workspace). You can optionally [share paths](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages#share-data-between-steps-in-a-stage) outside the workspace between steps in your stage by setting `spec.sharedPaths`.
 
 ```yaml
   stages:
@@ -384,7 +384,7 @@ The cache key and paths differ by language.
 <TabItem value="Node.js">
 ```
 
-[Npm](https://www.npmjs.com/) pipelines must reference `package-lock.json` for `spec.key` in **Save Cache to S3** and **Restore Cache From S3** steps, for example:
+[npm](https://www.npmjs.com/) pipelines must reference `package-lock.json` for `spec.key` in **Save Cache to S3** and **Restore Cache From S3** steps, for example:
 
 ```yaml
                   spec:

--- a/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
@@ -355,7 +355,7 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 
 ## Language-specific requirements
 
-Cache key and paths differ by language.
+The cache key and paths differ by language.
 
 ```mdx-code-block
 <Tabs>
@@ -374,8 +374,8 @@ Cache key and paths differ by language.
 ```yaml
                   spec:
                     sourcePaths:
-                    - /go/pkg/mod
-                    - /root/.cache/go-build
+                      - /go/pkg/mod
+                      - /root/.cache/go-build
 ```
 
 ```mdx-code-block
@@ -398,12 +398,12 @@ Cache key and paths differ by language.
                     key: cache-{{ checksum "yarn.lock" }}
 ```
 
-`spec.sourcePaths` must include `node_modues` in the **Save Cache to S3** step, for example:
+`spec.sourcePaths` must include `node_modules` in the **Save Cache to S3** step, for example:
 
 ```yaml
                   spec:
                     sourcePaths:
-                    - node_modules
+                      - node_modules
 ```
 
 ```mdx-code-block
@@ -424,7 +424,7 @@ Cache key and paths differ by language.
 ```yaml
                   spec:
                     sourcePaths:
-                    - /root/.m2
+                      - /root/.m2
 ```
 
 ```mdx-code-block

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -8,12 +8,9 @@ slug: /ci-pipelines/build/java
 
 # Build, test, and publish a Java app
 
-In this tutorial, you will create a Harness CI pipeline that does the following:
+In this tutorial, you'll create a Harness CI pipeline that builds, tests, and publishes a Java app.
 
-1. Build and test a Java HTTP server application.
-2. Publish a Docker image.
-3. Pull the published Docker image and run it as a service dependency.
-4. Run a connectivity test against the running application.
+In addition to creating a pipeline, you'll learn about **connectors**, **variables**, **caching**, and **service dependencies** in Harness CI pipelines.
 
 ```mdx-code-block
 import CISignupTip from '/tutorials/shared/ci-signup-tip.md';

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -184,7 +184,7 @@ import TabItem from '@theme/TabItem';
 3. For **Variable Name**, enter `DOCKERHUB_USERNAME`.
 4. For **Type** select **String**, and then select **Save**.
 5. Enter the value `<+input>`. This allows you to specify a Docker Hub username at runtime.
-1. Select **Apply Changes**.
+6. Select **Apply Changes**.
 
 ```mdx-code-block
   </TabItem>
@@ -296,27 +296,24 @@ Add a step to build an image of the JHTTP app and push it to Docker Hub. While t
   <TabItem value="Visual" label="Visual">
 ```
 
-1. In your Docker Hub account, create a repo called `jhttp`.
-2. In Harness, in the **Build** stage, select **Add Step** and add a **Build and Push an image to Docker Registry** step configured as follows.
+Add a **Build and Push an image to Docker Registry** step to the **Build** stage with the following configuration:
 
    * **Docker Connector:** Select your Docker connector.
    * **Docker Repository:** Enter `<+pipeline.variables.DOCKERHUB_USERNAME>/jhttp`
    * **Tags:** Select **Add** and enter `<+pipeline.sequenceId>`.
 
-3. Select **Apply Changes**.
-
 Notice the following about this step:
 
-* The **Docker Repository** value calls the [pipeline variable](#add-a-pipeline-variable) you created earlier.
-* The **Tag** value is an expression that uses the build ID as the image tag. Each time the pipeline runs, the build ID increments, creating a unique image tag for each run.
+* The **Docker Repository** value calls the [pipeline variable](#use-variables) you created earlier.
+* The **Tag** value is an [expression](/docs/platform/references/runtime-inputs/#expressions) that uses the build ID as the image tag. Each time the pipeline runs, the build ID increments, creating a unique image tag for each run.
 
 
 ```mdx-code-block
   </TabItem>
   <TabItem value="YAML" label="YAML" default>
 ```
-1. In your Docker Hub account, create a repo called `jhttp`.
-2. In Harness, add the following `step` block to the `Build Java App with Maven` stage. Replace the bracketed value with your [Docker connector](#prepare-the-docker-registry) ID.
+
+Add the following `step` block to the `Build` stage. Replace the bracketed value with your [Docker connector](#prepare-the-docker-registry) ID.
 
 ```yaml
               - step:
@@ -332,8 +329,8 @@ Notice the following about this step:
 
 Notice the following about this step:
 
-* The `repo` value calls the [pipeline variable](#add-a-pipeline-variable) you created earlier.
-* The `tag` value is an expression that uses the build ID as the tag. Each time the pipeline runs, the build ID increments, creating a unique image tag for each run.
+* The `repo` value calls the [pipeline variable](#use-variables) you created earlier.
+* The `tag` value is an [expression](/docs/platform/references/runtime-inputs/#expressions) that uses the build ID as the tag. Each time the pipeline runs, the build ID increments, creating a unique image tag for each run.
 
 ```mdx-code-block
   </TabItem>
@@ -364,7 +361,7 @@ Harness offers several options for [managing dependencies](/docs/continuous-inte
 
 5. Select **Apply Changes**.
 
-Notice that the **Image** value uses an expression that generates the image path by calling your [pipeline variable](#add-a-pipeline-variable) and the build ID expression, which was used as the **Tag** in the **Build and Push an image to Docker Registry** step.
+Notice that the **Image** value uses an expression that generates the image path by calling your [pipeline variable](#use-variables) and the build ID expression, which was used as the **Tag** in the **Build and Push an image to Docker Registry** step.
 
 ```mdx-code-block
   </TabItem>
@@ -407,7 +404,7 @@ This code block does the following:
 * `cloneCodebase: false` - This stage does not need to clone the GitHub repo because it will use the app image that was built and pushed to Docker Hub in the first stage.
 * `platform` - The stage uses the same build infrastructure as the first stage.
 * `step` - Adds a `Background` step that runs the JHTTP app image.
-* `image` - This value uses an expression that generates the image path by calling your [pipeline variable](#add-a-pipeline-variable) and the build ID expression, which was used as the `tag` value in the `Build and Push an image to Docker Registry` step.
+* `image` - This value uses an expression that generates the image path by calling your [pipeline variable](#use-variables) and the build ID expression, which was used as the `tag` value in the `Build and Push an image to Docker Registry` step.
 
 ```mdx-code-block
   </TabItem>

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -457,57 +457,11 @@ The `image` value is an expression that generates the image path by calling your
 
 Harness CI has several caching options.
 
-* [Cache Intelligence](#cache-intelligence)
-* [S3 and GCS caching](#s3-and-gcs-caching)
+* Automated caching with [Cache Intelligence](/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence)
+* [S3 caching](/docs/continuous-integration/use-ci/caching-ci-data/saving-cache)
+* [GCS caching](/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs)
 * [Shared Paths](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages#share-data-between-steps-in-a-stage), which you can use for temporary data sharing within a single stage
 * [Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages#docker-layer-caching)
-
-#### Cache Intelligence
-
-With [Cache Intelligence](/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence), Harness automatically caches and restores common dependencies. It doesn't require you to provide your own storage, because the cache is stored in our hosted environment, Harness Cloud.
-
-Cache Intelligence is available for the Harness Cloud build infrastructure only.
-
-To enable Cache Intelligence, add `caching: enabled: true` to he `stage: spec:` in the YAML editor, for example:
-
-```yaml
-    - stage:
-        name: Build Jhttp
-        identifier: Build_Jhttp
-        type: CI
-        spec:
-          caching:
-            enabled: true
-          cloneCodebase: true
-```
-
-To learn more about Cache Intelligence, including how to customize cache paths and keys, go to [Cache Intelligence](/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence).
-
-#### S3 and GCS caching
-
-
-[S3 caching](/docs/continuous-integration/use-ci/caching-ci-data/saving-cache)
-* [GCS caching](/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs)
-
-
-```mdx-code-block
-<Tabs>
-  <TabItem value="Visual" label="Visual" default>
-```
-
-some content
-
-```mdx-code-block
-  </TabItem>
-  <TabItem value="YAML" label="YAML">
-```
-
-some content
-
-```mdx-code-block
-  </TabItem>
-</Tabs>
-```
 
 ## Run the pipeline
 
@@ -518,7 +472,7 @@ some content
 
 While the build runs you can observe each step of the pipeline execution on the [Build details page](/docs/continuous-integration/use-ci/view-your-builds/viewing-builds). When the first stage completes, test results appear on the **Tests** tab.
 
-When the second stage completes, you should see the `curl` command running in the connectivity test step's logs. If it doesn't self-exit
+If you used the sample `curl` command in the second stage, the script may run indefinitely. Select the stop icon to terminate the build.
 
 :::tip
 
@@ -530,11 +484,7 @@ For a comprehensive guide on application testing, [Harness provides O'Reilly's *
 
 Now that you've created a basic pipeline for building and testing a Java app, you might want to explore the ways that you can [optimize and enhance CI pipelines](/docs/continuous-integration/use-ci/optimize-and-more/optimizing-ci-build-times), including:
 
-* Using [triggers](/docs/category/triggers/) to automatically start pipelines.
-* [Caching dependencies](/docs/continuous-integration/use-ci/caching-ci-data/saving-cache).
-
-You can also try adding more steps to add more functionality to this pipeline, such as:
-
+* [Using Terraform notifications to automatically start builds](/tutorials/ci-pipelines/build/tfc-notification).
 * [Uploading artifacts to JFrog](/docs/continuous-integration/use-ci/build-and-upload-artifacts/upload-artifacts-to-jfrog).
 * [Publishing an Allure Report to the Artifacts tab](/tutorials/ci-pipelines/test/allure-report).
 * [Including CodeCov code coverage and publishing results to your CodeCov dashboard](/tutorials/ci-pipelines/test/codecov/).

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -165,7 +165,7 @@ In contrast, if you choose to [use a Kubernetes cluster build infrastructure](/d
 
 :::caution
 
-You must ensure that the build farm can run the commands required by your build. You may need to modify your build machines or add steps to your pipeline to install necessary tools, libraries, and other dependencies.
+You must ensure that the build farm can run the commands required by your build. You might need to modify your build machines or add steps to your pipeline to install necessary tools, libraries, and other dependencies.
 
 :::
 

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -95,13 +95,12 @@ For this tutorial, you'll need a Docker connector to allow Harness to authentica
 2. When prompted to select a repository, search for **jhttp**, select the repository that you forked earlier, and then select **Configure Pipeline**.
 3. Select **Generate my Pipeline configuration**, and then select **Create a Pipeline**.
 
-**Generate my Pipeline configuration** automatically creates PR and Push triggers for the selected repository. If you want a more bare-bones pipeline, select **Create empty Pipeline configuration**.
+**Generate my Pipeline configuration** automatically creates PR and Push triggers for the selected repository. If you want a more bare bones pipeline, select **Create empty Pipeline configuration**.
 
 <details>
 <summary>Generated pipeline YAML</summary>
 
 The YAML for the generated pipeline is as follows. To switch to the YAML editor, select **YAML** at the top of the Pipeline Studio.
-
 
 ```yaml
 pipeline:
@@ -141,7 +140,7 @@ pipeline:
 
 </details>
 
-### Understand build infrastructure
+### Understand the build infrastructure
 
 This pipeline uses a Linux AMD64 machine on Harness Cloud build infrastructure, as declared in the stage's `platform` specifications.
 
@@ -249,7 +248,7 @@ You could also use **Pre-Command** to prepare the test environment. For example,
   <TabItem value="YAML" label="YAML" default>
 ```
 
-In the YAML editor, replace the `Echo Welcome Message` run step block with the following. Replace the bracketed value with your [Docker connector](#prepare-docker-registry) ID.
+In the YAML editor, replace the `Echo Welcome Message` run step block with the following. Replace the bracketed value with your [Docker connector](#prepare-the-docker-registry) ID.
 
 ```yaml
               - step:
@@ -317,7 +316,7 @@ Notice the following about this step:
   <TabItem value="YAML" label="YAML" default>
 ```
 1. In your Docker Hub account, create a repo called `jhttp`.
-2. In Harness, add the following `step` block to the `Build Java App with Maven` stage. Replace the bracketed value with your [Docker connector](#prepare-docker-registry) ID.
+2. In Harness, add the following `step` block to the `Build Java App with Maven` stage. Replace the bracketed value with your [Docker connector](#prepare-the-docker-registry) ID.
 
 ```yaml
               - step:
@@ -372,7 +371,7 @@ Notice that the **Image** value uses an expression that generates the image path
   <TabItem value="YAML" label="YAML" default>
 ```
 
-Add the following code block to the end of your pipeline YAML. Replace the bracketed value with your [Docker connector](#prepare-docker-registry) ID.
+Add the following code block to the end of your pipeline YAML. Replace the bracketed value with your [Docker connector](#prepare-the-docker-registry) ID.
 
 ```yaml
     - stage:
@@ -494,7 +493,7 @@ You can also try adding more steps to add more functionality to this pipeline, s
 
 ## Reference: Pipeline YAML
 
-Here is the complete YAML for this tutorial's pipeline. If you copy this example, make sure to replace the bracketed values with corresponding values for your Harness project, [GitHub connector ID](#create-a-github-connector), GitHub account name, and [Docker connector ID](#prepare-docker-hub).
+Here is the complete YAML for this tutorial's pipeline. If you copy this example, make sure to replace the bracketed values with corresponding values for your Harness project, [GitHub connector ID](#create-the-github-connector), GitHub account name, and [Docker connector ID](#prepare-the-docker-registry).
 
 <details>
 <summary>Pipeline YAML</summary>

--- a/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
+++ b/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 import CISignupTip from '/tutorials/shared/ci-signup-tip.md';
 ```
 
-In this tutorial, you'll create a Harness CI pipeline that builds, tests, and publishes a NodeJS app.
+In this tutorial, you'll create a Harness CI pipeline that builds, tests, and publishes a [Node.js](https://nodejs.org/en/docs/guides/getting-started-guide) app.
 
 <CISignupTip />
 
@@ -256,11 +256,11 @@ Add a step to run tests against the NodeJS app code. This portion of the tutoria
 
 7. Select **Apply Changes** to save the step, and then select **Save** to save the pipeline.
 
-:::tip
+:::tip Specify the Node version
 
 This tutorial pipeline uses Harness Cloud build infrastructure that already has Node installed. If you changed the build infrastructure, you may need to specify the **Container Registry** and **Image** containing the binaries that the step needs to run your script, such as `node:latest`.
 
-For information about when these fields are required, how to specify images, and information about all **Run** step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings).
+For information about when these fields are required, how to specify images, and information about all **Run** step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings). For information about Harness Cloud image specifications and how to modify Harness Cloud build infrastructure, go to [Platform and image specifications for Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure#platforms-and-image-specifications).
 
 :::
 
@@ -284,11 +284,9 @@ In the YAML editor, replace the `Echo Welcome Message` run step block with the f
                       npm test
 ```
 
-:::tip
+:::tip Specify the Node version
 
 This tutorial pipeline uses Harness Cloud build infrastructure that already has Node installed. If you changed the build infrastructure, you may need to specify the `connectorRef` and `image` containing the binaries that the step needs to run your script, such as `node:latest`.
-
-For information about when these fields are required, how to specify images, and information about all `Run` step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings).
 
 The following example shows the same `Run` step with `connectorRef` and `image`.
 
@@ -306,6 +304,8 @@ The following example shows the same `Run` step with `connectorRef` and `image`.
                       npm run build --if-present
                       npm test
 ```
+
+For information about when these fields are required, how to specify images, and information about all `Run` step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings). For information about Harness Cloud image specifications and how to modify Harness Cloud build infrastructure, go to [Platform and image specifications for Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure#platforms-and-image-specifications).
 
 :::
 

--- a/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
+++ b/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
@@ -151,64 +151,58 @@ For this tutorial, you'll need a Docker connector to allow Harness to authentica
 
 8. In the list of connectors, make a note of your Docker connector's ID.
 
-## Create the Java starter pipeline
+## Create a pipeline
 
 1. Under **Project Setup**, select **Get Started**.
 2. When prompted to select a repository, search for **easy-node-docker**, select the repository that you forked earlier, and then select **Configure Pipeline**.
-3. Under **Choose a Starter Configuration**, select **Java with Maven** and then select **Create a Pipeline**.
+3. Select **Generate my Pipeline configuration**, and then select **Create a Pipeline**.
+
+**Generate my Pipeline configuration** automatically creates PR and Push triggers for the selected repository. If you want a more bare bones pipeline, select **Create empty Pipeline configuration**.
 
 <details>
-<summary>Java with Maven starter pipeline YAML</summary>
+<summary>Generated pipeline YAML</summary>
 
-The YAML for the **Java with Maven** starter pipeline is as follows. To switch to the YAML editor, select **YAML** at the top of the Pipeline Studio.
+The YAML for the generated pipeline is as follows. To switch to the YAML editor, select **YAML** at the top of the Pipeline Studio.
 
 ```yaml
 pipeline:
-  name: Build Java with Maven
-  identifier: Build_Java_with_Maven
+  name: Build easy-node-docker
+  identifier: Build_easy_node_docker
   projectIdentifier: [your-project-ID]
   orgIdentifier: default
-  properties:
-    ci:
-      codebase:
-        connectorRef: [your-github-connector]
-        repoName: [your-github-account]/easy-node-docker
-        build: <+input>
   stages:
     - stage:
-        name: Build Java App with Maven
-        identifier: Build_Java_App_with_Maven
-        description: ""
+        name: Build
+        identifier: Build
         type: CI
         spec:
           cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Echo Welcome Message
+                  identifier: Echo_Welcome_Message
+                  spec:
+                    shell: Sh
+                    command: echo "Welcome to Harness CI"
           platform:
             os: Linux
             arch: Amd64
           runtime:
             type: Cloud
             spec: {}
-          execution:
-            steps:
-              - step:
-                  type: Run
-                  name: Build Java App
-                  identifier: Build_Java_App
-                  spec:
-                    shell: Sh
-                    command: |-
-                      echo "Welcome to Harness CI"
-                      mvn -B package --file pom.xml
+  properties:
+    ci:
+      codebase:
+        connectorRef: [your-github-connector]
+        repoName: [your-github-account]/easy-node-docker
+        build: <+input>
 ```
 
 </details>
 
-
-
-
-
-
-### Understand build infrastructure
+### Understand the build infrastructure
 
 This pipeline uses a Linux AMD64 machine on Harness Cloud build infrastructure, as declared in the stage's `platform` specifications.
 
@@ -236,39 +230,11 @@ In contrast, if you choose to [use a Kubernetes cluster build infrastructure](/d
 * [Various caching options](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages) to load dependency caches.
 * [Run steps](/docs/category/run-scripts) for running all manner of scripts and commands.
 
+## Run tests
 
+## Build and push to Docker registry
 
-
-
-## Create Your First Pipeline
-
-In the Build Module [Harness Continuous Integration], walking through the wizard is the fastest path to get your build running. Click Get Started. This will create a basic Pipeline for you.
-
-![Get Started](../static/ci-tutorial-node-docker/get_started.png)
-
-Once you click Get Started, select GitHub as the repository you use, and then you can enter your GitHub Access Token that was created or being leveraged for the example.
-
-![SCM Choice](../static/ci-tutorial-node-docker/scm_choice.png)
-
-Click Continue. Then click Select Repository to select the Repository that you want to build [the sample is called *easy-node-docker*].
-
-![Node Docker Repo](../static/ci-tutorial-node-docker/node_docker_repo.png)
-
-Select the repository, then click Create Pipeline. The next step to focus on will be where you want to run the build by configuring the Pipeline. 
-
-```mdx-code-block
-<Tabs>
-<TabItem value="Harness Hosted Build Infrastructure">
-```
-Can leverage one of the Starter Configs or create a Starter Pipeline. In this case if leveraging the example app which is NodeJS based, leveraging the Node.js Starter Configuration works fine. 
-
-![Configure Node JS](../static/ci-tutorial-node-docker/configure_nodejs.png)
-
-Click Continue to define what infrastructure to run the build on. To run on Harness Hosted Infrastructure, first change the Infrastructure to “Cloud”.
-
-![Where to Build](../static/ci-tutorial-node-docker/where_to_build_cloud.png)
-
-The scaffolding will take care of the NPM install for you. End goal would be to have a published Docker Image of your artifact. Can add an additional Step to take care of the Docker Push. 
+the build infra will take care of the NPM install for you. End goal would be to have a published Docker Image of your artifact. Can add an additional Step to take care of the Docker Push. 
 
 
 ![Add Publish](../static/ci-tutorial-node-docker/add_publish.png)
@@ -276,31 +242,6 @@ The scaffolding will take care of the NPM install for you. End goal would be to 
 Select “Build and Push” image to Docker Registry.
 
 ![Docker Publish Step](../static/ci-tutorial-node-docker/add_docker_step.png)
-
-Next, create a new Docker Connector by clicking on + New Connector. 
-
-* Name: `my_docker_hub_account`
-
-![My Docker Hub](../static/ci-tutorial-node-docker/my_docker_hub.png)
-
-Next fill out the details of your account credentials for a Docker Push. 
-
-
-* Registry URL: https://index.docker.io/v2/
-* Authentication: Username and Password
-* Provider Type: DockerHub
-* Username: `your_docker_hub_user`
-* Password: `your_docker_hub_pw`
-
-![Docker Hub Details](../static/ci-tutorial-node-docker/dh_details.png)
-
-For sensitive items such as your Docker Hub password, these can be stored as a Harness Secret. 
-
-![Docker Hub Password Secret](../static/ci-tutorial-node-docker/dh_pw.png)
-
-Click Save and Continue. You can run this connection directly from the Harness Platform. 
-
-![User Harness Docker](../static/ci-tutorial-node-docker/connect_harness.png)
 
 Once selected, you can run a connectivity test and you are ready to provide the registry details. 
 
@@ -317,149 +258,76 @@ Click Apply Changes then Save.
 
 Now you are ready to run once saved. 
 
-```mdx-code-block
-</TabItem>
-<TabItem value="Self-Managed Build Infrastructure">
-```
 
-If you want to use your own self-managed build infrastructure, then you should install the [Kubernetes Delegate](/tutorials/platform/install-delegate) in the Kubernetes cluster of your choice. 
 
-<details>
-<summary>Install Delegate</summary>
-<DelegateInstall />
-</details>
+## Run the pipeline
 
-For the self-managed infrastructure, can leverage one of the Starter Configs or create a Starter Pipeline. In this case, can run the Starter Pipeline. 
-
-![Build Self Hosted Step](../static/ci-tutorial-node-docker/self_hosted_starter.png)
-
-Click Continue to start to build out the Pipeline. 
-
-![Build Step](../static/ci-tutorial-node-docker/build_step.png)
-
-Click Continue to define what infrastructure to run the build on.
-
-First change the infrastructure to “Kubernetes”.
-
-![Where to Build](../static/ci-tutorial-node-docker/where_to_build.png)
-
-Then select the drop-down “Select Kubernetes Cluster”. Then + New Connector.
-
-![New K8s Connector](../static/ci-tutorial-node-docker/new_connector.png)
-
-In the wizard, name the Kubernetes connection “myfirstcinode”.
-
-![First CI Node](../static/ci-tutorial-node-docker/first_ci_node.png)
-
-Click continue. With Harness, you can use the same cluster the Harness Delegate is running on by selecting “Use Credentials of a specific Harness Delegate”. The Harness Delegate will facilitate all needed work on the Kubernetes cluster.
-
-![Delegate Connect](../static/ci-tutorial-node-docker/delegate_connect.png)
-
-Click continue. Now select the Harness Delegate that corresponds to your Kubernetes cluster.
-
-![Kubernetes Delegate](../static/ci-tutorial-node-docker/k8s_delegate.png)
-
-Click “Save and Continue” and the connection will be validated.
-Back in the Pipeline Builder, “myfirstcinode” will be listed.
-
-Provide a Namespace and OS to run.
-
-- Namespace: default
-- OS: Linux [if using Windows WSL, Linux is the correct setting].
-
-![Build Infra](../static/ci-tutorial-node-docker/build_infra.png)
-
-After the Build Infrastructure is set, now time to set up the Push step to push the artifact to a Docker Registry. In the Pipeline View, click + Add Stage and create a Staged called “Push”.Then click on “Set Up Stage”.
-
-![Push Stage](../static/ci-tutorial-node-docker/push_stage.png)
-
-Click on “Set Up Stage”.
-
-![Set Up Push](../static/ci-tutorial-node-docker/set_up_push.png)
-
-In the setup of the Stage, can leverage the infrastructure that the previous artifact build was run on by selecting “Propagate from an existing stage”.
-
-![Where To Run](../static/ci-tutorial-node-docker/where_to_run.png)
-
-Click Continue now, you can add a Step to represent the Docker Push. Click “Add Step”.
-
-![Add Publish](../static/ci-tutorial-node-docker/add_publish.png)
-
-Select “Build and Push” image to Docker Registry.
-
-![Docker Publish](../static/ci-tutorial-node-docker/docker_publish.png)
-
-Can create a new Push connector.
-
-Name: pushtodockerhub
-
-![Push Connector](../static/ci-tutorial-node-docker/push_connector.png)
-
-Next, set up the Docker Connector by clicking on the dropdown for Docker Connector.
-Then create a new connector.
-
-![Docker Connector](../static/ci-tutorial-node-docker/docker_connector.png)
-
-Can name the new docker registry connector “dockerhub”.
-
-![Docker Hub Conncetor](../static/ci-tutorial-node-docker/dh_connector.png)
-
-Click continue and can enter your credentials to Docker Hub.
-
-- Provider Type: Docker Hub
-- Docker Registry URL: https://registry.hub.docker.com/v2/
-- Authentication: your_user
-- Password: your_password [Will be saved as a Harness Secret]
-
-![Docker Hub Creds](../static/ci-tutorial-node-docker/dh_creds.png)
-
-Click Continue and select the Harness Delegate to execute on. This will be your Kubernetes infrastructure.
-
-![Kubernetes Delegate](../static/ci-tutorial-node-docker/k8s_delegate.png)
-
-Click Save and Continue, and the connection will validate.
-Then click Finish. Lastly, enter your Docker Repository and Tag information.
-
-- Docker Repository: `your_account/your_registry`
-- Tags: cibuilt
-
-![Push Settings](../static/ci-tutorial-node-docker/push_settings.png)
-
-Then click “Apply Changes” and Save the Changes.
-
-![Save Changes](../static/ci-tutorial-node-docker/save_changes.png)
-
-With those changes saved, you are ready to execute your first CI Pipeline.
-
-```mdx-code-block
-</TabItem>
-</Tabs>
-```
-## Running Your First CI Pipeline
-
-Executing is simple. Head back to your pipeline and click on “Run”. Unlike your local machine, where you had to wire in NPM and Docker dependencies, Harness CI will resolve these by convention.
-
-![Pipeline](../static/ci-tutorial-node-docker/pipeline.png)
-
-Then you can select a branch to run off of and execute a step.
-Branch Name: main [if using the example repo]
+1. In the **Pipeline Studio**, save your pipeline and then select **Run**.
+2. In the **Build Type** field, select **Git Branch**, and then enter `main` in the **Branch Name** field.
+3. Select **Run Pipeline**.
 
 ![Run Pipeline](../static/ci-tutorial-node-docker/run_pipeline.png)
 
-Now you are ready to execute. Click “Run Pipeline”.
+While the build runs you can observe each step of the pipeline execution on the [Build details page](/docs/continuous-integration/use-ci/view-your-builds/viewing-builds).
 
 ![Execute Pipeline](../static/ci-tutorial-node-docker/execution.png)
 
-Once a successful run, head back to Docker Hub, and `cibuilt` is there!
+If the build succeeds, you'll find your `cibuilt` image in your Docker Hub repo.
 
 ![Success](../static/ci-tutorial-node-docker/success.png)
 
-This is just the start of your Continuous Integration journey. It might seem like multiple steps to get your local build in the platform, but it unlocks the world of possibilities.
+## Do more with this pipeline
 
-## Continuing on Your Continuous Integration Journey
+Now that you've created a basic pipeline for building and testing a NodeJS app, you might want to explore the ways that you can [optimize and enhance CI pipelines](/docs/continuous-integration/use-ci/optimize-and-more/optimizing-ci-build-times), including:
 
-You can now execute your builds whenever you want in a consistent fashion. Can modify the trigger to watch for SCM events so upon commit, for example, the Pipeline gets kicked off automatically. All of the objects you create are available for you to re-use. One part we did not touch upon in this example is executing your test suites, such as demonstrated in the [build and test on a Kubernetes cluster build infrastructure tutorial](/tutorials/ci-pipelines/build/kubernetes-build-farm). Lastly, you can even save your backing work / have it as part of your source code. Everything that you do in Harness is represented by YAML; feel free to store it as part of your project.
+* Using [triggers](/docs/category/triggers/) to automatically start pipelines.
+* [Caching dependencies](/docs/continuous-integration/use-ci/caching-ci-data/saving-cache).
+* [Variables and expressions](/docs/category/variables-and-expressions)
 
-![CI as Code](../static/ci-tutorial-node-docker/ci_as_code.png)
+<details>
+<summary>Example: Use variables</summary>
 
-After you have built your artifact, the next step is to deploy your artifact. This is where Continuous Delivery steps in and make sure to check out some other [CD Tutorials](/tutorials/cd-pipelines#all-tutorials).
+Variables and expressions make your pipelines more versatile by allowing variable inputs and values. For example, you can add a pipeline-level variable that lets you specify a Docker Hub username when the pipeline runs.
+
+To add a pipeline variable in the YAML editor, add the following `variables` block between the `properties` and `stages` sections.
+
+```yaml
+  variables:
+    - name: DOCKERHUB_USERNAME
+      type: String
+      description: Your Docker Hub username
+      value: <+input>
+```
+
+To add a pipeline variable in the visual editor:
+
+1. In the Pipeline Studio, select **Variables** on the right side of the Pipeline Studio.
+2. Under **Pipeline**, select **Add Variable**.
+3. For **Variable Name**, enter `DOCKERHUB_USERNAME`.
+4. For **Type** select **String**, and then select **Save**.
+5. Enter the value `<+input>`. This allows you to specify a Docker Hub username at runtime.
+1. Select **Apply Changes**.
+
+</details>
+
+You can also try adding more steps to add more functionality to this pipeline, such as:
+
+* [Uploading artifacts to JFrog](/docs/continuous-integration/use-ci/build-and-upload-artifacts/upload-artifacts-to-jfrog).
+* [Publishing an Allure Report to the Artifacts tab](/tutorials/ci-pipelines/test/allure-report).
+* [Including CodeCov code coverage and publishing results to your CodeCov dashboard](/tutorials/ci-pipelines/test/codecov/).
+* [Updating Jira issues when builds run](/docs/continuous-integration/use-ci/use-drone-plugins/ci-jira-int-plugin).
+
+After building an artifact, you can deploy your artifact with Harness [Continuous Delivery](/tutorials/cd-pipelines#all-tutorials).
+
+## Reference: Pipeline YAML
+
+Here is the complete YAML for this tutorial's pipeline. If you copy this example, make sure to replace the bracketed values with corresponding values for your Harness project, [GitHub connector ID](#create-the-github-connector), GitHub account name, and [Docker connector ID](#prepare-the-docker-registry).
+
+<details>
+<summary>Pipeline YAML</summary>
+
+```yaml
+...
+```
+
+</details>

--- a/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
+++ b/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
@@ -232,7 +232,7 @@ In contrast, if you choose to [use a Kubernetes cluster build infrastructure](/d
 
 ## Run tests
 
-Add a step to run tests against the NodeJS app code. This portion of the tutorial uses a **Run** step to [run tests in Harness CI](/docs/continuous-integration/use-ci/set-up-test-intelligence/run-tests-in-ci.md). For more examples, go to [Run a script in a Build stage](/docs/continuous-integration/use-ci/run-ci-scripts/run-a-script-in-a-ci-stage.md).
+Add a step to run tests against the NodeJS app code. This portion of the tutorial uses a **Run** step to [run tests in Harness CI](/docs/continuous-integration/use-ci/set-up-test-intelligence/run-tests-in-ci). For more examples, go to [Run a script in a Build stage](/docs/continuous-integration/use-ci/run-ci-scripts/run-a-script-in-a-ci-stage).
 
 ```mdx-code-block
 <Tabs>
@@ -258,7 +258,7 @@ Add a step to run tests against the NodeJS app code. This portion of the tutoria
 
 This tutorial pipeline uses Harness Cloud build infrastructure that already has Node installed. If you changed the build infrastructure, you may need to specify the **Container Registry** and **Image** containing the binaries that the step needs to run your script, such as `node:latest`.
 
-For information about when these fields are required, how to specify images, and information about all **Run** step settings, go to the [Run step settings reference](./run-step-settings.md).
+For information about when these fields are required, how to specify images, and information about all **Run** step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings).
 
 :::
 
@@ -286,7 +286,7 @@ In the YAML editor, replace the `Echo Welcome Message` run step block with the f
 
 This tutorial pipeline uses Harness Cloud build infrastructure that already has Node installed. If you changed the build infrastructure, you may need to specify the `connectorRef` and `image` containing the binaries that the step needs to run your script, such as `node:latest`.
 
-For information about when these fields are required, how to specify images, and information about all `Run` step settings, go to the [Run step settings reference](./run-step-settings.md).
+For information about when these fields are required, how to specify images, and information about all `Run` step settings, go to the [Run step settings reference](/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings).
 
 The following example shows the same `Run` step with `connectorRef` and `image`.
 
@@ -385,7 +385,7 @@ Now that you've created a basic pipeline for building and testing a NodeJS app, 
 
 Variables and expressions make your pipelines more versatile by allowing variable inputs and values. For example, you can add a pipeline-level variable that lets you specify a Docker Hub username when the pipeline runs.
 
-To add a pipeline variable in the YAML editor:
+#### Add a pipeline variable in the YAML editor
 
 1. Add the following `variables` block between the `properties` and `stages` sections.
 
@@ -400,7 +400,7 @@ To add a pipeline variable in the YAML editor:
 2. In the `BuildAndPushDockerRegistry` step, change the `repo` value to `<+pipeline.variables.DOCKERHUB_USERNAME>/samplejs`.
 3. Save and run the pipeline. You'll be prompted to provide a Docker Hub username before the pipeline runs.
 
-To add a pipeline variable in the visual editor:
+#### Add a pipeline variable in the visual editor
 
 1. In the Pipeline Studio, select **Variables** on the right side of the Pipeline Studio.
 2. Under **Pipeline**, select **Add Variable**.
@@ -419,7 +419,7 @@ You can also try adding more steps to add more functionality to this pipeline, s
 * [Publishing an Allure Report to the Artifacts tab](/tutorials/ci-pipelines/test/allure-report).
 * [Including CodeCov code coverage and publishing results to your CodeCov dashboard](/tutorials/ci-pipelines/test/codecov/).
 * [Updating Jira issues when builds run](/docs/continuous-integration/use-ci/use-drone-plugins/ci-jira-int-plugin).
-* [Running background services](/docs/continuous-integration/use-ci/manage-dependencies/background-step-settings.md)
+* [Running background services](/docs/continuous-integration/use-ci/manage-dependencies/background-step-settings)
 
 <details>
 <summary>Example: Run a service dependency in a Background step</summary>

--- a/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
+++ b/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
@@ -57,8 +57,8 @@ To build this app locally:
 1. Clone the [easy node docker repo](https://github.com/harness-apps/easy-node-docker) to your local machine.
 2. Create a Docker Hub account, if you don't already have a Docker registry account.
 3. Create a repo in your Docker registry account where you can push your app image.
-4. Make sure your local machine has [NPM](https://nodejs.org/en/download/package-manager) and [Docker](https://docs.docker.com/engine/install/).
-5. Use [docker build](https://docs.docker.com/build/building/context/) to call the underlying NPM install and start the build process. In the following example commands, replace the bracketed values with your Docker Hub or Docker registry username, the name of the repo where you want to push the image, and an appropriate image tag, such as `latest`.
+4. Make sure your local machine has [npm](https://nodejs.org/en/download/package-manager) and [Docker](https://docs.docker.com/engine/install/).
+5. Use [docker build](https://docs.docker.com/build/building/context/) to call the underlying npm install and start the build process. In the following example commands, replace the bracketed values with your Docker Hub or Docker registry username, the name of the repo where you want to push the image, and an appropriate image tag, such as `latest`.
 
    ```
    docker build --tag [your_docker_username]/[your-docker-repo-name]:[tag] .
@@ -228,7 +228,7 @@ In contrast, if you choose to [use a Kubernetes cluster build infrastructure](/d
 
 :::caution
 
-You must ensure that the build farm can run the commands required by your build. You may need to modify your build machines or add steps to your pipeline to install necessary tools, libraries, and other dependencies.
+You must ensure that the build farm can run the commands required by your build. You might need to modify your build machines or add steps to your pipeline to install necessary tools, libraries, and other dependencies.
 
 :::
 

--- a/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
+++ b/tutorials/ci-pipelines/build/ci-node-docker-quickstart.md
@@ -204,7 +204,7 @@ pipeline:
 
 ### Understand the build infrastructure
 
-This pipeline uses a Linux AMD64 machine on Harness Cloud build infrastructure, as declared in the stage's `platform` specifications.
+If you inspect the pipeline you just created, you can see that it uses a Linux AMD64 machine on Harness Cloud build infrastructure. You can see this on the **Build** stage's **Infrastructure** tab in the visual editor, or in the stage's `platform` specification in the YAML editor.
 
 ```yaml
     - stage:
@@ -221,14 +221,20 @@ This pipeline uses a Linux AMD64 machine on Harness Cloud build infrastructure, 
 
 You can change the build infrastructure if you want to use a different OS, arch, or infrastructure. With Harness Cloud build infrastructure, your builds run on pre-configured machines provided by Harness. You can also run builds locally or bring your own VMs or Kubernetes cluster build infrastructure. For more information on build infrastructure options, go to [Which build infrastructure is right for me](/docs/continuous-integration/use-ci/set-up-build-infrastructure/which-build-infrastructure-is-right-for-me).
 
-Regardless of the build infrastructure you choose, you must ensure the build farm can run the commands required by your pipeline. For example, this tutorial uses tools that are publicly available through Docker Hub or already installed on [Harness Cloud's preconfigured machines](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure#platforms-and-image-specifications).
+Regardless of the build infrastructure you choose, you must ensure that the build farm can run the commands required by your pipeline. For example, this tutorial uses tools that are publicly available through Docker Hub or already installed on [Harness Cloud's preconfigured machines](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure#platforms-and-image-specifications).
 
 In contrast, if you choose to [use a Kubernetes cluster build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure) and your pipeline requires a tool that is not already available in the cluster, you can configure your pipeline to load those prerequisite tools when the build runs. There are several ways to do this in Harness CI, including:
 
 * [Background steps](/docs/continuous-integration/use-ci/manage-dependencies/dependency-mgmt-strategies) for running dependent services.
-* [Plugin steps](/docs/continuous-integration/use-ci/use-drone-plugins/explore-ci-plugins) to run templated scripts, such as GitHub Actions, BitBucket Integrations, or any Drone plugin.
+* [Plugin steps](/docs/continuous-integration/use-ci/use-drone-plugins/explore-ci-plugins) to run templated scripts, such as GitHub Actions, BitBucket Integrations, Drone plugins, and your own custom plugins.
 * [Various caching options](/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages) to load dependency caches.
 * [Run steps](/docs/category/run-scripts) for running all manner of scripts and commands.
+
+:::caution
+
+You must ensure that the build farm can run the commands required by your build. You may need to modify your build machines or add steps to your pipeline to install necessary tools, libraries, and other dependencies.
+
+:::
 
 ## Run tests
 


### PR DESCRIPTION
## Revised Node tutorial

Preview: https://6450069d914719149e51765c--harness-developer.netlify.app/tutorials/ci-pipelines/build/nodejs

## Additional revisions to Java tutorial

* Reflect changes to starter pipeline
* Make the background step + connection test optional
* Add/promote information about caching
* Add more info to the standalone yaml if users skip the other content.

Preview:  https://6450069d914719149e51765c--harness-developer.netlify.app/tutorials/ci-pipelines/build/java

## Save/Restore cache S3/GCS

* Make them easier to read
* Fix some minor issues
* Replicate language-specific info on the GCS page (previously only on the S3 page)

S3 preview: https://6450069d914719149e51765c--harness-developer.netlify.app/docs/continuous-integration/use-ci/caching-ci-data/saving-cache

GCS preview: https://6450069d914719149e51765c--harness-developer.netlify.app/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs