### PR TITLE
[DOC-3561] Delegate release notes - move deprecation notices above latest

### DIFF
--- a/docs/first-gen/firstgen-release-notes/fg-delegate.md
+++ b/docs/first-gen/firstgen-release-notes/fg-delegate.md
@@ -20,9 +20,6 @@ To identify the cluster that hosts your account, open Harness FirstGen, go to **
 
 For FirstGen SaaS release notes, go to [Harness SaaS Release Notes (FirstGen)](/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes.md). For Self-Managed Enterprise Edition release notes, go to [Self-Managed Enterprise Edition (FirstGen)](/docs/first-gen/firstgen-release-notes/harness-on-prem-release-notes.md).
 
-
-## Latest - August 4, 2023, Harness version 80120, Harness Delegate version 80104
-
 #### Deprecation notices
 
 **Helm 2**
@@ -36,6 +33,8 @@ import Helmdep from '/release-notes/shared/helm-2-deprecation-notice.md'
 import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-notice.md'
 
 <Kustomizedep />
+
+## Latest - August 4, 2023, Harness version 80120, Harness Delegate version 80104
 
 ```mdx-code-block
 <Tabs>

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -20,10 +20,6 @@ Harness Delegate (NextGen SaaS) releases every two weeks. On the other hand, Har
 Harness deploys changes to Harness SaaS clusters on a progressive basis. This means that the features and fixes that these release notes describe may not be immediately available in your cluster. To identify the cluster that hosts your account, go to the **Account Overview** page. 
 :::
 
-## Latest - August 4, 2023, Harness version 80120, Harness Delegate version 80104
-
-Harness NextGen release 80120 includes the following changes for the Harness Delegate.
-
 #### Deprecation notices
 
 **Helm 2**
@@ -37,6 +33,10 @@ import Helmdep from '/release-notes/shared/helm-2-deprecation-notice.md'
 import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-notice.md'
 
 <Kustomizedep />
+
+## Latest - August 4, 2023, Harness version 80120, Harness Delegate version 80104
+
+Harness NextGen release 80120 includes the following changes for the Harness Delegate.
 
 ```mdx-code-block
 <Tabs>
@@ -71,9 +71,9 @@ import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-noti
 
    In the above example, `a` and `b` represent the respective queries:
 
-   - a = kubernetes.memory.usage{cluster-name:chi-play}
+   - a = `kubernetes.memory.usage{cluster-name:chi-play}`
 
-   - b = kubernetes.memory.total{cluster-name:chi-play}
+   - b = `kubernetes.memory.total{cluster-name:chi-play}`
 
    You can include any number of queries in the final formula using alphabetical variables, such as a, b, c, d, and so on.
 


### PR DESCRIPTION
Delegate release notes - move deprecation notices above latest for FG and NG

For reviewers, previews are available.

[Delegate Release Notes (NextGen)](https://64d3a3c41310936fd21d67d9--harness-developer.netlify.app/release-notes/delegate)
[Delegate Release Notes (FirstGen)](https://64d3a3c41310936fd21d67d9--harness-developer.netlify.app/docs/first-gen/firstgen-release-notes/fg-delegate)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
