### PR TITLE
take down BG scale down step docs until dev issues are fixed

### DIFF
--- a/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-blue-green-deployment.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-blue-green-deployment.md
@@ -145,7 +145,7 @@ Harness adds all the steps you need to perform the Blue Green strategy:
 
 ![bg steps](./static/create-a-kubernetes-blue-green-deployment-30.png)
 
-Additionally, you can add a Blue Green Stage Scale Down step to scale down the last successful stage environment created during a Blue Green deployment.
+<!--Additionally, you can add a Blue Green Stage Scale Down step to scale down the last successful stage environment created during a Blue Green deployment.
 
 :::info
 
@@ -157,7 +157,7 @@ This functionality is behind a feature flag, `CDS_BG_STAGE_SCALE_DOWN_STEP_NG`.
 
 This functionality helps you efficiently manage your resources. You can configure the scale down step within the same stage or a different stage, based on your requirement.
 
-During scale down, the `HorizontalPodAutoscaler` and `PodDisruptionBudget` resources are removed, and the Deployments, StatefulSets, DaemonSets, and Deployment Configs resources are scaled down. Make sure that the infrastructure definition of these resources and the Blue Green service are the same. This is necessary as Harness identifies resources from the release history, which is mapped to a release name. If you configure a different infrastructure definition, it might lead to scaling down important resources.
+During scale down, the `HorizontalPodAutoscaler` and `PodDisruptionBudget` resources are removed, and the Deployments, StatefulSets, DaemonSets, and Deployment Configs resources are scaled down. Make sure that the infrastructure definition of these resources and the Blue Green service are the same. This is necessary as Harness identifies resources from the release history, which is mapped to a release name. If you configure a different infrastructure definition, it might lead to scaling down important resources.-->
 
 That's it. Harness will deploy the artifact using the stage service initially, and swap traffic to the primary service.
 
@@ -318,9 +318,9 @@ A great benefit of a Blue Green deployment is rapid rollback: rolling back to th
 
 You do not need to redeploy previous versions of the app and the pods that comprised their environment.
 
-Add a [Blue Green Stage Scale Down](#add-the-execution-steps) step to scale down the last successful stage environment created during a Blue Green deployment. 
+<!--Add a [Blue Green Stage Scale Down](#add-the-execution-steps) step to scale down the last successful stage environment created during a Blue Green deployment.-->
 
-Alternatively, you can add a [Shell Script step](/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/using-shell-scripts) to the post-deployment steps of your stage.
+You can add a [Shell Script step](/docs/continuous-delivery/x-platform-cd-features/executions/cd-general-steps/using-shell-scripts) to the post-deployment steps of your stage to scale down the last successful stage environment.
 
 Here's an example using `<+pipeline.stages.[stage_name].spec.execution.steps.stageDeployment.output.stageServiceName>` to reference the stage service name. The name of the stage is nginx so the reference is `<+pipeline.stages.nginx.spec.execution.steps.stageDeployment.output.stageServiceName>`.
 

--- a/release-notes/continuous-delivery.md
+++ b/release-notes/continuous-delivery.md
@@ -113,7 +113,7 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 <details>
 <summary>2023 releases</summary>
 
-#### Latest - June 09, 2023, version 79516
+#### June 09, 2023, version 79516
 
 ##### What's new
 
@@ -164,7 +164,7 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 ##### Early access
 
-- Scale down the last successful stage environment created by using a Blue Green Deployment strategy. (CDS-68527)
+<!--- Scale down the last successful stage environment created by using a Blue Green Deployment strategy. (CDS-68527)
   
   This functionality is behind a feature flag, `CDS_BG_STAGE_SCALE_DOWN_STEP_NG`. 
 
@@ -172,7 +172,7 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
   During scale down, the `HorizontalPodAutoscaler` and `PodDisruptionBudget` resources are removed, and the Deployments, StatefulSets, DaemonSets, and Deployment Configs resources are scaled down. Make sure that the infrastructure definition of these resources and the Blue Green service are the same. This is necessary as Harness identifies resources from the release history, which is mapped to a release name. If you configure a different infrastructure definition, it might lead to scaling down important resources.
 
-  Harness Delegate version 79503 is required for this feature.
+  Harness Delegate version 79503 is required for this feature.-->
 - Kubernetes deployments support `HorizontalPodAutoscaler` and `PodDisruptionBudget` for Blue Green and Canary execution strategies. (CDS-59011)
 
   This functionality is behind a feature flag, `CDS_SUPPORT_HPA_AND_PDB_NG`. 

--- a/release-notes/early-access.md
+++ b/release-notes/early-access.md
@@ -54,7 +54,7 @@ For more information on this feature, go to the documentation on [Output variabl
 
 ### Continuous Delivery, version 79516
 
-- Scale down the last successful stage environment created by using a Blue Green Deployment strategy. (CDS-68527)
+<!--- Scale down the last successful stage environment created by using a Blue Green Deployment strategy. (CDS-68527)
   
   This functionality is behind a feature flag, `CDS_BG_STAGE_SCALE_DOWN_STEP_NG`. 
 
@@ -62,7 +62,7 @@ For more information on this feature, go to the documentation on [Output variabl
 
   During scale down, the `HorizontalPodAutoscaler` and `PodDisruptionBudget` resources are removed, and the Deployments, StatefulSets, DaemonSets and Deployment Configs resources are scaled down. Make sure that the infrastructure definition of these resources and the Blue Green deployment are the same. This is necessary as Harness identifies resources from the release history, which is mapped to a release name. If you configure a different infrastructure definition, it might lead to scaling down important resources.
 
-  Harness Delegate version 79503 is required for this feature.
+  Harness Delegate version 79503 is required for this feature.-->
 - Kubernetes deployments support `HorizontalPodAutoscaler` and `PodDisruptionBudget` for Blue Green and Canary execution strategies. (CDS-59011)
 
   This functionality is behind a feature flag, `CDS_SUPPORT_HPA_AND_PDB_NG`. 


### PR DESCRIPTION
Commented out Blue Green Scale Down step documentation as the feature is facing some issues. Will re-publish once QA approves and makes sure that there are no bugs in the feature.