### PR TITLE
Revert CI-8370

### DIFF
--- a/client-redirects.js
+++ b/client-redirects.js
@@ -39,10 +39,6 @@ module.exports = {
       from: "/docs/category/get-started-3/",
       to: "/docs/category/get-started-with-cet",
     },
-    {
-      from: "/docs/category/get-started-2",
-      to: "/docs/category/get-started-with-srm",
-    },
 
     // Created by aimurphy for branch doc-3441-rbac on July 28, 2023
 

--- a/client-redirects.js
+++ b/client-redirects.js
@@ -34,9 +34,8 @@ module.exports = {
     //  },
     //===================================================================================
 
-     // Created by SudheendraKatte for branch cet-whats-supported on August 3 2023
-
-     {
+    // Created by SudheendraKatte for branch cet-whats-supported on August 3 2023
+    {
       from: "/docs/category/get-started-3/",
       to: "/docs/category/get-started-with-cet",
     },

--- a/docs/platform/7_Connectors/Code-Repositories/git-hub-app-support.md
+++ b/docs/platform/7_Connectors/Code-Repositories/git-hub-app-support.md
@@ -94,13 +94,25 @@ You need a private key for your GitHub app to configure your Harness GitHub conn
 
 ## Configure the GitHub connector
 
-You can use your GitHub App as either the [primary authentication method](/docs/platform/Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference#authentication) or the [API access authentication method](/docs/platform/Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference#enable-api-access) for your GitHub connector.
+You can use your GitHub App as <!-- either the [primary authentication method](/docs/platform/Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference#authentication) or -->the [API access authentication method](/docs/platform/Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference#enable-api-access) for your GitHub connector.
+
+<!-- At 803xx release, remove below steps and uncomment tabs. -->
+
+1. In your Harness project, select **Connectors** under **Project Setup**.
+2. Create a new connector or edit an existing GitHub connector.
+3. Configure the [GitHub connector settings](./ref-source-repo-provider/git-hub-connector-settings-reference.md). The GitHub App is part of the **Credentials** settings.
+4. Select **Enable API access**. This setting is only available for connection types and authentication methods where it is not already enabled by default.
+5. For **API Authentication**, select **GitHub App**.
+6. Enter the your GitHub [installation ID and app ID](#get-the-installation-id-and-app-id).
+7. Select your [private key file secret](#generate-a-private-key).
+8. Select **Continue**.
+9. If the connection test succeeds, select **Finish** to save the connector.
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ```
-
+<!--
 ```mdx-code-block
 <Tabs>
   <TabItem value="primary" label="Primary authentication">
@@ -146,6 +158,7 @@ The [Git Clone step](/docs/continuous-integration/use-ci/codebase-configuration/
   </TabItem>
 </Tabs>
 ```
+-->
 
 ## Option: Set up a PR trigger
 

--- a/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
@@ -81,7 +81,9 @@ Provide authentication credentials for the connector.
 
 Authentication is required for all accounts and repos, including read-only repos. The **Connection Type** you chose in the [Details settings](#details-settings) determines the available **Authentication** methods:
 
-* For **HTTP** connections, you can use **Username and Token**, **OAuth**, or **GitHub App** authentication.
+<!-- At 803xx release, uncomment below phrase and GH App tab -->
+
+* For **HTTP** connections, you can use **Username and Token** or **OAuth**<!--, or **GitHub App**--> authentication.
 * For **SSH** connections, you must use **SSH Key** authentication.
 
 ```mdx-code-block
@@ -93,7 +95,7 @@ Authentication is required for all accounts and repos, including read-only repos
 2. In the **Username** field, enter your personal GitHub account name. You can use either plaintext or a [Harness encrypted text secret](../../../Secrets/2-add-use-text-secrets.md).
 3. In the **Personal Access Token** field, provide a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) as a [Harness encrypted text secret](../../../Secrets/2-add-use-text-secrets.md).
 
-<!-- is this method required for accounts with 2FA? Do OAuth & SSH key support accounts w/ 2FA? -->
+<!--Is this method required for accounts with 2FA? Do OAuth, GH App, & SSH key support accounts w/ 2FA? -->
 
 :::info Personal access token permissions
 
@@ -159,6 +161,7 @@ For more information about GitHub's deprecation of RSA support, go to the GitHub
 
 :::
 
+<!--
 ```mdx-code-block
   </TabItem>
   <TabItem value="ghapp" label="GitHub App">
@@ -192,7 +195,7 @@ The [Git Clone step](/docs/continuous-integration/use-ci/codebase-configuration/
    ![](../../static/git-hub-app-support-59.png)
 
 4. For **GitHub Private Key**, provide your GitHub App's PEM key file as a [Harness encrypted file secret](/docs/platform/Secrets/add-file-secrets).
-
+-->
 ```mdx-code-block
   </TabItem>
 </Tabs>

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -313,7 +313,7 @@ This release does not include early access features.
 
 ##### What's new
 
-* When you [use a GitHub App in a GitHub connector](/docs/platform/Connectors/Code-Repositories/git-hub-app-support#step-5-use-github-app-and-secret-in-harness-github-connector), you can now use encrypted text secrets for the **Installation ID** and **Application ID**. (CI-7380)
+* When you [use a GitHub App in a GitHub connector](/docs/platform/Connectors/Code-Repositories/git-hub-app-support), you can now use encrypted text secrets for the **Installation ID** and **Application ID**. (CI-7380)
 * Added a [codebase expression](/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference) for commit messages: `<+codebase.commitMessage>`. (CI-7222)
 
 ##### Early access

--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -1885,7 +1885,7 @@ https://github.com/harness/helm-charts/releases/tag/harness-0.5.0
   For more information, go to [Monitoring](/docs/self-managed-enterprise-edition/monitor-harness-on-prem). 
 - Deployments load static files from the application server and no longer attempt to connect to static.harness.io. (SMP-851)
 #### Continuous Integration
-- When you [use a GitHub App in a GitHub connector](/docs/platform/Connectors/Code-Repositories/git-hub-app-support#step-5-use-github-app-and-secret-in-harness-github-connector), you can now use encrypted text secrets for the **Installation ID** and **Application ID**. (CI-7380)
+- When you [use a GitHub App in a GitHub connector](/docs/platform/Connectors/Code-Repositories/git-hub-app-support), you can now use encrypted text secrets for the **Installation ID** and **Application ID**. (CI-7380)
 #### Continuous Delivery & GitOps
 - You can no longer delete an infrastructure used in a pipeline or template. (CDS-42182)
 


### PR DESCRIPTION
* The FF CDS_GITHUB_APP_AUTHENTICATION won't be deployed til 803xx. Hiding the doc related to that FF until it is deployed.
* Also removed 1 redirect that Docusaurus was ignoring (explanation below).
* Fix a couple links that were pointing to a nonexistent anchor.

When there are multiple categories.json with the same `label`, Docusaurus automatically assigns numbers to them to differentiate them. If one of those categories.json changes and has a different label, Docusaurus updates the numbering for the remaining same-label pages. Thus,  /docs/category/get-started-2 now points to the Platform doc's Get Started page; whereas it used to point to the Get Started with SRM page.

TL;DR: /docs/category/get-started-2 is a valid path so Docusaurus won't honor the redirect.