### PR TITLE
DOC-3607

### DIFF
--- a/docs/platform/8_Pipelines/w_pipeline-steps-reference/triggers-reference.md
+++ b/docs/platform/8_Pipelines/w_pipeline-steps-reference/triggers-reference.md
@@ -398,7 +398,7 @@ When Git Experience is enabled for your Pipeline, the **Pipeline Input** tab inc
 
 For all Git providers supported by Harness, a webhook is automatically created in the repo. Usually, the webhook is automatically registered. If automatic registration fails, you can [manually register the webhook](#manual-and-custom-webhook-registration).
 
-For each repo, Harness creates one webhook with a superset of all permissions, rather than separate webhooks for each Git event type. The following Git events are included webhooks that Harness registers.
+For each repo, Harness creates one webhook with a superset of all permissions, rather than separate webhooks for each Git event type. The following Git events are included in the webhooks that Harness registers.
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';

--- a/docs/platform/8_Pipelines/w_pipeline-steps-reference/triggers-reference.md
+++ b/docs/platform/8_Pipelines/w_pipeline-steps-reference/triggers-reference.md
@@ -396,9 +396,9 @@ When Git Experience is enabled for your Pipeline, the **Pipeline Input** tab inc
 
 ## Webhook registration
 
-For all Git providers supported by Harness, the webhook is automatically created in the repo. You usually don't need to copy the URL and add it to your repo's webhook settings.
+For all Git providers supported by Harness, a webhook is automatically created in the repo. Usually, the webhook is automatically registered. If automatic registration fails, you can [manually register the webhook](#manual-and-custom-webhook-registration).
 
-The following Git events are automatically added to the webhooks that Harness registers.
+For each repo, Harness creates one webhook with a superset of all permissions, rather than separate webhooks for each Git event type. The following Git events are included webhooks that Harness registers.
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
[Clarify that Harness creates one webhook w all permissions, rather than separate webhooks for each event type](https://64e6465a78294d024e0e90cc--harness-developer.netlify.app/docs/platform/Pipelines/w_pipeline-steps-reference/triggers-reference#webhook-registration:~:text=For%20each%20repo%2C%20Harness%20creates%20one%20webhook%20with%20a%20superset%20of%20all%20permissions%2C%20rather%20than%20separate%20webhooks%20for%20each%20Git%20event%20type.)
