### PR TITLE
FFM-7363 Add SDK codes to Python and Ruby docs

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
@@ -278,3 +278,31 @@ def main():
 if __name__ == "__main__":  
     main()
 ```
+
+## Troubleshooting 
+The SDK logs the following codes for certain lifecycle events, e.g. authentication, which can aid troubleshooting.
+
+|          |                                                                                          |
+|----------|------------------------------------------------------------------------------------------|
+| **Code** | **Description**                                                                          |
+| **1000** | Successfully initialized                                                                 |
+| **1001** | Failed to initialize due to authentication error                                         |
+| **1002** | Failed to initialize due to a missing or empty API key                                   |
+| **1003** | `wait_for_initialzation` was called and the SDK is waiting for initialzation to complete |
+| **2000** | Successfully authenticated                                                               |
+| **2001** | Authentication failed with a non recoverable error                                       |
+| **2002** | Authentication failed and is retrying                                                    |
+| **2003** | Authentication failed and max retries have been exceeded                                 |
+| **4000** | Polling service started                                                                  |
+| **4001** | Polling service stopped                                                                  |
+| **5000** | Streaming service started                                                                |
+| **5001** | Streaming service stopped                                                                |
+| **5002** | Streaming event received                                                                 |
+| **5003** | Streaming disconnected and is retrying to connect                                        |
+| **5004** | Streaming stopped                                                                        |
+| **6000** | Evaluation was successfully                                                              |
+| **6001** | Evaluation failed and the default value was returned                                     |
+| **7000** | Metrics service has started                                                              |
+| **7001** | Metrics service has stopped                                                              |
+| **7002** | Metrics posting failed                                                                   |
+| **7003** | Metrics posting success                                                                  |

--- a/docs/feature-flags/ff-sdks/server-sdks/ruby-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/ruby-sdk-reference.md
@@ -352,3 +352,31 @@ clients.each do |name, client|
 end  
 
 ```
+
+## Troubleshooting
+The SDK logs the following codes for certain lifecycle events, e.g. authentication, which can aid troubleshooting.
+
+|          |                                                                                          |
+|----------|------------------------------------------------------------------------------------------|
+| **Code** | **Description**                                                                          |
+| **1000** | Successfully initialized                                                                 |
+| **1001** | Failed to initialize due to authentication error                                         |
+| **1002** | Failed to initialize due to a missing or empty API key                                   |
+| **1003** | `wait_for_initialzation` was called and the SDK is waiting for initialzation to complete |
+| **2000** | Successfully authenticated                                                               |
+| **2001** | Authentication failed with a non recoverable error                                       |
+| **2002** | Authentication failed and is retrying                                                    |
+| **2003** | Authentication failed and max retries have been exceeded                                 |
+| **4000** | Polling service started                                                                  |
+| **4001** | Polling service stopped                                                                  |
+| **5000** | Streaming service started                                                                |
+| **5001** | Streaming service stopped                                                                |
+| **5002** | Streaming event received                                                                 |
+| **5003** | Streaming disconnected and is retrying to connect                                        |
+| **5004** | Streaming stopped                                                                        |
+| **6000** | Evaluation was successfully                                                              |
+| **6001** | Evaluation failed and the default value was returned                                     |
+| **7000** | Metrics service has started                                                              |
+| **7001** | Metrics service has stopped                                                              |
+| **7002** | Metrics posting failed                                                                   |
+| **7003** | Metrics posting success                                                                  |


### PR DESCRIPTION
# What
We have improved the logging in the Python and Ruby SDKS where on certain lifecycle events, we will log a set code. This PR adds a table of codes as defined in our wiki page here: https://harness.atlassian.net/wiki/spaces/FFM/pages/21356052573/SDK+Codes

Note: The Ruby SDK has already been released with these codes a little while ago, so we are backfilling the docs here, but the Python release with these codes is pending, so I will mark as do not merge for now.