### PR TITLE
[DOC-1808] [DOC-1604] [DOC-2543] CI Docs - Format Test Reports

### DIFF
--- a/docs/continuous-integration/ci-quickstarts/test-intelligence-concepts.md
+++ b/docs/continuous-integration/ci-quickstarts/test-intelligence-concepts.md
@@ -19,8 +19,10 @@ Test Intelligence is available for the following codebases:
 
 * Java
 * Kotlin
-* .NET Core: Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
 * Scala
+* C# .NET Core, Framework, NUnit
+  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+  * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only.
 
 :::info
 

--- a/docs/continuous-integration/ci-quickstarts/test-intelligence-concepts.md
+++ b/docs/continuous-integration/ci-quickstarts/test-intelligence-concepts.md
@@ -20,9 +20,8 @@ Test Intelligence is available for the following codebases:
 * Java
 * Kotlin
 * Scala
-* C# .NET Core, Framework, NUnit
-  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
-  * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only.
+* C# .NET Core, <!-- Framework, -->NUnit
+  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature. <!-- * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only. -->
 
 :::info
 

--- a/docs/continuous-integration/use-ci/manage-dependencies/background-step-settings.md
+++ b/docs/continuous-integration/use-ci/manage-dependencies/background-step-settings.md
@@ -241,9 +241,9 @@ Select this option to run the container with escalated privileges. This is the e
 
 ### Report Paths
 
-The path to the file(s) that store results in JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+The path to the file(s) that store [results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
-This setting is required for commands run in the Background step to be able to publish test results.
+This setting is required for commands run in the Background step to be able to [publish test results](../set-up-test-intelligence/viewing-tests.md).
 
 ### Environment Variables
 

--- a/docs/continuous-integration/use-ci/prep-ci-pipeline-components.md
+++ b/docs/continuous-integration/use-ci/prep-ci-pipeline-components.md
@@ -60,7 +60,7 @@ With Input Sets and Overlays, you can use the same pipeline for multiple scenari
 
 A CI stage is a subset of a pipeline that contains one major segment of the CI workflow. All stages have stage settings and one or more steps.
 
-To [add a stage to a pipeline](/docs/platform/pipelines/add-a-stage/), select **Add Stage** in the Pipeline Studio. The most essential stage for CI pipelines is the **Build** stage. A **Build** stage often includes [steps](#steps) for building, pushing, and testing code, among other steps.
+To [add a stage to a pipeline](/docs/platform/pipelines/add-a-stage/), select **Add Stage** in the Pipeline Studio. The most essential stage for CI pipelines is the **Build** stage, which includes [steps](#steps) for building, pushing, and testing code, among other steps.
 
 [CI Build stage settings](./set-up-build-infrastructure/ci-stage-settings.md) include [codebase configuration](#codebases), [build infrastructure](#build-infrastructure), [shared paths](#shared-paths), and other [advanced settings](#advanced-stage-and-step-settings).
 

--- a/docs/continuous-integration/use-ci/prep-ci-pipeline-components.md
+++ b/docs/continuous-integration/use-ci/prep-ci-pipeline-components.md
@@ -60,7 +60,7 @@ With Input Sets and Overlays, you can use the same pipeline for multiple scenari
 
 A CI stage is a subset of a pipeline that contains one major segment of the CI workflow. All stages have stage settings and one or more steps.
 
-To [add a stage to a pipeline](/docs/platform/pipelines/add-a-stage/), select **Add Stage** in the Pipeline Studio. The most essential stage for CI pipelines is the **Build** stage, which includes [steps](#steps) for building, pushing, and testing code, among other steps.
+To [add a stage to a pipeline](/docs/platform/pipelines/add-a-stage/), select **Add Stage** in the Pipeline Studio. The most essential stage for CI pipelines is the **Build** stage, which includes [steps](#steps) that test code, build and push images, and upload artifacts, among other steps.
 
 [CI Build stage settings](./set-up-build-infrastructure/ci-stage-settings.md) include [codebase configuration](#codebases), [build infrastructure](#build-infrastructure), [shared paths](#shared-paths), and other [advanced settings](#advanced-stage-and-step-settings).
 

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings.md
@@ -213,9 +213,9 @@ Enable this option to run the container with escalated privileges. This is equiv
 
 ### Report Paths
 
-The path to the file(s) that store test results in the JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+The path to the file(s) that store test [results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
-This setting is required for the Run step to be able to publish test results.
+This setting is required for the Run step to be able to [publish test results](../set-up-test-intelligence/viewing-tests.md).
 
 ### Environment Variables
 

--- a/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings.md
+++ b/docs/continuous-integration/use-ci/run-ci-scripts/run-step-settings.md
@@ -213,7 +213,7 @@ Enable this option to run the container with escalated privileges. This is equiv
 
 ### Report Paths
 
-The path to the file(s) that store test [results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+Specify one or more paths to files that store [test results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
 This setting is required for the Run step to be able to [publish test results](../set-up-test-intelligence/viewing-tests.md).
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
@@ -68,6 +68,7 @@ import TabItem from '@theme/TabItem';
 
 Select the build environment to test.
 
+<!--
 :::info .NET Framework
 
 .NET Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only. You must specify `buildEnvironment: Framework` in your pipeline's YAML, for example:
@@ -86,6 +87,7 @@ Select the build environment to test.
 ```
 
 :::
+-->
 
 ### Framework Version
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
@@ -193,7 +193,7 @@ The following languages and build tools have specific build argument requirement
 
 ## Test Report Paths
 
-The path to the file(s) that store test [results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+Specify one or more paths to files that store [test results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
 This field is required for the Run Tests step to [publish test results](./viewing-tests.md).
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
@@ -68,6 +68,25 @@ import TabItem from '@theme/TabItem';
 
 Select the build environment to test.
 
+:::info .NET Framework
+
+.NET Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only. You must specify `buildEnvironment: Framework` in your pipeline's YAML, for example:
+
+```yaml
+              - step:
+                  type: RunTests
+                  name: runTests
+                  identifier: runTest
+                  spec:
+                    language: Csharp
+                    buildEnvironment: Framework
+                    frameworkVersion: "5.0"
+                    buildTool: Nunitconsole
+                    ...
+```
+
+:::
+
 ### Framework Version
 
 Select the framework version to test.

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Run Tests step settings
-description: The Run Tests step runs tests and enables Test Intelligence.
+description: The Run Tests step runs tests and can be used to enable Test Intelligence.
 sidebar_position: 30
 helpdocs_topic_id: axzckflbt2
 helpdocs_category_id: 4xo13zdnfx
@@ -12,7 +12,7 @@ This topic describes settings for the Harness CI Run Tests step. Use the Run Tes
 
 :::info Hidden settings
 
-* Some settings are located under **Additional Configuration**.
+* Some settings are located under **Additional Configuration** in the Pipeline Studio's visual editor.
 * Some settings are only applicable to certain languages or build tools.
 * Settings specific to containers, such as **Set Container Resources**, are not applicable when using the step in a stage with VM or Harness Cloud build infrastructure.
 
@@ -55,19 +55,35 @@ Select the source code language to build: **C#**, **Java**, **Kotlin**, or **Sca
 
 Additional settings appear if you select **C#** or **Java**.
 
-### Build Environment (C#)
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+```mdx-code-block
+<Tabs>
+  <TabItem value="csharp" label="C#" default>
+```
+
+### Build Environment
 
 Select the build environment to test.
 
-### Framework Version (C#)
+### Framework Version
 
 Select the framework version to test.
 
-### Namespaces (.NET C#)
+### Namespaces
+
+This setting is only available if you select **DOTNET** as the [Build Tool](#build-tool).
 
 Supply a comma-separated list of namespace prefixes that you want to test.
 
-### Do you want to enable Error Tracking? (Java)
+```mdx-code-block
+  </TabItem>
+  <TabItem value="java" label="Java">
+```
+
+### Do you want to enable Error Tracking?
 
 Error tracking helps you be more proactive at discovering and remediating errors early in the software development lifecycle. It help s you more easily discover issues and assess the quality of code before it reaches production.
 
@@ -109,29 +125,77 @@ cd $PROJ_DIR
 
 Error tracking output is reported on the [Error Tracking tab](../viewing-builds.md) when the pipeline runs.
 
-### Test Annotations (Java)
+### Test Annotations
 
 This setting is located under **Additional Configuration**.
 
-Provide a comma-separated list of test annotations used in unit testing. Any method with a specified annotation is treated as a test method. The defaults are: `org.junit.Test, org.junit.jupiter.api.Test, org.testing.annotations.Test`
+You can provide a comma-separated list of test annotations used in unit testing. Any method with a specified annotation is treated as a test method. If not specified, the defaults are: `org.junit.Test, org.junit.jupiter.api.Test, org.testing.annotations.Test`
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```
 
 ## Build Tool
 
-Select the build automation tool. Supported tools vary by **Language**. For example, Harness supports [Bazel](https://bazel.build/), [Maven](https://maven.apache.org/), and [Gradle](https://gradle.org/) for **Java** and [NET CLI](https://docs.microsoft.com/en-us/dotnet/core/tools/) and [Nunit](https://nunit.org/) for **.NET:** .
+Select the build automation tool. Supported tools vary by **Language**.
+
+```mdx-code-block
+<Tabs>
+  <TabItem value="csharp" label="C#" default>
+```
+
+* [DOTNET CLI](https://docs.microsoft.com/en-us/dotnet/core/tools/)
+* [NUnit](https://nunit.org/)
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="Java" label="Java">
+```
+
+* [Bazel](https://bazel.build/)
+* [Maven](https://maven.apache.org/)
+* [Gradle](https://gradle.org/)
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="Kotlin" label="Kotlin">
+```
+
+* [Bazel](https://bazel.build/)
+* [Maven](https://maven.apache.org/)
+* [Gradle](https://gradle.org/)
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="Scala" label="Scala">
+```
+
+* [Bazel](https://bazel.build/)
+* [Maven](https://maven.apache.org/)
+* [Gradle](https://gradle.org/)
+* [Sbt](https://www.scala-sbt.org/)
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```
 
 ## Build Arguments
 
 Enter the arguments for the build tool. These are used as input for the chosen build tool.
 
+The following languages and build tools have specific build argument requirements:
+
 * **Java:** Provide runtime arguments for the tests, for example: `Test -Dmaven.test.failure.ignore=true -DfailIfNoTests=false`.
 * **C#:** Provide runtime arguments for the tests, for example: `/path/to/test.dll /path/to/testProject.dll`. **Do not** inject another instrumenting agent, such as a code-coverage agent, in the argument string.
-* **C#/Nunit:** Provide runtime executables and arguments for the tests, for example: `. "path/to/nunit3-console.exe" path/to/TestProject.dll --result="UnitTestResults.xml" /path/to/testProject.dll`. You must include the executable in the string. **Do not** inject another instrumenting agent, such as a code-coverage agent, in the string.
+* **NUnit C#:** Provide runtime executables and arguments for the tests, for example: `. "path/to/nunit3-console.exe" path/to/TestProject.dll --result="UnitTestResults.xml" /path/to/testProject.dll`. You must include the executable in the string. **Do not** inject another instrumenting agent, such as a code-coverage agent, in the string.
 
-## Report Paths
+## Test Report Paths
 
-The path to the file(s) that store test results in the JUnit XML format. You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
+The path to the file(s) that store test [results in JUnit XML format](../set-up-test-intelligence/test-report-ref.md). You can add multiple paths. If you specify multiple paths, make sure the files contain unique tests to avoid duplicates. [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is supported.
 
-This field is required for the Run Tests step to publish test results.
+This field is required for the Run Tests step to [publish test results](./viewing-tests.md).
 
 ## Pre-Command
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -42,7 +42,7 @@ import TabItem from '@theme/TabItem';
 Add the **Run Tests** step to the **Build** stage. To run tests with Test Intelligence, configure the step as follows:
 
 * Provide a **Name**.
-* Define one or more **Test Report Paths**. JUnit XML format is required. For details about formatting test reports, go to [Format unit test reports](./test-report-ref.md). <!-- update per final topic title -->
+* Define one or more **Test Report Paths**. JUnit XML format is required. For details about formatting test reports, go to [Format test reports](./test-report-ref.md).
 * Select **Run Only Selected Tests**.
 * Specify the **Language**, **Build Tool**, **Build Arguments**, and other language- or tool-specific settings as described in the [Run Tests step settings reference](./configure-run-tests-step-settings.md).
 * Specify the **Container Registry** and **Image**, if required by the build infrastructure.
@@ -59,7 +59,7 @@ Add a `RunTests` step to your pipeline's `CI` stage. To run tests with Test Inte
 
 * `type: RunTests`
 * `name:` Enter a name for the step.
-* `reports:` Specify one or more report paths. JUnit XML format is required. For details about formatting test reports, go to [Format unit test reports](./test-report-ref.md). <!-- update per final topic title -->
+* `reports:` Specify one or more report paths. JUnit XML format is required. For details about formatting test reports, go to [Format test reports](./test-report-ref.md).
 * `runOnlySelectedTests: true`
 * `language`, `buildTool`, `args`, and other language- or tool-specific settings as described in the [Run Tests step settings reference](./configure-run-tests-step-settings.md).
 * `connectorRef` and `image`: Specify if required by the build infrastructure.

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -25,7 +25,9 @@ Test Intelligence is available for the following codebases:
 * Java
 * Kotlin
 * Scala
-* C# .NET Core/NUnit: Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+* C# .NET Core, Framework, NUnit
+  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+  * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only, and you must specify the [build environment](/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings#build-environment) in your pipeline's YAML.
 
 :::
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -25,9 +25,8 @@ Test Intelligence is available for the following codebases:
 * Java
 * Kotlin
 * Scala
-* C# .NET Core, Framework, NUnit
-  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
-  * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only, and you must specify the [build environment](/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings#build-environment) in your pipeline's YAML.
+* C# .NET Core, <!--Framework, -->NUnit
+  * Test Intelligence for .NET is behind the Feature Flag `TI_DOTNET`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.<!-- * Framework is supported on Windows [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures/) only, and you must specify the [build environment](/docs/continuous-integration/use-ci/set-up-test-intelligence/configure-run-tests-step-settings#build-environment) in your pipeline's YAML. -->
 
 :::
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -10,7 +10,7 @@ helpdocs_is_published: true
 
 Test Intelligence (TI) improves unit test time by running only the unit tests required to confirm the quality of the code changes that triggered the build. To learn more about how Test Intelligence works, go to [Get started with Test Intelligence](../../ci-quickstarts/test-intelligence-concepts.md).
 
-You must add the **Run Tests** step to a pipeline's **Build** stage to enable Test Intelligence on that pipeline. The **Run Tests** step executes one or more test on a container image. The first time you enable Test Intelligence on a repo, you must use a webhook-based PR trigger to generate an initial call graph, which sets the baseline for intelligent test selection in future builds.
+You must add the **Run Tests** step to a pipeline's **Build** stage to enable Test Intelligence on that pipeline. The **Run Tests** step executes one or more tests on a container image. The first time you enable Test Intelligence on a repo, you must use a webhook-based PR trigger to generate an initial call graph, which sets the baseline for intelligent test selection in future builds.
 
 You can also [enable test splitting for Test Intelligence](#enable-parallelism-test-splitting-for-test-intelligence) to further optimize your tests.
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/set-up-test-intelligence.md
@@ -331,6 +331,21 @@ Note that while parallelism for Test Intelligence can improve the total time it 
 
 </details>
 
+## Ignore tests or files
+
+If you want Test Intelligence to ignore certain tests or files, create a `.ticonfig.yaml` file in your codebase containing a list of tests and files to ignore, for example:
+
+```yaml
+config:
+  ignore:
+    - "README.md"
+    - ".ticonfig.yaml"
+    - "**/*.go"
+    - "**/Dockerfile*"
+    - "licenses/**/*"
+    - "img/**/*"
+```
+
 ## Troubleshooting
 
 You may encounter the following issues when using Test Intelligence with Maven.

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -141,6 +141,29 @@ If your test tool doesn't automatically produce test results in JUnit XML format
 * [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
 * [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
 
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Powershell
+                    command: |-
+                      cd dotnet-agent/TestProject1
+                      wget -UseBasicParsing https://dot.net/v1/dotnet-install.ps1 -o dotnet-install.ps1
+                      .\dotnet-install.ps1
+                      dotnet build
+
+                      wget https://raw.githubusercontent.com/nunit/nunit-transforms/master/nunit3-junit/nunit3-junit.xslt -o nunit3-junit.xslt
+
+                      "C:/Program Files (x86)/NUnit.org/nunit-console/nunit3-console.exe" dotnet-agent/TestProject1/bin/Debug/net48/TestProject1.dll --result="UnitTestResults.xml;transform=nunit3-junit.xslt"
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - UnitTestResults.xml
+```
+
 <!-- Framework example
 The following example runs tests with [Test Intelligence](./set-up-test-intelligence.md).
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -285,9 +285,7 @@ This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/
         command: |
           npm install
           mkdir /harness/junit
-          mocha test --reporter mocha-junit-reporter
-      envVariables:
-         MOCHA_FILE: "/harness/junit/test-results.xml"
+          mocha test --reporter mocha-junit-reporter --reporter-options mochaFile=./path_to_your/file.xml
       reports:
         type: JUnit
         spec:

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -1,0 +1,28 @@
+---
+title: Format unit test reports
+description: Test reports must be in JUnit XML format.
+sidebar_position: 50
+---
+
+The parsed test report in the [Tests tab](./viewing-tests.md) comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing.
+
+we support only junit but there are converters available for all major languages. 
+
+Examples to work from:
+* gitlab: https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html
+* Circleci: https://circleci.com/docs/collect-test-data/#enabling-formatters 
+
+## C# .NET/NUnit
+
+Use converter to convert nunit to JUnit, such as https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit
+
+https://docs.testmo.com/integrations/automation/nunit
+
+## JUnit XML format resources
+
+Use these resources to learn about JUnit XML formatting.
+
+* [Common JUnit XML format and examples from Testmo](https://github.com/testmoapp/junitxml)
+* [Examples of JUnit XML format mapping from IBM](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=formats-junit-xml-format)
+* [Apache Ant JUnit schema](https://github.com/windyroad/JUnit-Schema)
+* 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -136,10 +136,44 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
 
 If your test tool doesn't automatically produce test results in JUnit XML format, there are JUnit converters, formatters, and plugins available for all major languages. Some examples of conversion tools and corresponding Harness YAML are provided below.
 
-### C# - .NET, NUnit
+### C# - .NET Core, Framework, NUnit
 
-* [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
-* [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
+For C#, you can use conversion tools such as [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit) and [.NET trx2JUnit](https://github.com/gfoidl/trx2junit).
+
+The following example runs tests with [Test Intelligence](./set-up-test-intelligence.md).
+
+```yaml
+                  - step:
+                      type: RunTests
+                      name: runTests
+                      identifier: runTest
+                      spec:
+                        language: Csharp
+                        buildEnvironment: Framework
+                        frameworkVersion: "5.0"
+                        buildTool: Nunitconsole
+                        args: . "C:/Program Files (x86)/NUnit.org/nunit-console/nunit3-console.exe" dotnet-agent/TestProject1/bin/Debug/net48/TestProject1.dll --result="UnitTestResults.xml;transform=nunit3-junit.xslt"
+                        packages: TestProject1
+                        namespaces: TestProject1
+                        runOnlySelectedTests: true
+                        preCommand: |-
+                          wget https://github.com/nunit/nunit-console/releases/download/3.13/NUnit.Console-3.13.0.msi -o nunit.msi
+                          ./nunit.msi
+                          git status
+                          cd dotnet-agent/TestProject1
+                          wget -UseBasicParsing https://dot.net/v1/dotnet-install.ps1 -o dotnet-install.ps1
+                          .\dotnet-install.ps1
+                          dotnet build
+                          cd ..
+                          cd ..
+                          wget https://raw.githubusercontent.com/nunit/nunit-transforms/master/nunit3-junit/nunit3-junit.xslt -o nunit3-junit.xslt
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - UnitTestResults.xml
+                        shell: Powershell
+```
 
 ### Clojure
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -23,6 +23,28 @@ Use these resources to learn about JUnit XML formatting.
 
 Here are some Harness YAML examples for tools that produce JUnit XML output by default.
 
+### C, C++
+
+You can use the [--output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit) command with CTest.
+
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      mkdir build
+                      cmake -S . -B build
+                      ctest --test-dir build --output-junit out.xml
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - /harness/build/out.xml
+```
+
 ### Java - Gradle
 
 This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligence.md).
@@ -113,28 +135,6 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
 ## JUnit converters, formatters, and plugins
 
 If your test tool doesn't automatically produce test results in JUnit XML format, there are JUnit converters, formatters, and plugins available for all major languages. Some examples of conversion tools and corresponding Harness YAML are provided below.
-
-### C, C++
-
-You can use the [--output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit) command with CTest.
-
-```yaml
-              - step:
-                  type: Run
-                  identifier: test
-                  name: Test
-                  spec:
-                    shell: Sh
-                    command: |-
-                      mkdir build
-                      cmake -S . -B build
-                      ctest --test-dir build --output-junit out.xml
-                    reports:
-                      type: JUnit
-                      spec:
-                        paths:
-                          - /harness/build/out.xml
-```
 
 ### C# - .NET, NUnit
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -136,10 +136,11 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
 
 If your test tool doesn't automatically produce test results in JUnit XML format, there are JUnit converters, formatters, and plugins available for all major languages. Some examples of conversion tools and corresponding Harness YAML are provided below.
 
-### C# - .NET Core, Framework, NUnit
+### C# - .NET Core, NUnit
 
 For C#, you can use conversion tools such as [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit) and [.NET trx2JUnit](https://github.com/gfoidl/trx2junit).
 
+<!-- Framework example
 The following example runs tests with [Test Intelligence](./set-up-test-intelligence.md).
 
 ```yaml
@@ -174,6 +175,7 @@ The following example runs tests with [Test Intelligence](./set-up-test-intellig
                               - UnitTestResults.xml
                         shell: Powershell
 ```
+-->
 
 ### Clojure
 

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -23,10 +23,7 @@ Use these resources to learn about JUnit XML formatting.
 
 Here are some Harness YAML examples for tools that produce JUnit XML output by default.
 
-```mdx-code-block
-<Tabs>
-  <TabItem value="Java" label="Java" default>
-```
+### Java - Gradle
 
 This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligence.md).
 
@@ -48,10 +45,7 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
                     runOnlySelectedTests: true
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="php" label="PHP">
-```
+### PHP
 
 ```yaml
               - step:
@@ -70,10 +64,7 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
                           - /harness/phpunit/junit.xml
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="Python" label="Python">
-```
+### Python
 
 ```yaml
               - step:
@@ -99,10 +90,7 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
 
 :::
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="Ruby" label="Ruby - Cucumber">
-```
+### Ruby - Cucumber
 
 ```yaml
               - step:
@@ -122,19 +110,11 @@ This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligen
                           - /harness/cucumber/junit.xml
 ```
 
-```mdx-code-block
-  </TabItem>
-</Tabs>
-```
-
 ## JUnit converters, formatters, and plugins
 
 If your test tool doesn't automatically produce test results in JUnit XML format, there are JUnit converters, formatters, and plugins available for all major languages. Some examples of conversion tools and corresponding Harness YAML are provided below.
 
-```mdx-code-block
-<Tabs>
-  <TabItem value="c" label="C, C++" default>
-```
+### C, C++
 
 You can use the [--output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit) command with CTest.
 
@@ -153,29 +133,20 @@ You can use the [--output-junit](https://cmake.org/cmake/help/latest/manual/ctes
                       type: JUnit
                       spec:
                         paths:
-                          - /build/out.xml
+                          - /harness/build/out.xml
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="csharp" label="C# - .NET, NUnit">
-```
+### C# - .NET, NUnit
 
 * [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
 * [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="clojure" label="Clojure">
-```
+### Clojure
 
 * [Kaocha JUnit Plugin](https://clojars.org/lambdaisland/kaocha-junit-xml)
 * [Clojure.test JUnit Plugin](https://github.com/ruedigergad/test2junit)
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="go" label="Go">
-```
+### Go
 
 You can use the [go-junit-report](https://github.com/jstemmer/go-junit-report) tool.
 
@@ -197,10 +168,7 @@ You can use the [go-junit-report](https://github.com/jstemmer/go-junit-report) t
                           - report.xml
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="java" label="Java - Maven">
-```
+### Java - Maven
 
 This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/) and runs Maven tests with [Test Intelligence](./set-up-test-intelligence.md).
 
@@ -210,7 +178,7 @@ This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/
                   identifier: Run_Tests_with_Intelligence
                   name: Run Tests with Intelligence
                   spec:
-                    args: test -Dmaven.test.failure.ignore=true -DfailIfNoTests=false -T 16C -fae
+                    args: test -Dmaven.test.failure.ignore=true -DfailIfNoTests=false
                     buildTool: Maven
                     enableTestSplitting: true
                     language: Java
@@ -222,10 +190,7 @@ This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/
                     runOnlySelectedTests: true
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="javascript" label="JavaScript">
-```
+### JavaScript
 
 <details>
 <summary>ESLint</summary>
@@ -332,10 +297,7 @@ This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/
 
 </details>
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="ruby" label="Ruby">
-```
+### Ruby
 
 <details>
 <summary>Minitest</summary>
@@ -385,8 +347,3 @@ Add the [RSpec JUnit formatter](https://rubygems.org/gems/rspec_junit_formatter)
 ```
 
 </details>
-
-```mdx-code-block
-  </TabItem>
-</Tabs>
-```

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -1,8 +1,13 @@
 ---
 title: Format test reports
 description: Test reports must be in JUnit XML format to appear on the Tests tab.
-sidebar_position: 50
+sidebar_position: 40
 ---
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
 
 Results on the [Tests tab](./viewing-tests.md) are parsed from test reports specified in the **Report Paths** setting in **Run** and **Run Tests** steps. Test reports must be in [JUnit XML format](https://llg.cubic.org/docs/junit/) to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only.
 
@@ -14,35 +19,374 @@ Use these resources to learn about JUnit XML formatting.
 * [Examples of JUnit XML format mapping from IBM](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=formats-junit-xml-format)
 * [Apache Ant JUnit schema](https://github.com/windyroad/JUnit-Schema)
 
+## Tools with built-in JUnit XML output
+
+Here are some Harness YAML examples for tools that produce JUnit XML output by default.
+
+```mdx-code-block
+<Tabs>
+  <TabItem value="Java" label="Java" default>
+```
+
+This example runs Gradle tests with [Test Intelligence](./set-up-test-intelligence.md).
+
+```yaml
+              - step:
+                  type: RunTests
+                  identifier: Run_Tests_with_Intelligence
+                  name: Run Tests with Intelligence
+                  spec:
+                    args: gradle test --tests
+                    buildTool: Gradle
+                    enableTestSplitting: true
+                    language: Java
+                    reports:
+                      spec:
+                        paths:
+                          - "/harness/results.xml"
+                      type: JUnit
+                    runOnlySelectedTests: true
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="php" label="PHP">
+```
+
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      mkdir -p /harness/phpunit
+                      phpunit --log-junit /harness/phpunit/junit.xml tests
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - /harness/phpunit/junit.xml
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="Python" label="Python">
+```
+
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      . venv/bin/activate
+                      mkdir /harness/test-results
+                      pytest --junitxml=harness/test-results/junit.xml
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - /harness/test-results/junit.xml
+```
+
+:::tip
+
+[Use pytest to run unittest.](https://docs.pytest.org/en/6.2.x/unittest.html)
+
+:::
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="Ruby" label="Ruby - Cucumber">
+```
+
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      bundle check || bundle install
+                      mkdir -p /harness/cucumber
+                      bundle exec cucumber --format junit --out /harness/cucumber/junit.xml
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - /harness/cucumber/junit.xml
+```
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```
+
 ## JUnit converters, formatters, and plugins
 
-If your test tool doesn't automatically produce test results in JUnit XML format, JUnit converters, formatters, and plugins are available for all major languages. Some examples are provided below.
+If your test tool doesn't automatically produce test results in JUnit XML format, there are JUnit converters, formatters, and plugins available for all major languages. Some examples of conversion tools and corresponding Harness YAML are provided below.
 
-### C, C++
+```mdx-code-block
+<Tabs>
+  <TabItem value="c" label="C, C++" default>
+```
 
-* [CTest --output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit)
-### C#, .NET, NUnit
+You can use the [--output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit) command with CTest.
+
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      mkdir build
+                      cmake -S . -B build
+                      ctest --test-dir build --output-junit out.xml
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - /build/out.xml
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="csharp" label="C# - .NET, NUnit">
+```
 
 * [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
 * [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
 
-### Clojure
+```mdx-code-block
+  </TabItem>
+  <TabItem value="clojure" label="Clojure">
+```
 
 * [Kaocha JUnit Plugin](https://clojars.org/lambdaisland/kaocha-junit-xml)
 * [Clojure.test JUnit Plugin](https://github.com/ruedigergad/test2junit)
 
-### Java
+```mdx-code-block
+  </TabItem>
+  <TabItem value="go" label="Go">
+```
 
-* [Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/)
+You can use the [go-junit-report](https://github.com/jstemmer/go-junit-report) tool.
 
-### JavaScript
+```yaml
+              - step:
+                  type: Run
+                  identifier: test
+                  name: Test
+                  spec:
+                    shell: Sh
+                    command: |-
+                      go install github.com/jstemmer/go-junit-report/v2@latest
+                      go test -v ./... | tee report.out
+                      cat report.out | $HOME/go/bin/go-junit-report -set-exit-code > report.xml
+                    reports:
+                      type: JUnit
+                      spec:
+                        paths:
+                          - report.xml
+```
 
-* [ESLint JUnit Formatter](https://eslint.org/docs/latest/use/formatters/#junit)
-* [Jest JUnit Reporter](https://www.npmjs.com/package/jest-junit)
-* [Karma JUnit Reporter](https://www.npmjs.com/package/karma-junit-reporter)
-* [Mocha JUnit Reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+```mdx-code-block
+  </TabItem>
+  <TabItem value="java" label="Java - Maven">
+```
 
-### Ruby
+This example uses the [Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/) and runs Maven tests with [Test Intelligence](./set-up-test-intelligence.md).
 
-* [RSpec JUnit Formatter](https://rubygems.org/gems/rspec_junit_formatter)
-* [Minitest Junit Formatter](https://github.com/aespinosa/minitest-junit)
+```yaml
+              - step:
+                  type: RunTests
+                  identifier: Run_Tests_with_Intelligence
+                  name: Run Tests with Intelligence
+                  spec:
+                    args: test -Dmaven.test.failure.ignore=true -DfailIfNoTests=false -T 16C -fae
+                    buildTool: Maven
+                    enableTestSplitting: true
+                    language: Java
+                    reports:
+                      spec:
+                        paths:
+                          - "target/surefire-reports/*.xml"
+                      type: JUnit
+                    runOnlySelectedTests: true
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+```
+
+<details>
+<summary>ESLint</summary>
+
+[ESLint JUnit Formatter](https://eslint.org/docs/latest/use/formatters/#junit)
+
+```yaml
+  - step:
+      type: Run
+      name: Run ESLint Tests
+      identifier: run_eslint_tests
+      spec:
+        shell: Sh
+        command: |
+          mkdir -p /harness/reports
+          eslint ./src/ --format junit --output-file /harness/reports/eslint.xml
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/reports/eslint.xml"
+```
+
+</details>
+
+<details>
+<summary>Jest</summary>
+
+[Jest JUnit Reporter](https://www.npmjs.com/package/jest-junit)
+
+```yaml
+  - step:
+      type: Run
+      name: Run Jest Tests
+      identifier: run_jest_tests
+      spec:
+        shell: Sh
+        command: |
+          yarn add --dev jest-junit
+          jest --ci --runInBand --reporters=default --reporters=jest-junit
+      envVariables:
+         JEST_JUNIT_OUTPUT_DIR: "/harness/reports"
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/reports/*.xml"
+```
+
+</details>
+
+<details>
+<summary>Karma</summary>
+
+[Karma JUnit Reporter](https://www.npmjs.com/package/karma-junit-reporter)
+
+```yaml
+  - step:
+      type: Run
+      name: Run Karma Tests
+      identifier: run_karma_tests
+      spec:
+        shell: Sh
+        command: |
+          npm install
+          mkdir /harness/junit
+          karma start ./karma.conf.js
+      envVariables:
+        JUNIT_REPORT_PATH: /harness/junit/
+        JUNIT_REPORT_NAME: test-results.xml
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/junit/test-results.xml"
+```
+
+</details>
+
+<details>
+<summary>Mocha</summary>
+
+[Mocha JUnit Reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+
+```yaml
+  - step:
+      type: Run
+      name: Run Mocha Tests
+      identifier: run_mocha_tests
+      spec:
+        shell: Sh
+        command: |
+          npm install
+          mkdir /harness/junit
+          mocha test --reporter mocha-junit-reporter
+      envVariables:
+         MOCHA_FILE: "/harness/junit/test-results.xml"
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/junit/test-results.xml"
+```
+
+</details>
+
+```mdx-code-block
+  </TabItem>
+  <TabItem value="ruby" label="Ruby">
+```
+
+<details>
+<summary>Minitest</summary>
+
+Add the [Minitest Junit Formatter](https://github.com/aespinosa/minitest-junit) to your Gemfile.
+
+```yaml
+  - step:
+      type: Run
+      name: Run RSpec Tests
+      identifier: run_rspec_tests
+      spec:
+        shell: Sh
+        command: |
+          bundle check || bundle install
+          bundle exec rake test --junit
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/report.xml"
+```
+
+</details>
+
+<details>
+<summary>RSpec</summary>
+
+Add the [RSpec JUnit formatter](https://rubygems.org/gems/rspec_junit_formatter) to your Gemfile.
+
+```yaml
+  - step:
+      type: Run
+      name: Run RSpec Tests
+      identifier: run_rspec_tests
+      spec:
+        shell: Sh
+        command: |
+          bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+          mkdir /harness/rspec
+          bundle exec rspec --format progress --format RspecJunitFormatter -o /harness/rspec/rspec.xml
+      reports:
+        type: JUnit
+        spec:
+          paths:
+            - "/harness/rspec/rspec.xml"
+```
+
+</details>
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -138,7 +138,8 @@ If your test tool doesn't automatically produce test results in JUnit XML format
 
 ### C# - .NET Core, NUnit
 
-For C#, you can use conversion tools such as [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit) and [.NET trx2JUnit](https://github.com/gfoidl/trx2junit).
+* [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
+* [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
 
 <!-- Framework example
 The following example runs tests with [Test Intelligence](./set-up-test-intelligence.md).

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref.md
@@ -1,22 +1,10 @@
 ---
-title: Format unit test reports
-description: Test reports must be in JUnit XML format.
+title: Format test reports
+description: Test reports must be in JUnit XML format to appear on the Tests tab.
 sidebar_position: 50
 ---
 
-The parsed test report in the [Tests tab](./viewing-tests.md) comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing.
-
-we support only junit but there are converters available for all major languages. 
-
-Examples to work from:
-* gitlab: https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html
-* Circleci: https://circleci.com/docs/collect-test-data/#enabling-formatters 
-
-## C# .NET/NUnit
-
-Use converter to convert nunit to JUnit, such as https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit
-
-https://docs.testmo.com/integrations/automation/nunit
+Results on the [Tests tab](./viewing-tests.md) are parsed from test reports specified in the **Report Paths** setting in **Run** and **Run Tests** steps. Test reports must be in [JUnit XML format](https://llg.cubic.org/docs/junit/) to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only.
 
 ## JUnit XML format resources
 
@@ -25,4 +13,36 @@ Use these resources to learn about JUnit XML formatting.
 * [Common JUnit XML format and examples from Testmo](https://github.com/testmoapp/junitxml)
 * [Examples of JUnit XML format mapping from IBM](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=formats-junit-xml-format)
 * [Apache Ant JUnit schema](https://github.com/windyroad/JUnit-Schema)
-* 
+
+## JUnit converters, formatters, and plugins
+
+If your test tool doesn't automatically produce test results in JUnit XML format, JUnit converters, formatters, and plugins are available for all major languages. Some examples are provided below.
+
+### C, C++
+
+* [CTest --output-junit](https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit)
+### C#, .NET, NUnit
+
+* [NUnit to JUnit](https://github.com/nunit/nunit-transforms/tree/master/nunit3-junit)
+* [.NET trx2JUnit](https://github.com/gfoidl/trx2junit)
+
+### Clojure
+
+* [Kaocha JUnit Plugin](https://clojars.org/lambdaisland/kaocha-junit-xml)
+* [Clojure.test JUnit Plugin](https://github.com/ruedigergad/test2junit)
+
+### Java
+
+* [Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/)
+
+### JavaScript
+
+* [ESLint JUnit Formatter](https://eslint.org/docs/latest/use/formatters/#junit)
+* [Jest JUnit Reporter](https://www.npmjs.com/package/jest-junit)
+* [Karma JUnit Reporter](https://www.npmjs.com/package/karma-junit-reporter)
+* [Mocha JUnit Reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+
+### Ruby
+
+* [RSpec JUnit Formatter](https://rubygems.org/gems/rspec_junit_formatter)
+* [Minitest Junit Formatter](https://github.com/aespinosa/minitest-junit)

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
@@ -12,14 +12,14 @@ Your pipelines can run tests in **Run** and **Run Tests** steps.
 
 To publish test results, set the **Report Paths** setting in the relevant [Run](../run-ci-scripts/run-step-settings.md) or [Run Tests](./configure-run-tests-step-settings.md) step.
 
-If the test reports are in JUnit XML format, you can review test reports on the **Tests** tab on the [Build details page](../viewing-builds.md).
+If the [test reports are in JUnit XML format](./test-report-ref.md), you can review test reports on the **Tests** tab on the [Build details page](../viewing-builds.md).
 
 ![](./static/viewing-tests-533.png)
 
-If you use Test Intelligence for your unit tests, the **Tests** tab contains information unique to Test Intelligence. To learn more about the contents of this dashboard with Test Intelligence enabled, go to [Enable Test Intelligence](./set-up-test-intelligence.md).
+If you [enabled Test Intelligence](./set-up-test-intelligence.md) for your unit tests, the **Tests** tab contains information unique to Test Intelligence.
 
 You can also publish reports to the **Artifacts** tab. For example, you can [Publish an Allure Report to the Artifacts tab](/tutorials/ci-pipelines/test/allure-report).
 
 ## Troubleshooting: Test suites incorrectly parsed
 
-The parsed test report in the **Tests** tab comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing.
+The parsed test report in the **Tests** tab comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing. For more information, go to [Format test reports](./test-report-ref.md). <!-- update link based on final page title -->

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
@@ -22,4 +22,4 @@ You can also publish reports to the **Artifacts** tab. For example, you can [Pub
 
 ## Troubleshooting: Test suites incorrectly parsed
 
-The parsed test report in the **Tests** tab comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing. For more information, go to [Format test reports](./test-report-ref.md). <!-- update link based on final page title -->
+The parsed test report in the **Tests** tab comes strictly from the provided test reports. Test reports must be in JUnit XML format to appear on the **Tests** tab, because Harness parses test reports that are in JUnit XML format only. It is important to adhere to the standard [JUnit format](https://llg.cubic.org/docs/junit/) to improve test suite parsing. For more information, go to [Format test reports](./test-report-ref.md).

--- a/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
+++ b/docs/continuous-integration/use-ci/set-up-test-intelligence/viewing-tests.md
@@ -1,7 +1,7 @@
 ---
 title: View tests
 description: View the results from CI tests.
-sidebar_position: 40
+sidebar_position: 50
 helpdocs_topic_id: sof7n3qjap
 helpdocs_category_id: flam7377aq
 helpdocs_is_private: false

--- a/tutorials/ci-pipelines/build/ci-java-http-server.md
+++ b/tutorials/ci-pipelines/build/ci-java-http-server.md
@@ -226,7 +226,7 @@ Add a step to run tests against the JHTTP app code. This portion of the tutorial
    * **Build Tool:** Select **Maven**.
    * **Maven setup:** Select **No**.
    * **Build Arguments:** Enter `test`.
-   * **Test Report Paths:** Select **Add** and enter `**/*.xml`.
+   * **Test Report Paths:** Select **Add** and enter `target/surefire-reports/*.xml`.
    * **Post-Command:** Enter `mvn package -DskipTests`.
    * **Packages:** Enter `io.harness`.
    * **Container Registry:** Select your Docker connector.
@@ -271,7 +271,7 @@ In the YAML editor, replace the `Echo Welcome Message` run step block with the f
                       type: JUnit
                       spec:
                         paths:
-                          - "**/*.xml"
+                          - "target/surefire-reports/*.xml"
                   timeout: 30m
 ```
 
@@ -552,7 +552,7 @@ pipeline:
                       type: JUnit
                       spec:
                         paths:
-                          - "**/*.xml"
+                          - "target/surefire-reports/*.xml"
                   timeout: 30m
               - step:
                   type: BuildAndPushDockerRegistry


### PR DESCRIPTION
## DOC-1808, DOC-1604

- New topic about formatting test reports:
- https://646651542bf1342276580365--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-test-intelligence/test-report-ref
- Related changes to link to the new page and some non-technical updates to "Enable Test Intelligence" and "Run Tests step settings"

## DOC-2543

- Use .ticonfig.yaml to ignore tests/files
- https://646651542bf1342276580365--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-test-intelligence/#ignore-tests-or-files
