### PR TITLE
DOC-2823-execution time inputs

### DIFF
--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -95,11 +95,11 @@ You can select the following runtime input types for a step or stage during exec
 You can add execution inputs in this format: `<+input>.default(DefaultInputValue).executionInput()`.  
 For example:  
 * `<+input>.allowedValues(value1,value2).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs.
-* `<+input>.allowedValues(value1,value2).default(value1).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs. `value1` is the default input in this example, so it appears as the deafult input in the prompt.  
+* `<+input>.allowedValues(value1,value2).default(value1).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs. `value1` is the default input in this example, so it appears as the default input in the prompt.  
 
 You can also create default values in templates and later override them during the pipeline execution. 
 
-Here's a YAML example of a stage template with default value, `<+input>.default(“ABC”)`. You can ovveride this default value during pipeline execution. 
+Here's a YAML example of a stage template with default value, `<+input>.default(“ABC”)`. You can override this default value during pipeline execution. 
 ```
 pipeline:
   name: UsingStageTempWithDefaults
@@ -139,7 +139,7 @@ The multiple selection functionality is currently behind the feature flag, `PIE_
 
 ![](./static/runtime-inputs-11.png)
 
-Commas are supported in both allowed and default values. A string with comma must be wrapped within `\'   \'`. 
+Commas are supported in both allowed and default values. A string with a comma must be wrapped within `\'   \'`. 
 
 For example, `<+input>.default(\'london,uk\').allowedValues(\'bengaluru,india\',\'newyork,usa\',\'london,uk\')`.
 
@@ -167,7 +167,7 @@ Save and run the pipeline.
 
 #### Using runtime input with an Approval step
 
-To add a runtime input with an Approval step, create a new pipeline, add an Approval stage, and click **Set Up Stage**.
+To add a runtime input with an Approval step, create a new pipeline, add an Approval stage, and then click **Set Up Stage**.
 
 In the workflow for Execution, click **Approval**.
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -74,7 +74,13 @@ You can use Runtime Inputs for the Service in a CD stage's Service settings.
 
 ### Using runtime inputs during execution
 
-Currently, this feature is behind the feature flag `NG_EXECUTION_INPUT`. Contact [Harness Support](mailto:support@harness.io) to enable the feature. You can add runtime input to a pipeline that runs when a stage or a step is executed. If a custom stage is setup for runtime input, you can enter a shell script when prompted by Harness during execution. If a Harness Approval step is setup for runtime input, when the pipeline executes, you can specify the Harness Groups that will approve that step.
+Currently, this feature is behind the feature flag `NG_EXECUTION_INPUT`. Contact [Harness Support](mailto:support@harness.io) to enable the feature. 
+
+You can add runtime input to a pipeline that runs when a stage or a step is executed. For example, for a custom stage with a Shell Script step that has an runtime input field, you will be prompted to enter the input during the execution just before starting the Shell Script step.
+
+If a custom stage is setup for runtime input, you can enter a shell script when prompted by Harness during execution. 
+
+If a Harness Approval step is setup for runtime input, when the pipeline executes, you can specify the Harness Groups that will approve that step.
 
 You can select the following runtime input types for a step or stage during an execution:  
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -84,11 +84,40 @@ If a Harness Approval step is setup for runtime input, when the pipeline execute
 
 You can select the following runtime input types for a step or stage during an execution:  
 
-* Allowed values (`allowedValues()`)
+* Allowed values (`allowedValues()`)  
 * Default value (optional) (`default()`)
 * Request input value when step/stage is being executed (`executionInput()`)
 
+You can add execution inputs in this format: `<+input>.default(DefaultInputValue).executionInput()`.  
+For example:
+* `<+input>.allowedValues(value1,value2).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs.
+* `<+input>.allowedValues(value1,value2).default(value1).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs. `value1` is the default input in this example, so it appears as the deafult input in the prompt.  
+
 You can also create default values in templates and later override them during the pipeline execution. 
+
+Here's a YAML example of a stage template with default value, `<+input>.default(“ABC”)`. You can ovveride this default value during pipeline execution. 
+```
+pipeline:
+  name: UsingStageTempWithDefaults
+  identifier: UsingStageTempWithDefaults
+  projectIdentifier: svcredesignhinger
+  orgIdentifier: harness
+  tags: {}
+  stages:
+    - stage:
+        name: s1
+        identifier: s1
+        template:
+          templateRef: stageTempDefaults1
+          versionLabel: v1
+          templateInputs:
+            type: Custom
+            variables:
+              - name: var1
+                type: String
+                default: ABC
+                value: <+input>.default(ABC)
+ ```
 
 #### Limitations and requirements
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -14,7 +14,7 @@ Most settings in Harness Pipelines allow you to use Fixed Values, Runtime Inputs
 
 This topic describes each of these options.
 
-### Fixed Values
+### Fixed values
 
 Fixed Values are simply values that you enter manually when you configure a setting and do not change at runtime.
 
@@ -26,7 +26,7 @@ For example, here'a a **Timeout** setting:
 
 You can enter a value for this setting such as `10m 30s`. That value is fixed and nothing that happens at runtime will change it.
 
-### Runtime Inputs
+### Runtime inputs
 
 When you use Runtime Inputs, you are setting placeholders for values that will be provided when you start a Pipeline execution.
 
@@ -44,7 +44,7 @@ For example, you might have an Approval step as part of the stage or Pipeline. O
 
 To do this, when you add certain stage settings to your Pipeline, use Runtime Inputs.
 
-#### How Do Runtime Inputs Work?
+#### How do runtime inputs work?
 
 You select Runtime Input as the option for a setting.
 
@@ -56,51 +56,57 @@ You can enter a value for the variable or use a Harness expression.
 
 Later, if you choose to rerun a Pipeline, the Pipeline will run using the Runtime Inputs you provided the last time it ran.
 
-#### Use Runtime Inputs in a Stage or Pipeline
+#### Use runtime inputs in a stage or pipeline
 
 Using Runtime Inputs templates some or all of a stage or Pipeline's settings. The same Pipeline can be run using different values for all of the Runtime Inputs.
 
-#### CI Example
+#### CI example
 
 You can use Runtime Inputs in a CI stage's Infrastructure. Here's an example using a Runtime Input in the **Namespace** setting.
 
 ![](./static/runtime-inputs-05.png)
 
-#### CD Example
+#### CD example
 
 You can use Runtime Inputs for the Service in a CD stage's Service settings.
 
 ![](./static/runtime-inputs-06.png)
 
-### Using allowed values and default values in runtime inputs
-
-You can set allowed values and a default value for a runtime input. The default value should be present in the list of allowed values. 
-
-For runtime inputs defined for pipelines, stages, and shell script variables, multiple selections are allowed. 
-
-The multiple selection functionality is currently behind the feature flag, `PIE_MULTISELECT_AND_COMMA_IN_ALLOWED_VALUES`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
-
-![](./static/runtime-inputs-11.png)
-
-### Using commas in allowed and default values in runtime inputs
-
-Commas are supported in both allowed and default values. A string with comma must be wrapped within `\'   \'`. 
-
-For example, `<+input>.default(\'london,uk\').allowedValues(\'bengaluru,india\',\'newyork,usa\',\'london,uk\')`.
-
-### Using Runtime Inputs During Execution
+### Using runtime inputs during execution
 
 Currently, this feature is behind the feature flag `NG_EXECUTION_INPUT`. Contact [Harness Support](mailto:support@harness.io) to enable the feature. You can add runtime input to a pipeline that runs when a stage or a step is executed. If a custom stage is setup for runtime input, you can enter a shell script when prompted by Harness during execution. If a Harness Approval step is setup for runtime input, when the pipeline executes, you can specify the Harness Groups that will approve that step.
 
-#### Limitations and Requirements
+You can select the following runtime input types for a step or stage during an execution:  
+
+* Allowed values (`allowedValues()`)
+* Default value (optional) (`default()`)
+* Request input value when step/stage is being executed (`executionInput()`)
+
+You can also create default values in templates and later override them during the pipeline execution. 
+
+#### Limitations and requirements
 
 The following limitations and requirements apply to this feature:
 
 - A Harness user must have the **Pipeline Execute** permission to be able to submit runtime input during execution.
 
-#### Using Runtime Input During Execution With a Shell Script
+#### Using allowed values and default values in runtime inputs
 
-If a runtime input was specified for a step with execution input, you are prompted to enter the values before the step begins. Harness prompts you for values in the Step details. The Pipeline runs when the values are entered.
+You can set allowed values and a default value for a runtime input. The default value should be present in the list of allowed values. 
+
+Multiple selection is allowed for runtime inputs defined for pipelines, stages, and shell script variables. 
+
+The multiple selection functionality is currently behind the feature flag, `PIE_MULTISELECT_AND_COMMA_IN_ALLOWED_VALUES`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
+![](./static/runtime-inputs-11.png)
+
+Commas are supported in both allowed and default values. A string with comma must be wrapped within `\'   \'`. 
+
+For example, `<+input>.default(\'london,uk\').allowedValues(\'bengaluru,india\',\'newyork,usa\',\'london,uk\')`.
+
+#### Using runtime input during execution with a shell script
+
+If a runtime input was specified for a step with execution input, you are prompted to enter the values before the step begins. Harness prompts you for values in the step details. The pipeline runs when the values are entered.
 
 When you create a pipeline with a custom stage, add a variable to the step and select **Running input**. To specify an input as runtime input during execution, add the following to the input by substituting the value within the quotes:
 
@@ -120,9 +126,9 @@ In **Execution**, click **Add Step for a Shell Script**, select **Shell Script**
 
 Save and run the pipeline.
 
-#### Using Runtime Input with an Approval Step
+#### Using runtime input with an Approval step
 
-To add a runtime input with an Approval step, create a new pipeline, add an Approval stage, and click Set Up Stage.
+To add a runtime input with an Approval step, create a new pipeline, add an Approval stage, and click **Set Up Stage**.
 
 In the workflow for Execution, click **Approval**.
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -74,22 +74,26 @@ You can use Runtime Inputs for the Service in a CD stage's Service settings.
 
 ### Using runtime inputs during execution
 
+:::info
+
 Currently, this feature is behind the feature flag `NG_EXECUTION_INPUT`. Contact [Harness Support](mailto:support@harness.io) to enable the feature. 
 
-You can add runtime input to a pipeline that runs when a stage or a step is executed. For example, for a custom stage with a Shell Script step that has an runtime input field, you will be prompted to enter the input during the execution just before starting the Shell Script step.
+:::
 
-If a custom stage is setup for runtime input, you can enter a shell script when prompted by Harness during execution. 
+You can add runtime inputs to a pipeline during a step or stage execution. For example, for a custom stage with a Shell Script step with a runtime input field, you will be prompted to enter the input during the execution just before starting the Shell Script step.
 
-If a Harness Approval step is setup for runtime input, when the pipeline executes, you can specify the Harness Groups that will approve that step.
+If a custom stage is setup with runtime input, you can enter a shell script when prompted by Harness during execution. 
 
-You can select the following runtime input types for a step or stage during an execution:  
+If a Harness Approval step is setup with runtime input, you can specify the Harness groups that will approve that step during pipeline execution.
+
+You can select the following runtime input types for a step or stage during execution:  
 
 * Allowed values (`allowedValues()`)  
 * Default value (optional) (`default()`)
 * Request input value when step/stage is being executed (`executionInput()`)
 
 You can add execution inputs in this format: `<+input>.default(DefaultInputValue).executionInput()`.  
-For example:
+For example:  
 * `<+input>.allowedValues(value1,value2).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs.
 * `<+input>.allowedValues(value1,value2).default(value1).executionInput()` - During execution, you will be prompted to enter `value 1` and `value 2` inputs. Only `value1` and `value2` values will be allowed as valid inputs. `value1` is the default input in this example, so it appears as the deafult input in the prompt.  
 


### PR DESCRIPTION
Added execution time runtime input types

You can select the following runtime input types for a step or stage during an execution:  

* Allowed values (`allowedValues()`)
* Default value (optional) (`default()`)
* Request input value when step/stage is being executed (`executionInput()`)
