### PR TITLE
[DOC-3214] Remove PL-38937 from 79411 release notes

### DIFF
--- a/release-notes/platform.md
+++ b/release-notes/platform.md
@@ -29,11 +29,9 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 ### Harness Manager delegate new features
 
-The features below are available with version 79411 and do not require a new delegate version. For Harness Delegate version-specific features, go to [Delegate release notes](/release-notes/delegate).
+The feature below is available with version 79411 and does not require a new delegate version. For Harness Delegate version-specific features, go to [Delegate release notes](/release-notes/delegate).
 
-- You can now fetch the list of delegates registered to an account using the Harness API. You can also filter these by scope, tags, status, and version. (PL-37981, ZD-40508,40688)
-
-- You can now use the legacy UI to create delegates. (PL-38937)
+- You can now fetch the list of delegates registered to an account using the Harness API. You can also filter these by scope, tags, status, and version. (PL-37981, ZD-40508, 40688)
 
 ### All other Platform new features
 

--- a/release-notes/whats-new.md
+++ b/release-notes/whats-new.md
@@ -67,11 +67,9 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 #### Harness Manager delegate
 
-The features below are available with version 79411 and do not require a new delegate version. For Harness Delegate version-specific features, go to [Delegate release notes](/release-notes/delegate).
+The feature below is available with version 79411 and does not require a new delegate version. For Harness Delegate version-specific features, go to [Delegate release notes](/release-notes/delegate).
 
-- You can now fetch the list of delegates registered to an account using the Harness API. You can also filter these by scope, tags, status, and version. (PL-37981, ZD-40508,40688)
-
-- You can now use the legacy UI to create delegates. (PL-38937)
+- You can now fetch the list of delegates registered to an account using the Harness API. You can also filter these by scope, tags, status, and version. (PL-37981, ZD-40508, 40688)
 
 #### All other Platform new features
 


### PR DESCRIPTION
PL-38937: Add back old Delegate Creation flow on UI was on the list for 79411, it's [published](https://developer.harness.io/release-notes/platform). This is now scheduled for the 795xx release. Remove the ticket from 79411 release notes and send to Rashmi to include in 795xx release notes.

For reviewers, previews are available:

[Harness Platform](https://647df53d79e95e193811e54b--harness-developer.netlify.app/release-notes/platform)
[What's new](https://647df53d79e95e193811e54b--harness-developer.netlify.app/release-notes/whats-new)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
