### PR TITLE
update ingestionOnly format support, remove DinD ref re DOC-3490

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/shared/legacy/_sto-ref-legacy-ingest.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/legacy/_sto-ref-legacy-ingest.md
@@ -2,7 +2,7 @@ The following setting is required for Security steps where the `policy_type` is 
 
 * `ingestion_file`  The results data file to use when running an Ingestion scan. You should specify the full path to the data file in your workspace, such as `/shared/customer_artifacts/my_scan_results.json`. 
 
-   In addition to ingesting scan data in the external scanner's native format, STO steps can also ingest  data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. 
+   In addition to ingesting scan data in the external scanner's native format, STO steps can also ingest data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. 
 
    The following steps outline the general workflow for ingesting scan data into your pipeline. For a complete workflow description and example, go to [Ingest Scan Results into an STO Pipeline](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-scan-results-into-an-sto-pipeline).
 

--- a/docs/security-testing-orchestration/sto-techref-category/shared/legacy/_sto-ref-legacy-ingest.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/legacy/_sto-ref-legacy-ingest.md
@@ -1,13 +1,13 @@
 The following setting is required for Security steps where the `policy_type` is `ingestionOnly`.
 
-* `ingestion_file`  The results data file to use when running an Ingestion scan. You should specify the full path to the data file in your workspace, such as `/shared/customer_artifacts/my_scan_results.json`. STO steps can ingest scan data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. 
+* `ingestion_file`  The results data file to use when running an Ingestion scan. You should specify the full path to the data file in your workspace, such as `/shared/customer_artifacts/my_scan_results.json`. 
 
-The following steps outline the general workflow for ingesting scan data into your pipeline:
+   In addition to ingesting scan data in the external scanner's native format, STO steps can also ingest  data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. 
+
+   The following steps outline the general workflow for ingesting scan data into your pipeline. For a complete workflow description and example, go to [Ingest Scan Results into an STO Pipeline](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-scan-results-into-an-sto-pipeline).
 
    1. Specify a shared folder for your scan results, such as `/shared/customer_artifacts`. You can do this in the Overview tab of the Security stage where you're ingesting your data.
 
    2. Create a Run step that copies your scan results to the shared folder. You can run your scan externally, before you run the build, or set up the Run step to run the scan and then copy the results.
 
    3. Add a Security step after the Run step and add the `target name`, `variant`, and `ingestion_file` settings as described above. 
-
-For a complete workflow description and example, go to [Ingest Scan Results into an STO Pipeline](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-scan-results-into-an-sto-pipeline).

--- a/docs/security-testing-orchestration/sto-techref-category/shared/step_palette/_sto-ref-ui-ingestion-file.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/step_palette/_sto-ref-ui-ingestion-file.md
@@ -1,1 +1,5 @@
-The results data file to use when running an Ingestion scan. STO steps can ingest scan data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. Generally an Ingestion scan consists of a scan step (to generate the data file) and an ingestion step (to ingest the data file).
+The results data file to use when running an Ingestion scan. 
+ 
+Generally an Ingestion scan consists of a scan step (to generate the data file) and an ingestion step (to ingest the data file).
+
+In addition to ingesting scan data in the external scanner's native format, STO steps can also ingest  data in [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) and [Harness Custom JSON](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners) format. 

--- a/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference.md
@@ -8,6 +8,7 @@ You can set up Jfrog Xray scans using a Security step: create a CI Build or Secu
 
 ## Before you begin
 
+<!-- 
 ### Docker-in-Docker requirements
 
 ```mdx-code-block
@@ -15,6 +16,8 @@ import StoDinDRequirements from '/docs/security-testing-orchestration/sto-techre
 ```
 
 <StoDinDRequirements />
+
+-->
 
 ### Root access requirements
 
@@ -25,7 +28,7 @@ import StoRootRequirements from '/docs/security-testing-orchestration/sto-techre
 <StoRootRequirements />
 
 
-### Security step settings
+## Security step settings
 
 ### Target and variant
 


### PR DESCRIPTION
# Harness Developer Pull Request

- Commented out a section on Docker-in-Docker requirements in the [jFrog Xray scanner reference](https://64d51cc9c3e7a80eac188cd2--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference).
- Updated a reusable snippet on supported ingestion formats for Security step references -- example section here: [Ingestion file](https://64d51cc9c3e7a80eac188cd2--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference/#ingestion-file) 
- Updated a reusable snippet on supported ingestion formats for scanner-specific step references -- example section here: [Ingestion settings](https://64d51cc9c3e7a80eac188cd2--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/black-duck-hub-scanner-reference/#ingestion-settings)