### PR TITLE
FFM-8289 Add table of SDK Codes

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
@@ -346,3 +346,28 @@ setInterval(() => {
   console.log('Evaluation for flag test and target: ', value, target);  
 }, 10000);
 ```
+
+## Troubleshooting
+The SDK logs the following codes for certain lifecycle events, for example authentication, which can aid troubleshooting.
+
+| **Code** | **Description**                                                                          |
+|----------|:-----------------------------------------------------------------------------------------|
+| **1000** | Successfully initialized                                                                 |
+| **1001** | Failed to initialize due to authentication error                                         |
+| **1002** | Failed to initialize due to a missing or empty API key                                   |
+| **2000** | Successfully authenticated                                                               |
+| **3000** | SDK Closing                                                                              |
+| **3001** | SDK closed successfully                                                                  |
+| **4000** | Polling service started                                                                  |
+| **4001** | Polling service stopped                                                                  |
+| **5000** | Streaming service started                                                                |
+| **5001** | Streaming service stopped                                                                |
+| **5002** | Streaming event received                                                                 |
+| **5003** | Streaming disconnected and is retrying to connect                                        |
+| **5004** | Streaming stopped                                                                        |
+| **6000** | Evaluation was successfully                                                              |
+| **6001** | Evaluation failed and the default value was returned                                     |
+| **7000** | Metrics service has started                                                              |
+| **7001** | Metrics service has stopped                                                              |
+| **7002** | Metrics posting failed                                                                   |
+| **7003** | Metrics posting success                                                                  |


### PR DESCRIPTION
# What
 Adds SDK codes which we are rolling on a per SDK bases - see https://harness.atlassian.net/wiki/spaces/FFM/pages/21356052573/SDK+Codes

# Does not include the following codes 
1003 - language constraint

2001 to 2003 - the SDK does not retry on authentication - known issue. 