### PR TITLE
[DOC-2457] Add auto-population details to enable API access

### DIFF
--- a/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
@@ -205,9 +205,7 @@ The [Git Clone step](/docs/continuous-integration/use-ci/codebase-configuration/
 
 This setting is only available for connection types and authentication methods where it is not already enabled by default.
 
-You must enable API access to use Git-based triggers, manage webhooks, or update Git statuses with this connector. If you are using the Harness Git Experience, this setting is required.
-
-Any operation that requires Harness to call GitHub APIs, including cloning a codebase, pre-populating the branch in **Run Pipeline**, etc., requires you to enable API access.
+API access is required for any operations that require Harness to call GitHub APIs, such as using the Harness Git Experience, cloning codebases, automatically detecting branch names when you manually run pipelines, using Git webhook triggers, and updating Git statuses.
 
 Enabling API access requires configuring an API authentication method, either a personal access token or a GitHub App.
 

--- a/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
@@ -207,6 +207,8 @@ This setting is only available for connection types and authentication methods w
 
 You must enable API access to use Git-based triggers, manage webhooks, or update Git statuses with this connector. If you are using the Harness Git Experience, this setting is required.
 
+Any operation that requires Harness to call GitHub APIs, including cloning a codebase, pre-populating the branch in **Run Pipeline**, etc., requires you to enable API access.
+
 Enabling API access requires configuring an API authentication method, either a personal access token or a GitHub App.
 
 ```mdx-code-block


### PR DESCRIPTION
Add auto-population details to enable API access

For reviewers, a preview is available.

[Enable API access](https://64dbdbe6fb88c128ccc52fd1--harness-developer.netlify.app/docs/platform/Connectors/Code-Repositories/ref-source-repo-provider/git-hub-connector-settings-reference#enable-api-access)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
