### PR TITLE
Update sto infra support doc 3078

### DIFF
--- a/docs/security-testing-orchestration/onboard-sto/shared/_supported-infrastructures.md
+++ b/docs/security-testing-orchestration/onboard-sto/shared/_supported-infrastructures.md
@@ -37,8 +37,8 @@ STO uses [CI build infrastructures](/docs/continuous-integration/use-ci/set-up-b
         <td>MacOS</td>
         <td>amd64</td>
         <td align="center">Roadmap</td>
-        <td align="center">Not Verified</td>
-        <td align="center">Not Verified</td>
+        <td align="center">Roadmap</td>
+        <td align="center">Roadmap</td>
         <td align="center">❌</td>
     </tr>
     <tr>

--- a/docs/security-testing-orchestration/onboard-sto/shared/_supported-infrastructures.md
+++ b/docs/security-testing-orchestration/onboard-sto/shared/_supported-infrastructures.md
@@ -36,7 +36,7 @@ STO uses [CI build infrastructures](/docs/continuous-integration/use-ci/set-up-b
     <tr>
         <td>MacOS</td>
         <td>amd64</td>
-        <td align="center">Not Verified</td>
+        <td align="center">Roadmap</td>
         <td align="center">Not Verified</td>
         <td align="center">Not Verified</td>
         <td align="center">❌</td>

--- a/docs/security-testing-orchestration/whats-supported.md
+++ b/docs/security-testing-orchestration/whats-supported.md
@@ -34,6 +34,14 @@ import StoSupportedScanners from '/docs/security-testing-orchestration/sto-techr
 
 <StoSupportedScanners />
 
+### STO support by CI build infrastructure type
+
+```mdx-code-block
+import StoInfraSupport from '/docs/security-testing-orchestration/onboard-sto/shared/_supported-infrastructures.md';
+```
+
+<StoInfraSupport />
+
 ### Scanner binaries used in STO container images
 
 ```mdx-code-block


### PR DESCRIPTION
# Harness Developer Pull Request

Update to the following table, which is in a [reusable snippet](https://github.com/harness/developer-hub/pull/2705/files#diff-b143760d1c266988092e97ef66d950b250e464b241fae43cfa92a9156a0e90a5):

* [STO support by CI build infrastructure type](https://64c44bcbeececd14ee7cdc6b--harness-developer.netlify.app/docs/security-testing-orchestration/whats-supported#sto-support-by-ci-build-infrastructure-type)


