### PR TITLE
fix: invalid secret IDs

### DIFF
--- a/docs/platform/Secrets/2-add-use-text-secrets.md
+++ b/docs/platform/Secrets/2-add-use-text-secrets.md
@@ -106,27 +106,27 @@ For an Encrypted Text secret that's been scoped to a Project, you reference the 
 
 ![](./static/add-use-text-secrets-50.png)
 
-Always reference a secret in an expression using its identifier. Names will not work.For example, if you have a text secret with the identifier `doc-secret`, you can reference it in a Shell Script step like this:
+Always reference a secret in an expression using its identifier. Names will not work.For example, if you have a text secret with the identifier `Docker_Hub_MRC`, you can reference it in a Shell Script step like this:
 
 
 ```
-echo "text secret is: " <+secrets.getValue("doc-secret")>
+echo "text secret is: " <+secrets.getValue("Docker_Hub_MRC")>
 ```
 You can reference a secret at the Org scope using an expression with `org`:
 
 
 ```
-<+secrets.getValue("org.your-secret-Id")>​
+<+secrets.getValue("org.Docker_Hub_MRC")>​
 ```
 You can reference a secret at the Account scope using an expression with `account`:
 
 
 ```
-<+secrets.getValue("account.your-secret-Id")>​​
+<+secrets.getValue("account.Docker_Hub_MRC")>​​
 ```
 Avoid using `$` in your secret value. If your secret value includes `$`, you must use single quotes when you use the expression in a script.  
-For example, if your secret in the Project scope has a value `'my$secret'`, and identifier `doc-secret`, to echo, use single quotes:  
-`echo '<+secrets.getValue("doc-secret")>'`
+For example, if your secret in the Project scope has a value `'my$secret'`, and identifier `Docker_Hub_MRC`, to echo, use single quotes:  
+`echo '<+secrets.getValue("Docker_Hub_MRC")>'`
 
 ## Invalid characters in secret names
 


### PR DESCRIPTION
# Harness Developer Pull Request

The example for referencing secrets uses secret id that are not possible, we do not allow `-` in IDs in harness.

I change the example secret name to match the secret shown in the screenshot above the examples to make the whole guide flow better, feel free to change the example ID if you want.

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
