### PR TITLE
CHAOS-2305: Fixes linux fault inputs formatting

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-error.md
@@ -29,7 +29,7 @@ Linux DNS error injects chaos to disrupt the DNS resolution on a Linux machine.
   </tr>
   <tr>
     <td> hostNames </td>
-    <td> List of the target host names or keywords. For example, '["google.com","litmuschaos.io"]'. </td>
+    <td> List of the target host names or keywords. For example, <code>google.com,litmuschaos.io</code>. </td>
     <td> If not provided, all host names are targeted. </td>
   </tr>
   <tr>
@@ -61,7 +61,7 @@ Linux DNS error injects chaos to disrupt the DNS resolution on a Linux machine.
 
 ### Host names
 
-The `hostNames` input variable subjects the comma-separated host names to chaos. 
+The `hostNames` input variable subjects the comma-separated host names to chaos.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -76,7 +76,7 @@ metadata:
     name: dns-error
 spec:
   dnsChaos/inputs:
-    hostNames: '["litmuschaos.io","google.com"]'
+    hostNames: 'litmuschaos.io,google.com'
 ```
 
 ### Match scheme

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-corruption.md
@@ -42,12 +42,12 @@ Linux network corruption injects chaos to disrupt network connectivity on a Linu
   </tr>
   <tr>
     <td> destinationHosts </td>
-    <td> List of the target host names or keywords. For example. <code>["google.com","litmuschaos.io"]</code> </td>
+    <td> List of the target host names or keywords. For example. <code>google.com,litmuschaos.io</code> </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted </td>
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example: <code>["1.1.1.1","8.8.8.8"]</code> </td>
+    <td> List of the target IPs. For example: <code>1.1.1.1,8.8.8.8</code> </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted</td>
   </tr>
   <tr>
@@ -83,7 +83,7 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"
 ```
 
@@ -103,7 +103,7 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"
 ```
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-duplication.md
@@ -43,12 +43,12 @@ Linux network duplication injects chaos to disrupt network connectivity on a Lin
   </tr>
     <tr>
     <td> destinationHosts </td>
-    <td> List of the target host names or keywords. For example, <code>["google.com","litmuschaos.io"]</code> </td>
+    <td> List of the target host names or keywords. For example, <code>google.com,litmuschaos.io</code> </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted </td>
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example, <code>["1.1.1.1","8.8.8.8"]</code> </td>
+    <td> List of the target IPs. For example, <code>1.1.1.1,8.8.8.8</code> </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted</td>
   </tr>
   <tr>
@@ -84,7 +84,7 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"
 ```
 
@@ -104,7 +104,7 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"
 ```
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-latency.md
@@ -42,12 +42,12 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
   </tr>
     <tr>
     <td> destinationHosts </td>
-    <td> List of the target hostnames or keywords. For example: <code>["google.com","litmuschaos.io"]</code> </td>
+    <td> List of the target hostnames or keywords. For example: <code>google.com,litmuschaos.io</code> </td>
     <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all hostnames/domains will be targeted </td>
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example: <code>["1.1.1.1","8.8.8.8"]</code> </td>
+    <td> List of the target IPs. For example: <code>1.1.1.1,8.8.8.8</code> </td>
     <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all hostnames/domains will be targeted</td>
   </tr>
   <tr>
@@ -93,7 +93,7 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"
 ```
 
@@ -113,13 +113,13 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"
 ```
 
 ### Latency and jitter
 
-The `latency` and `jitter` input variables add delay and a small deviation to the delay, respectively, with respect to the connection. 
+The `latency` and `jitter` input variables add delay and a small deviation to the delay, respectively, with respect to the connection.
 
 The following YAML snippet illustrates the use of this environment variable:
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-loss.md
@@ -42,12 +42,12 @@ Linux network loss injects chaos to disrupt network connectivity on the Linux ma
   </tr>
   <tr>
     <td> destinationHosts </td>
-    <td> List of the target host names or keywords. For example: <code>["google.com","litmuschaos.io"]</code></td>
+    <td> List of the target host names or keywords. For example: <code>google.com,litmuschaos.io</code></td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted </td>
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example: <code>["1.1.1.1","8.8.8.8"]</code> </td>
+    <td> List of the target IPs. For example: <code>1.1.1.1,8.8.8.8</code> </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted</td>
   </tr>
   <tr>
@@ -88,7 +88,7 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"
 ```
 
@@ -108,7 +108,7 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"
 ```
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-dns-error/hostnames.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-dns-error/hostnames.yaml
@@ -7,4 +7,4 @@ metadata:
     name: dns-error
 spec:
   dnsChaos/inputs:
-    hostNames: '["litmuschaos.io","google.com"]'
+    hostNames: 'litmuschaos.io,google.com'

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-corruption/destination-hosts.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-corruption/destination-hosts.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-corruption/destination-ips.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-corruption/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-duplication/destination-hosts.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-duplication/destination-hosts.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-duplication/destination-ips.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-duplication/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-latency/destination-hosts.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-latency/destination-hosts.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-latency/destination-ips.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-latency/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-loss/destination-hosts.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-loss/destination-hosts.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationHosts: '["google.com"]'
+    destinationHosts: 'google.com'
     networkInterface: "eth0"

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-loss/destination-ips.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/static/manifests/linux-network-loss/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationIPs: '["1.1.1.1"]'
+    destinationIPs: '1.1.1.1'
     networkInterface: "eth0"


### PR DESCRIPTION
# Harness Developer Pull Request
Fixes Linux fault input formatting for network and DNS faults.

## What Type of PR is This?
- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
