### PR TITLE
FFM-8260: adds java sdk v1.2.3 relnotes

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
@@ -31,7 +31,7 @@ Make sure you read and understand:
 
 ## Version
 
-The current version of this SDK is **1.0.18.** To use this version of the SDK, you also need to use Android API level 19 or higher.
+The current version of this SDK is **1.1.0.** To use this version of the SDK, you also need to use Android API level 19 or higher.
 
 ## Requirements
 

--- a/docs/feature-flags/ff-sdks/server-sdks/integrate-feature-flag-with-java-sdk.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/integrate-feature-flag-with-java-sdk.md
@@ -30,7 +30,7 @@ Make sure you read and understand:
 
 ## Version
 
-The current version of this SDK is **1.2.2.**
+The current version of this SDK is **1.2.3.**
 
 ## Requirements
 

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -46,6 +46,18 @@ This release does not include early access features.
 
 * The Create a new flag button did not behave as expected on the onboarding screen if there were existing flags. This issue has been fixed. (FFM-8019)
 
+#### Feature Flags SDKs
+
+The **Java** server SDK has been updated to version **1.2.3** with the following updates.
+
+* There were reports of customers having difficulty running the SDK because of a missing dependency, `oksse`. Unless users have the JitPack repo in their POM/Gradle file, they are likely to have this problem at compile time. With this fix, we've removed the `oksse` dependency and now use `okhttp-sse` instead. (FFM-5915)
+
+* Added `Harness-SDK-Info`, `Harness-EnvironmentID` and `Harness-AccountID` HTTP headers to outbound HTTP connections. (FFM-7037)
+
+* Updated the `maven-model` dependency to version 3.5.0 to remove the CVE-2022-4245 vulnerability. (FFM-8133)
+
+* Updated to the latest version of Guava, 32.0.1-jre, to remove security issues. (FFM-8233)
+
 ```mdx-code-block
   </TabItem>
 </Tabs>

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -58,6 +58,14 @@ The **Java** server SDK has been updated to version **1.2.3** with the following
 
 * Updated to the latest version of Guava, 32.0.1-jre, to remove security issues. (FFM-8233)
 
+The **Android** client SDK has been updated to version **1.1.0** with the following updates.
+
+* Added a new API to allow SDK users to provide a trusted TLS CA certificate for connecting to Feature Flag services with private root CAs. (FFM-7008)
+
+* Added `Harness-SDK-Info`, `Harness-EnvironmentID` and `Harness-AccountID` HTTP headers to outbound HTTP connections. (FFM-7037)
+
+* Fixed broken links in the first time setup documentation. (FFM-7867)
+
 ```mdx-code-block
   </TabItem>
 </Tabs>


### PR DESCRIPTION
**Preview:** https://64906b8938df297c5615220d--harness-developer.netlify.app/release-notes/feature-flags