### PR TITLE
CDS-56983-added secret manager connector variables syntax

### DIFF
--- a/docs/continuous-delivery/deploy-srv-diff-platforms/custom-deployments/custom-deployment-tutorial.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/custom-deployments/custom-deployment-tutorial.md
@@ -459,12 +459,19 @@ Here's the expressions referencing these variables:
 <+infra.variables.test12>
 ```
 
+Reference [Secret Manager](/docs/platform/Secrets/Secrets-Management/add-secrets-manager) connector variables with the following syntax:
+
+* [AWS KMS](/docs/platform/Secrets/Secrets-Management/add-an-aws-kms-secrets-manager): `<+infra.variables.AwsKms.spec.credential.type>`
+* [AWS Secrets Manager](/docs/platform/Secrets/Secrets-Management/add-an-aws-secret-manager): `<+infra.variables.AwsSecretsManager.spec.region>`
+* [Azure Key Vault](/docs/platform/Secrets/Secrets-Management/azure-key-vault): `<+infra.variables.AzureKeyVault.spec.vaultName>`
+* [Google KMS](/docs/platform/Secrets/Secrets-Management/add-google-kms-secrets-manager): `<+infra.variables.GcpKms.spec.keyName>`
+* [Google Cloud secret manager](/docs/platform/Secrets/Secrets-Management/add-a-google-cloud-secret-manager): `<+infra.variables.GcpSecMan.spec.credentialsRef.identifier>`
+* [Custom secret manager](/docs/platform/Secrets/Secrets-Management/custom-secret-manager): `<+infra.variables.CustomSecMan.spec.isDefault>`
+* [HashiCorp Vault](/docs/platform/Secrets/Secrets-Management/add-hashicorp-vault): `<+infra.variables.HashiCorp.spec.vaultUrl>`
 
 #### Overwriting variables
 
 When you define the Infrastructure Definition in your stage **Environment**, you can override any variable values.
-
-
 
 | **Deployment Template** | **Infrastructure Definition** |
 | --- | --- |

--- a/docs/continuous-delivery/deploy-srv-diff-platforms/custom-deployments/custom-deployment-tutorial.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/custom-deployments/custom-deployment-tutorial.md
@@ -459,7 +459,7 @@ Here's the expressions referencing these variables:
 <+infra.variables.test12>
 ```
 
-Reference [Secret Manager](/docs/platform/Secrets/Secrets-Management/add-secrets-manager) connector variables with the following syntax:
+Reference [Secret Manager](/docs/platform/Secrets/Secrets-Management/add-secrets-manager) connector variables using the following expressions.
 
 * [AWS KMS](/docs/platform/Secrets/Secrets-Management/add-an-aws-kms-secrets-manager): `<+infra.variables.AwsKms.spec.credential.type>`
 * [AWS Secrets Manager](/docs/platform/Secrets/Secrets-Management/add-an-aws-secret-manager): `<+infra.variables.AwsSecretsManager.spec.region>`


### PR DESCRIPTION
Added the following syntax:

AWS KMS: <+infra.variables.AwsKms.spec.credential.type>
AWS secret manager: <+infra.variables.AwsSecretsManager.spec.region>
Azure KeyVault: <+infra.variables.AzureKeyVault.spec.vaultName>
GCP KMS: <+infra.variables.GcpKms.spec.keyName>
GCP Secret manager: <+infra.variables.GcpSecMan.spec.credentialsRef.identifier>
Custom secret manager: <+infra.variables.CustomSecMan.spec.isDefault>
Hashicorp Vault: <+infra.variables.HashiCorp.spec.vaultUrl>
