### PR TITLE
Pl 40127 role creation fails for names starting with underscore

### DIFF
--- a/docs/platform/20_References/entity-identifier-reference.md
+++ b/docs/platform/20_References/entity-identifier-reference.md
@@ -62,6 +62,10 @@ Identifiers have the following restrictions:
 	+ org
 	+ account
 
+:::Exceptions
+Custom roles cannot start with underscore( _ ) as Harness managed roles identifiers start with underscore
+:::
+
 #### Identifier uniqueness
 
 Identifiers are unique for the scope in which they are created.

--- a/docs/platform/20_References/entity-identifier-reference.md
+++ b/docs/platform/20_References/entity-identifier-reference.md
@@ -37,6 +37,11 @@ The `identifier` field is immutable because Harness Entities use this field to i
 Identifiers have the following restrictions:
 
 * Identifiers must start with a-z, A-Z, or \_. Identifiers can then be followed by 0-9, a-z, A-Z, \_ or $.
+
+	:::note
+	Custom roles cannot start with an underscore( _ ) because Harness-managed role identifiers start with an underscore.
+	:::
+
 * Identifiers are case-sensitive. 
 * Identifiers shouldn't be any of the following words:
 	+ or
@@ -61,10 +66,6 @@ Identifiers have the following restrictions:
 	+ stepGroup
 	+ org
 	+ account
-
-:::note
-Exceptions: Custom roles cannot start with underscore( _ ) as Harness managed roles identifiers start with underscore
-:::
 
 #### Identifier uniqueness
 

--- a/docs/platform/20_References/entity-identifier-reference.md
+++ b/docs/platform/20_References/entity-identifier-reference.md
@@ -62,8 +62,8 @@ Identifiers have the following restrictions:
 	+ org
 	+ account
 
-:::Exceptions
-Custom roles cannot start with underscore( _ ) as Harness managed roles identifiers start with underscore
+:::note
+Exceptions: Custom roles cannot start with underscore( _ ) as Harness managed roles identifiers start with underscore
 :::
 
 #### Identifier uniqueness


### PR DESCRIPTION
Update RBAC doc to add identifier restriction for Roles
-- Custom roles cannot start with underscore( _ ) 

Ref: https://harness.atlassian.net/browse/PL-40127

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
