### PR TITLE
maint - fix issues in Node SDK docs around config options

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/node-js-sdk-reference.md
@@ -156,13 +156,13 @@ You can configure the following features of the SDK:
 
 
 
-|  |  |  |
-| --- | --- | --- |
-| **Name** | **Description** | **Default Value** |
-| baseUrl | The URL used to fetch Feature Flag Evaluations. When using the Relay Proxy, change this to: `http://localhost:7000` | `https://config.ff.harness.io/api/1.0` |
-| eventUrl | The URL for posting metrics data to the Feature Flag service. When using the Relay Proxy, change this to: `http://localhost:7000` | `https://events.ff.harness.io/api/1.0` |
-| pollInterval | The interval **in seconds** that we poll for changes when you are using stream mode. | `60` (seconds) |
-| streamEnabled | Set to `true` to enable streaming mode.Set to `false` to disable streaming mode. | `true` |
+|  |                                                                                                                                          |  |
+| --- |------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| **Name** | **Description**                                                                                                                          | **Default Value** |
+| baseUrl | The URL used to fetch Feature Flag Evaluations. When using the Relay Proxy, change this to: `http://localhost:7000`                      | `https://config.ff.harness.io/api/1.0` |
+| eventUrl | The URL for posting metrics data to the Feature Flag service. When using the Relay Proxy, change this to: `http://localhost:7000`        | `https://events.ff.harness.io/api/1.0` |
+| pollInterval | The interval **in miliseconds** that we poll for changes when you are using stream mode.                                                 | `60` (seconds) |
+| enableStream | Set to `true` to enable streaming mode.Set to `false` to disable streaming mode.                                                         | `true` |
 | analyticsEnabled | Set to `true` to enable analytics.Set to `false` to disable analytics.**Note**: When enabled, analytics data is posted every 60 seconds. | `true` |
 
 For example:
@@ -367,7 +367,7 @@ The SDK logs the following codes for certain lifecycle events, for example authe
 | **5004** | Streaming stopped                                                                        |
 | **6000** | Evaluation was successfully                                                              |
 | **6001** | Evaluation failed and the default value was returned                                     |
-| **7000** | Metrics service has started                                                              |
+| **7000** | Metrics HarnessFFWeb harnessservice has started                                                              |
 | **7001** | Metrics service has stopped                                                              |
 | **7002** | Metrics posting failed                                                                   |
 | **7003** | Metrics posting success                                                                  |


### PR DESCRIPTION
Change Config option docs for:

`streamEnabled` should be `enableStream` 

`pollInterval` should be miliseconds and not seconds