### PR TITLE
FFM-8599: adds python sdk 1.2.1 relnotes

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/python-sdk-reference.md
@@ -29,7 +29,7 @@ You should read and understand the following:
 
 ## Version
 
-The current version of this SDK is **1.2.0**.
+The current version of this SDK is **1.2.1**.
 
 ## Requirements
 

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -41,9 +41,13 @@ This release does not include early access features.
 
 #### Feature Flags SDKs
 
-The **Java** server SDK has been updated to version **1.2.4** with the following update.
+* The **Java** server SDK has been updated to version **1.2.4** with the following update.
 
-* Fixed an issue where, if a flag had prerequisite flags configured, only the first prerequisite flag was being processed and the remaining were being ignored. (FFM-6412)
+  * Fixed an issue where, if a flag had prerequisite flags configured, only the first prerequisite flag was being processed and the remaining were being ignored. (FFM-6412)
+
+The **Python** server SDK has been updated to version **1.2.1** with the following update.
+
+  * The SDK incorrectly logged low level debug information as errors. This issue has been fixed. (FFM-8544)
 
 
   </TabItem>


### PR DESCRIPTION
[**Link to preview**](https://64a530516ace7a76a6964928--harness-developer.netlify.app/release-notes/feature-flags)