### PR TITLE
Update build-custom-delegate-images-with-third-party-tools.md

### DIFF
--- a/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
+++ b/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
@@ -68,11 +68,19 @@ RUN mkdir /opt/harness-delegate/tools && cd /opt/harness-delegate/tools \
 ```
   
 
-The final instruction defines the Linux `$PATH` environment variable that provides the location of the tools to be installed:
+The `ENV` instruction defines the Linux `$PATH` environment variable that provides the location of the tools to be installed:
 
 
 ```
 ENV PATH=/opt/harness-delegate/tools/:$PATH
+```
+
+
+The final instruction switches the user back to `harness` so that our custom image does not run as root:
+
+
+```
+USER 1001
 ```
 The complete script is as follows:
 
@@ -94,6 +102,7 @@ RUN mkdir /opt/harness-delegate/tools && cd /opt/harness-delegate/tools \
   
 ENV PATH=/opt/harness-delegate/tools/:$PATH  
 
+USER 1001
 ```
 ### Upload the image to Docker Hub
 

--- a/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
+++ b/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
@@ -80,7 +80,7 @@ The final instruction switches the user back to `harness` so that our custom ima
 
 
 ```
-USER 1001
+USER harness
 ```
 The complete script is as follows:
 
@@ -102,7 +102,7 @@ RUN mkdir /opt/harness-delegate/tools && cd /opt/harness-delegate/tools \
   
 ENV PATH=/opt/harness-delegate/tools/:$PATH  
 
-USER 1001
+USER harness
 ```
 ### Upload the image to Docker Hub
 

--- a/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
+++ b/docs/platform/2_Delegates/install-delegates/build-custom-delegate-images-with-third-party-tools.md
@@ -27,7 +27,7 @@ You can build on either of the following Harness-provided images.
 | Harness Delegate Docker image | A publicly available Docker image providing Harness Delegate. |
 | Harness Minimal Delegate Docker image | A minimal delegate image available in Docker Hub at <https://hub.docker.com/r/harness/delegate/tags>. |
 
-Use the  last published `yy.mm.xxxxx` version of the minimal image from the Docker repository.
+Use the last published `yy.mm.xxxxx` version of the minimal image from the Docker repository.
 
 ![](./static/build-custom-delegate-images-with-third-party-tools-07.png)
 ### Build the delegate image
@@ -75,15 +75,12 @@ The `ENV` instruction defines the Linux `$PATH` environment variable that provid
 ENV PATH=/opt/harness-delegate/tools/:$PATH
 ```
 
-
-The final instruction switches the user back to `harness` so that our custom image does not run as root:
-
+The final instruction switches the user back to `harness` to ensure the custom image does not run as root:
 
 ```
 USER harness
 ```
 The complete script is as follows:
-
 
 ```
 FROM harness/delegate:22.10.77029.minimal  


### PR DESCRIPTION
# Harness Developer Pull Request

when instructing users on how to create a custom delegate image, the current instuctions result in a delegate image that runs as root. this is not the default behavior, and should not be used as then every pipeline will run on the delegate as root.

add instruction to switch the user back to the harness user, which is the default in a normal image

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
