### PR TITLE
DOC-3574: Updating documentation for limitation related to nested json

### DIFF
--- a/docs/platform/20_References/runtime-inputs.md
+++ b/docs/platform/20_References/runtime-inputs.md
@@ -98,7 +98,7 @@ For example, you can use the following JSON string for a runtime input.
 
 Harness does not support the following JSON string for a runtime input.
 
-`<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')` 
+`"<+input>.default('{\"risk\": 100,\"availabilityVsCost\": \"balanced\",\"drainingTimeout\": 120,\"lifetimePeriod\": \"days\", \"fallbackToOd\": true,\"scalingStrategy\": {\"terminationPolicy\": \"default\" }}')"` 
 
 :::
 


### PR DESCRIPTION
DOC-3574: Updating documentation for limitation related to nested json - added double inverted comas around nested JSON string

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
