### PR TITLE
[CDS-69726]: document repeat strategy limitation for command steps

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
@@ -26,6 +26,8 @@ For SSH and WinRM, the Command step(s) is added automatically when you select th
 
 Also, the looping strategy needed to run the Command step on each target host is set automatically to **Repeat**.
 
+> **_NOTE:_**  Only **Repeat** looping strategy is supported with Command steps
+
 You can edit or add any automatically-added Command step.
 
 For more information, go to:

--- a/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
@@ -26,7 +26,7 @@ For SSH and WinRM, the Command step(s) is added automatically when you select th
 
 Also, the looping strategy needed to run the Command step on each target host is set automatically to **Repeat**.
 
-> **_NOTE:_**  Only **Repeat** looping strategy is supported with Command steps
+> **_NOTE:_**  Only **Repeat** looping strategy is supported with Command step
 
 You can edit or add any automatically-added Command step.
 

--- a/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/download-and-copy-artifacts-using-the-command-step.md
@@ -26,7 +26,11 @@ For SSH and WinRM, the Command step(s) is added automatically when you select th
 
 Also, the looping strategy needed to run the Command step on each target host is set automatically to **Repeat**.
 
-> **_NOTE:_**  Only **Repeat** looping strategy is supported with Command step
+:::info Note
+
+The Command step supports only the **Repeat** looping strategy.
+
+:::
 
 You can edit or add any automatically-added Command step.
 


### PR DESCRIPTION
# Harness Developer Pull Request
Document that 
"Only **Repeat** looping strategy is supported with Command steps"
## What Type of PR is This?

- [x] Issue
- [ ] Feature
- [ ] Maintenance/Chore

![image](https://github.com/harness/developer-hub/assets/50823735/e39c4796-38e6-4a3e-98f2-66b83ec4947d)

