### PR TITLE
[DOC-2299] Removed custom secret manager feature flag

### DIFF
--- a/docs/first-gen/firstgen-platform/techref-category/api/use-custom-secrets-manager-api.md
+++ b/docs/first-gen/firstgen-platform/techref-category/api/use-custom-secrets-manager-api.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Currently, this feature is behind the Feature Flag `CUSTOM_SECRETS_MANAGER`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.Harness provides first-class support and built-in integration for the most common secret managers. If you are using a [secret manager](../../security/secrets-management/secret-management.md) that Harness does provide first-class support for, you can configure and use your secret manager by using the Harness Custom Secrets Manager.
+Harness provides first-class support and built-in integration for the most common secret managers. If you are using a [secret manager](../../security/secrets-management/secret-management.md) that Harness does provide first-class support for, you can configure and use your secret manager by using the Harness Custom Secrets Manager.
 
 This topic describes how to create, update, and delete a Custom Secrets Manager using the Harness API.
 

--- a/docs/first-gen/firstgen-platform/techref-category/api/use-custom-secrets-manager-api.md
+++ b/docs/first-gen/firstgen-platform/techref-category/api/use-custom-secrets-manager-api.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-Harness provides first-class support and built-in integration for the most common secret managers. If you are using a [secret manager](../../security/secrets-management/secret-management.md) that Harness does provide first-class support for, you can configure and use your secret manager by using the Harness Custom Secrets Manager.
+Harness provides first-class support and built-in integration for the most common [secret managers](../../security/secrets-management/secret-management.md). If you're not using a secret manager that's supported, you can configure it by using the Harness Custom Secrets Manager.
 
 This topic describes how to create, update, and delete a Custom Secrets Manager using the Harness API.
 


### PR DESCRIPTION
Removed feature flag corresponding to Custom secret manager from the FirstGen API doc.

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x ] Tested Locally
- [ ] *Optional* Screen Shoot. 
