### PR TITLE
[DOC-3329] Update revoke token info, add to NG release notes and what's new June 28

### DIFF
--- a/docs/platform/2_Delegates/secure-delegates/secure-delegates-with-tokens.md
+++ b/docs/platform/2_Delegates/secure-delegates/secure-delegates-with-tokens.md
@@ -131,7 +131,7 @@ To update and restart an existing Docker delegate, do the following:
 
 Harness loads tokens during the delegate startup process as part of the connection heartbeat. When you change the delegate token, you must restart the delegate cycle process.
 
-Delegates are disconnected within approximately 20 minutes after a token is revoked.
+Delegates are immediately disconnected when you revoke a token. Harness sends `SELF_DESTRUCT` to all delegates using the revoked token.
 
 To revoke tokens, do the following:
 

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -46,6 +46,8 @@ This release introduces the following new features and enhancements:
 
 - The delegate JRE is upgraded to 11.0.19_7. (PL-37994)
 
+- When a delegate token is revoked, Harness now sends `SELF_DESTRUCT` to all delegates that are using the revoked token. (PL-38957)
+
 ```mdx-code-block
   </TabItem>
   <TabItem value="Early access">

--- a/release-notes/whats-new.md
+++ b/release-notes/whats-new.md
@@ -133,6 +133,8 @@ For information on how to set up this workflow, go to [Configure STO to Download
 
 - Upgraded the delegate JRE to 11.0.19_7. (PL-37994)
 
+- When a delegate token is revoked, Harness now sends `SELF_DESTRUCT` to all delegates that are using the revoked token. (PL-38957)
+
 ## June 21, 2023
 
 ### Cloud Cost Management, version 79803


### PR DESCRIPTION
Update revoke token info, add to ng release notes and what's new June 28

For reviewers, previews are available:

[NG delegate release notes](https://64b1c94d5e708e20486a39c2--harness-developer.netlify.app/release-notes/delegate)
[What's new](https://64b1c94d5e708e20486a39c2--harness-developer.netlify.app/release-notes/whats-new)
[Revoke tokens](https://64b1c94d5e708e20486a39c2--harness-developer.netlify.app/docs/platform/Delegates/secure-delegates/secure-delegates-with-tokens#option-revoke-tokens)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
