### PR TITLE
FFM-8131: adds notes to sdk's on whether supported on SMP

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
@@ -10,6 +10,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
 This topic describes how to use the Harness Feature Flags Android SDK for your Android application. 
 
 For getting started quickly, you can use our [sample code from the SDK README](https://github.com/harness/ff-android-client-sdk/blob/main/README.md). You can also [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and run a sample application from the [Android SDK GitHub Repository.](https://github.com/harness/ff-android-client-sdk)

--- a/docs/feature-flags/ff-sdks/client-sdks/flutter-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/flutter-sdk-reference.md
@@ -10,6 +10,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
 This topic describes how to use the Harness Feature Flags SDK for your Flutter application. 
 
 For getting started quickly, you can use our [sample code from the SDK README](https://github.com/harness/ff-flutter-client-sdk/blob/main/README.md). You can also [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and run a sample application from the [Flutter SDK GitHub Repository.](https://github.com/harness/ff-flutter-client-sdk)

--- a/docs/feature-flags/ff-sdks/client-sdks/ios-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/ios-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This topic describes how to use the Harness Feature Flags iOS SDK for your iOS application. 
 

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This topic describes how to use the Harness Feature Flags Javascript SDK for your JavaScript application.
 

--- a/docs/feature-flags/ff-sdks/client-sdks/react-client.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/react-client.md
@@ -9,6 +9,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
 
 This topic describes how to use the Harness Feature Flags SDK for your React Client application. 
 

--- a/docs/feature-flags/ff-sdks/client-sdks/react-native-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/react-native-sdk-reference.md
@@ -10,6 +10,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
 
 This topic describes how to use the Harness Feature Flags SDK for your React Native application. 
 

--- a/docs/feature-flags/ff-sdks/client-sdks/xamarin-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/xamarin-sdk-reference.md
@@ -10,6 +10,11 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
+
 This topic describes how to use the Harness Feature Flags SDK for your Xamarin application. You can use the Xamarin SDK for Android and iOS.
 
 For getting started quickly, you can [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and run a sample application from the  [Xamarin Client Sample GitHub Repository](https://github.com/harness/ff-xamarin-client-sample).

--- a/docs/feature-flags/ff-sdks/server-sdks/apex-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/apex-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This SDK is currently in beta. This topic describes how to use the Harness Feature Flags Apex SDK for your Apex application.
 

--- a/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/erlang-sdk-reference.md
@@ -6,6 +6,10 @@ sidebar_position: 15
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
+
 This topic describes how to use the Harness Feature Flags Erlang SDK for your Erlang or Elixir based application. 
 
 For getting started quickly:

--- a/docs/feature-flags/ff-sdks/server-sdks/feature-flag-sdks-go-application.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/feature-flag-sdks-go-application.md
@@ -10,6 +10,11 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpyes from '../shared/note-smp-compatible.md'
+
+<Smpyes />
+
+
 This topic describes how to use the Harness Feature Flags Go SDK for your Go application. 
 
 For getting started quickly, you can use our [sample code from the SDK README](https://github.com/harness/ff-golang-server-sdk). You can also [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and run a sample application from the [Go SDK GitHub Repository.](https://github.com/harness/ff-golang-server-sdk)

--- a/docs/feature-flags/ff-sdks/server-sdks/integrate-feature-flag-with-java-sdk.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/integrate-feature-flag-with-java-sdk.md
@@ -10,6 +10,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpyes from '../shared/note-smp-compatible.md'
+
+<Smpyes />
+
 
 This topic describes how to use the Harness Feature Flags Java SDK for your Java application.
 

--- a/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 :::caution 
 In Version 1.1.3 of the .NET SDK, the package name for installing the SDK changed from **ff-netF48-server-sdk** to **ff-dotnet-server-sdk**. To use this version, make sure you remove the old package name and use the new one. You can do this by using the following commands:  

--- a/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This topic describes how to use the Harness Feature Flags Node.js SDK for your Node.js application.
 

--- a/docs/feature-flags/ff-sdks/server-sdks/php-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/php-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This topic describes how to use the Harness Feature Flags PHP SDK for your PHP application.
 

--- a/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
@@ -10,6 +10,9 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpno from '../shared/note-smp-not-compatible.md'
+
+<Smpno />
 
 This topic describes how to use the Harness Feature Flags Java SDK for your Java application.
 

--- a/docs/feature-flags/ff-sdks/server-sdks/ruby-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/ruby-sdk-reference.md
@@ -10,6 +10,10 @@ helpdocs_is_published: true
 
 import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 
+import Smpyes from '../shared/note-smp-compatible.md'
+
+<Smpyes />
+
 
 This topic describes how to use the Harness Feature Flags Ruby SDK for your Java application.
 

--- a/docs/feature-flags/ff-sdks/shared/note-smp-compatible.md
+++ b/docs/feature-flags/ff-sdks/shared/note-smp-compatible.md
@@ -1,0 +1,3 @@
+:::info note
+This SDK works with Harness Self-Managed Enterprise Edition (on premises).
+::: 

--- a/docs/feature-flags/ff-sdks/shared/note-smp-not-compatible.md
+++ b/docs/feature-flags/ff-sdks/shared/note-smp-not-compatible.md
@@ -1,3 +1,3 @@
 :::info note
-This SDK does is not currently supported on Harness Self-Managed Enterprise Edition (on premises).
+This SDK is not currently supported on Harness Self-Managed Enterprise Edition (on premises).
 :::

--- a/docs/feature-flags/ff-sdks/shared/note-smp-not-compatible.md
+++ b/docs/feature-flags/ff-sdks/shared/note-smp-not-compatible.md
@@ -1,0 +1,3 @@
+:::info note
+This SDK does is not currently supported on Harness Self-Managed Enterprise Edition (on premises).
+:::


### PR DESCRIPTION
[**Link to preview**](https://64805943cf8b0653c101b299--harness-developer.netlify.app/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference)

This PR adds a note at top of each SDK topic to say whether or not SDK works with SMP.