### PR TITLE
DOC-3574: Adding documentation for limitation related to nested json

### DIFF
--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -90,7 +90,7 @@ You can use JSON body as a string for the variable runtime input default value.
 
 :::info note
 
-Harness does not support the use of a nested JSON body as a string for the variable runtime input default value. 
+Harness does not support using a nested JSON body as a string for the variable runtime input default value. 
 
 ::
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -86,11 +86,21 @@ Commas are supported in both allowed and default values. A string with a comma m
 
 For example, `<+input>.default(\'london,uk\').allowedValues(\'bengaluru,india\',\'newyork,usa\',\'london,uk\')`.
 
-JSON body as a string can also be used currently as the variable runtime input default value. 
+You can use JSON body as a string for the variable runtime input default value. 
 
-NOTE: Currently we don’t support the use of nested JSON body as a string as the variable runtime input default value. 
+:::info note
 
-For example, this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` can be used as a runtime input, but this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` is currently not supported as a runtime input.
+Harness does not support the use of a nested JSON body as a string for the variable runtime input default value. 
+
+::
+
+For example, you can use the following JSON string for a runtime input.
+
+`<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` 
+
+Harness does not support the following JSON string for a runtime input.
+
+`<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` 
 
 Multiple selection is allowed for runtime inputs defined for pipelines, stages, and shell script variables. You must specify the allowed values in the input as mentioned in the above examples. 
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -92,8 +92,6 @@ You can use JSON body as a string for the variable runtime input default value.
 
 Harness does not support using a nested JSON body as a string for the variable runtime input default value. 
 
-::
-
 For example, you can use the following JSON string for a runtime input.
 
 `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` 
@@ -101,6 +99,8 @@ For example, you can use the following JSON string for a runtime input.
 Harness does not support the following JSON string for a runtime input.
 
 `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` 
+
+:::
 
 Multiple selection is allowed for runtime inputs defined for pipelines, stages, and shell script variables. You must specify the allowed values in the input as mentioned in the above examples. 
 
@@ -152,9 +152,9 @@ The following limitations and requirements apply to this feature:
 
 You can configure runtime inputs to a pipeline to be supplied during a step or stage execution. For example, you can configure a custom stage with a Shell Script step with a runtime input field with this property, you will be prompted to enter the input during the execution just before starting the Shell Script step.
 
-If a custom stage is setup with runtime input, you can enter a shell script when prompted by Harness during execution. 
+If a custom stage is set up with runtime input, you can enter a shell script when prompted by Harness during execution. 
 
-If a Harness Approval step is setup with runtime input, you can specify the Harness groups that will approve that step during pipeline execution.
+If a Harness Approval step is set up with runtime input, you can specify the Harness groups that will approve that step during pipeline execution.
 
 To configure runtime inputs in the Harness Pipeline Studio:
 

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -86,6 +86,12 @@ Commas are supported in both allowed and default values. A string with a comma m
 
 For example, `<+input>.default(\'london,uk\').allowedValues(\'bengaluru,india\',\'newyork,usa\',\'london,uk\')`.
 
+JSON body as a string can also be used currently as the variable runtime input default value. 
+
+NOTE: Currently we don’t support the use of nested JSON body as a string as the variable runtime input default value. 
+
+For example, this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` can be used as runtime input, but this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` is not supported currently as runtime input.
+
 Multiple selection is allowed for runtime inputs defined for pipelines, stages, and shell script variables. You must specify the allowed values in the input as mentioned in the above examples. 
 
 The multiple selection functionality is currently behind the feature flag, `PIE_MULTISELECT_AND_COMMA_IN_ALLOWED_VALUES`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.

--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -90,7 +90,7 @@ JSON body as a string can also be used currently as the variable runtime input d
 
 NOTE: Currently we don’t support the use of nested JSON body as a string as the variable runtime input default value. 
 
-For example, this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` can be used as runtime input, but this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` is not supported currently as runtime input.
+For example, this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true}')` can be used as a runtime input, but this JSON string `<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` is currently not supported as a runtime input.
 
 Multiple selection is allowed for runtime inputs defined for pipelines, stages, and shell script variables. You must specify the allowed values in the input as mentioned in the above examples. 
 


### PR DESCRIPTION
DOC-3574: Adding documentation for limitation related to nested json. Currently we don’t support the use of nested JSON body as it’s runtime input default value.

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
