### PR TITLE
Hotfix: link fixes per deadLinkChecker

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
@@ -36,7 +36,7 @@ Pod IO error:
       <tr>
         <td> ERROR_CODE </td>
         <td> Specify the error code to be injected in file system calls</td>
-        <td> For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-io-error#error-code">error code</a>.</td>
+        <td> For more information, go to <a href="#error-code">error code</a>.</td>
       </tr>
       <tr>
         <td> MOUNT_PATH </td>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-latency.md
@@ -36,7 +36,7 @@ Pod IO latency:
       <tr>
         <td> LATENCY </td>
         <td> Specify the latency to be injected in file system calls</td>
-        <td> Accepts any unit of time, for example, 60s, 1m, or 60000ms. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-io-latency#io-latency">latency</a>.</td>
+        <td> Accepts any unit of time, for example, 60s, 1m, or 60000ms. For more information, go to <a href="#io-latency">latency</a>.</td>
       </tr>
       <tr>
         <td> MOUNT_PATH </td>

--- a/docs/feature-flags/ff-sdks/client-sdks/ios-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/ios-sdk-reference.md
@@ -68,7 +68,7 @@ dependencies: [
 ```
 ### Install using CocoaPods
 
-CocoaPods is built with Ruby and can be installed with the default Ruby on macOS. You can use a Ruby Version manager, however, we recommend that you use the standard Ruby available on macOS.To install the iOS using [CocoaPods](https://cocoapods.org//), complete the following steps:
+CocoaPods is built with Ruby and can be installed with the default Ruby on macOS. You can use a Ruby Version manager, however, we recommend that you use the standard Ruby available on macOS.To install the iOS using [CocoaPods](https://cocoapods.org/), complete the following steps:
 
 1. To install CocoaPods using the default Ruby available on macOS, use the `sudo` command when installing the gems, for example:
 ```

--- a/tutorials/chaos-experiments/chaos-experiments-on-gitlab.md
+++ b/tutorials/chaos-experiments/chaos-experiments-on-gitlab.md
@@ -19,7 +19,7 @@ Create a [chaos experiment](https://developer.harness.io/tutorials/chaos-experim
 
 ## Create a launch script
 
-HCE APIs are used to invoke or launch a chaos experiment from the pipeline. To simplify creating an API call with the required secure parameters and data, a [CLI tool](https://storage.googleapis.com/hce-api/hce-api-linux-amd64) is provided. Use this tool to create an appropriate API command to include in the pipeline script.
+HCE APIs are used to invoke or launch a chaos experiment from the pipeline. To simplify creating an API call with the required secure parameters and data, a CLI tool is provided. Use this tool to create an appropriate API command to include in the pipeline script.
 
 Below is a sample launch script.
 ```


### PR DESCRIPTION
Fixes dead links in 4 files:

- /docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
- /docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-latency.md
- /docs/feature-flags/ff-sdks/client-sdks/ios-sdk-reference.md
- /tutorials/chaos-experiments/chaos-experiments-on-gitlab.md
