### PR TITLE
DOC-3627 Add a note to some pages about plan tier requirement for build infra options

### DIFF
--- a/docs/continuous-integration/ci-quickstarts/ci-concepts.md
+++ b/docs/continuous-integration/ci-quickstarts/ci-concepts.md
@@ -30,6 +30,7 @@ https://harness-1.wistia.com/medias/rpv5vwzpxz-->
 ## Architecture
 
 <figure>
+
 ![](./static/ci-concepts-10.png)
 
 <figcaption>Harness CI architecture diagram.</figcaption>

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings.md
@@ -116,6 +116,12 @@ The following **Platform** settings are available:
 
 Use the **Kubernetes** infrastructure option to [set up a Kubernetes cluster build infrastructure](./k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md).
 
+:::info
+
+The Kubernetes cluster build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
+:::
+
 The following **Platform** settings are available:
 
 * **Select the Operating System:** Select the relevant OS.
@@ -250,6 +256,12 @@ The following **Platform** settings are available:
 ```
 
 Use the **VMs** infrastructure option for [self-hosted cloud provider VM build infrastructures](/docs/category/set-up-vm-build-infrastructures).
+
+:::info
+
+The VM build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
+:::
 
 The following **Platform** settings are available:
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
@@ -18,6 +18,12 @@ CI build infrastructure pods can interact with servers using self-signed certifi
 * Harness uses a UBI image for the Git Clone step. UBI reads certificates from `/etc/ssl/certs/ca-bundle.crt`.
 * Different base images use different paths as their default certificate location. For example, Alpine images use this path to recognize certificates: `/etc/ssl/certs/ca-certificates.crt` For any other image, make sure you verify the default certificate path.
 
+:::info
+
+The Kubernetes cluster build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
+:::
+
 ### STO pipelines
 
 If you have STO scan steps in your pipeline, you can set up your certificates using the workflow described below. However, there are some additional steps and requirements. For more information, go to [Adding Custom Artifacts to STO Pipelines](/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/add-artifacts-to-pipelines.md).

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/run-windows-builds-in-a-kubernetes-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/run-windows-builds-in-a-kubernetes-build-infrastructure.md
@@ -16,6 +16,12 @@ You can run Windows builds in your Kubernetes build infrastructure. Windows Serv
 * The following steps aren't supported on Windows platforms on Kubernetes cluster build infrastructures: **Build and Push an image to Docker Registry**, **Build and Push to ECR**, and **Build and Push to GCR**. Try using the [buildah plugin](../../build-and-upload-artifacts/build-and-push-nonroot.md) instead.
 * **Docker commands aren't supported.** If your build process needs to run Docker commands, [Docker-in-Docker (DinD) with privileged mode](../../run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md) is necessary when using a Kubernetes cluster build infrastructure; however, Windows doesn't support privileged mode. If you need to run Docker commands, you must use another build infrastructure, such as [Harness Cloud](../use-harness-cloud-build-infrastructure.md) or a [VM build infrastructure](/docs/category/set-up-vm-build-infrastructures), where you can run Docker commands directly on the host.
 
+:::info
+
+The Kubernetes cluster build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
+:::
+
 ## Windows Server 2019 is required
 
 Only Windows Server 2019 images are supported.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
@@ -17,6 +17,12 @@ This topic assumes you have a basic understanding of [Harness' key concepts](/do
 
 Review the following important information about using Kubernetes cluster build infrastructures for your Harness CI builds.
 
+:::info
+
+The Kubernetes cluster build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
+:::
+
 ### Privileged mode is required for Docker-in-Docker
 
 If your build process needs to run Docker commands, [Docker-in-Docker (DinD) with privileged mode](../../run-ci-scripts/run-docker-in-docker-in-a-ci-stage.md) is necessary when using a Kubernetes cluster build infrastructure.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-azure.md
@@ -14,7 +14,11 @@ import TabItem from '@theme/TabItem';
 ```
 
 :::note
+
+This build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
 Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
 :::
 
 This topic describes how to set up a CI build infrastructure in Microsoft Azure. To do this, you will create a VM and install a Harness Delegate and Drone VM Runner on it. The runner creates VMs dynamically in response to CI build requests. The delegate and runner VM can be inside or outside Azure; however, the instructions on this page assume you will create the VM in Azure.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-a-ci-build-infrastructure-in-google-cloud-platform.md
@@ -9,7 +9,11 @@ helpdocs_is_published: true
 ---
 
 :::note
+
+This build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
 Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
 :::
 
 This topic describes how to set up a CI build infrastructure in Google Cloud Platform (GCP). To do this, you will create an Ubuntu VM and then install a Harness Delegate and Drone VM Runner on it. The runner creates VMs dynamically in response to CI build requests.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-macos-build-infra-with-anka-registry.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/define-macos-build-infra-with-anka-registry.md
@@ -6,6 +6,8 @@ sidebar_position: 40
 
 :::note
 
+This build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
 Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
 
 :::

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md
@@ -14,7 +14,11 @@ import TabItem from '@theme/TabItem';
 ```
 
 :::note
+
+This build infrastructure option is only available with Harness CI Team and Enterprise plans.
+
 Currently, this feature is behind the Feature Flag `CI_VM_INFRASTRUCTURE`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
 :::
 
 This topic describes how to use AWS VMs as Harness CI build infrastructure. To do this, you will create an Ubuntu VM and install a Harness Delegate and Drone VM Runner on it. The runner creates VMs dynamically in response to CI build requests. You can also configure the runner to hibernate AWS Linux and Windows VMs when they aren't needed.

--- a/tutorials/ci-pipelines/ci-kubernetes-build-farm.md
+++ b/tutorials/ci-pipelines/ci-kubernetes-build-farm.md
@@ -19,6 +19,12 @@ title: Build on a Kubernetes cluster
 
 This tutorial shows you how to create a two-stage Harness CI pipeline that uses a Kubernetes cluster build infrastructure. The pipeline builds and runs a unit test on a codebase, uploads the artifact to Docker Hub, and then runs integration tests. This tutorial uses publicly-available code, images, and your Github and Docker Hub accounts.
 
+:::info
+
+The Kubernetes cluster build infrastructure option is only available with Harness CI Team and Enterprise plans. For Free plans, try the [Harness Cloud build infrastructure tutorial](/tutorials/ci-pipelines/fastest-ci).
+
+:::
+
 You'll learn how to create a CI pipeline that does the following:
 
 1. Clones the code repo for an app.


### PR DESCRIPTION
Some examples (added to the K8s cluster tutorial, all K8s build infra configuration topics, all VM build infra config topics, and the build stage settings topic):

[Build on a Kubernetes cluster](https://64e90bb7f3c7703d802dc89f--harness-developer.netlify.app/tutorials/ci-pipelines/kubernetes-build-farm)
[Set up a Kubernetes cluster build infrastructure](https://64e90bb7f3c7703d802dc89f--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure)
[Set up an AWS VM build infrastructure](https://64e90bb7f3c7703d802dc89f--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure)
Build stage settings - [Infrastructure](https://64e90bb7f3c7703d802dc89f--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings#infrastructure)