### PR TITLE
[DOC-3260] Add helm 2 deprecation notice to delegate release notes, scrub helm 2 content

### DIFF
--- a/docs/platform/2_Delegates/delegate-reference/common-delegate-profile-scripts.md
+++ b/docs/platform/2_Delegates/delegate-reference/common-delegate-profile-scripts.md
@@ -56,53 +56,6 @@ mv ./terraform /usr/bin/
 terraform --version
 ```
 
-### Helm 2
-
-The following script installs Helm and Tiller in the delegate cluster:
-
-```
-# Add the Helm version that you want to install  
-HELM_VERSION=v2.14.0  
-# v2.13.0  
-# v2.12.0  
-# v2.11.0  
-  
-export DESIRED_VERSION=${HELM_VERSION}  
-  
-echo "Installing Helm $DESIRED_VERSION ..."  
-  
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash  
-  
-# If Tiller is already installed in the cluster   
-helm init --client-only  
-  
-# If Tiller is not installed in the cluster  
-# helm init    
-```
-The `helm init` command is used with Helm 2 to install Tiller into a Kubernetes cluster. The command does not exist in Helm 3; nor is Tiller used in Helm 3. `DESIRED_VERSION` is used by a function in the [Helm install script](https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get). If Helm is installed in a different cluster than the delegate, make sure the `kubeconfig` in the delegate cluster references the correct cluster. Use the following command to set the context.
-
-```
-kubectl config current-context cluster_name
-```
-
-If you are using TLS for communication between Helm and Tiller, ensure that you use the `--tls` parameter with your commands. For more information, go to [Using SSL Between Helm and Tiller](https://docs.helm.sh/using_helm/#using-ssl-between-helm-and-tiller) from Helm, and the section **Securing your Helm Installation** in that document. The following example shows how to add a Helm chart from a private repository using the secrets `repoUsername` and `repoPassword` from Harness [Text Secrets](../../Secrets/2-add-use-text-secrets.md). 
-
-```
-# Alternate installation method  
-# curl https://raw.githubusercontent.com/helm/helm/master/scripts/get> get_helm.sh  
-# chmod 700 get_helm.sh  
-# ./get_helm.sh  
-  
-curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash  
-  
-helm init --client-only  
-  
-helm repo add --username <+secrets.getValue("repoUsername")> --password <+secrets.getValue("repoPassword")> nginx https://charts.bitnami.com/bitnami  
-  
-helm repo update
-```
-The `helm init` command does not exist in Helm 3. This command is used with Helm 2 to install Tiller into a Kubernetes cluster. Tiller is not used in Helm 3.
-
 ### Helm 3
 
 You do not need to add a script for Helm 3. Harness includes Helm 3 support in any Delegate that can connect to the target Kubernetes cluster.

--- a/docs/platform/2_Delegates/install-delegates/install-a-kubernetes-delegate.md
+++ b/docs/platform/2_Delegates/install-delegates/install-a-kubernetes-delegate.md
@@ -400,7 +400,7 @@ The Java Runtime Environment version used by the delegate.
  
 #### HELM3_PATH, HELM_PATH 
 
-When you Install and run a new Harness Delegate, Harness includes Helm 3 support automatically. In some cases, you may want to use one of the custom Helm binaries available from [Helm release](https://github.com/helm/helm/releases). For a Helm 3 binary, enter the local path to the binary in `HELM3_PATH`. For a Helm 2 binary, enter the path local path to the binary in `HELM_PATH`. If you are performing a [Native Helm deployment](/docs/continuous-delivery/deploy-srv-diff-platforms/helm/helm-cd-quickstart), do not use `HELM_PATH` for the Helm 2 binary. Harness looks for the Helm 2 binary on the delegate in its standard path, such as `/usr/local/bin/helm`. 
+When you Install and run a new Harness Delegate, Harness includes Helm 3 support automatically. In some cases, you may want to use one of the custom Helm binaries available from [Helm release](https://github.com/helm/helm/releases). For a Helm 3 binary, enter the local path to the binary in `HELM3_PATH`.
 
   ```
   - name: HELM3_PATH  value: ""- name: HELM_PATH  value: ""

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -23,6 +23,11 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 Harness NextGen release 79516 includes the following changes for the Harness Delegate.
 
+### Deprecation notice
+
+import Helmdep from '/release-notes/shared/helm-2-deprecation-notice.md'
+
+<Helmdep />
 
 ```mdx-code-block
 <Tabs>

--- a/release-notes/shared/helm-2-deprecation-notice.md
+++ b/release-notes/shared/helm-2-deprecation-notice.md
@@ -1,4 +1,4 @@
-To safeguard your operations and protect against potential security vulnerabilities, Harness will launch an update to deprecate the Helm 2 binary from delegates with an immutable image type (image tag yy.mm.xxxxx) on July 30, 2023. For information on delegate types, go to [Delegate image types](/docs/platform/delegates/delegate-concepts/delegate-image-types).
+To safeguard your operations and protect against potential security vulnerabilities, Harness will launch an update to deprecate the Helm 2 binary from delegates with an immutable image type (image tag `yy.mm.xxxxx`) on **July 30, 2023**. For information on delegate types, go to [Delegate image types](/docs/platform/delegates/delegate-concepts/delegate-image-types).
 
 Helm 2 was deprecated by the Helm community in November 2020 and is no longer supported by Helm. If you continue to maintain the Helm 2 binary on your delegate, it might introduce high and critical vulnerabilities and put your infrastructure at risk.
 


### PR DESCRIPTION
Add helm 2 deprecation notice to delegate release notes, scrub helm 2 content

For reviewers, previews are available:
[Delegate release notes](https://6488844cc35cd21119e24c05--harness-developer.netlify.app/release-notes/delegate)
[Common delegate initialization scripts](https://6488844cc35cd21119e24c05--harness-developer.netlify.app/docs/platform/Delegates/delegate-reference/common-delegate-profile-scripts)
[Install a legacy Kubernetes delegate](https://6488844cc35cd21119e24c05--harness-developer.netlify.app/docs/platform/Delegates/install-delegates/install-a-kubernetes-delegate)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
