### PR TITLE
[DOC-3264] Add kms:GenerateDataKey requirement for S3 buckets - custom aws kms key

### DIFF
--- a/docs/platform/7_Connectors/Cloud-providers/ref-cloud-providers/aws-connector-settings-reference.md
+++ b/docs/platform/7_Connectors/Cloud-providers/ref-cloud-providers/aws-connector-settings-reference.md
@@ -32,7 +32,7 @@ To do this, create a [Customer Managed Policy](https://docs.aws.amazon.com/IAM/l
 
 For example:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -79,7 +79,7 @@ There are two required policies to read from AWS S3:
 * **Description:** `Provides read-only access to all buckets via the AWS Management Console`
 * **Policy JSON:**
 
-```
+```json
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -104,7 +104,7 @@ There are two required policies to read from AWS S3:
 * **Description:** `Harness S3 policy that uses EC2 permissions.`
 * **Policy JSON:**
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -131,7 +131,7 @@ There are two [Customer Managed Policies](https://docs.aws.amazon.com/IAM/latest
 * **Description:** `Custom policy for pushing to S3.`
 * **Policy JSON:**
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -145,6 +145,29 @@ There are two [Customer Managed Policies](https://docs.aws.amazon.com/IAM/latest
 }
 ```
 
+:::info note
+If the S3 bucket uses a custom AWS Key Management Service (KMS) key, you must set the `kms:GenerateDataKey` permission to allow write access. For more information, go to [S3 bucket access default encryption](https://repost.aws/knowledge-center/s3-bucket-access-default-encryption) in the AWS Knowledge Center.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": [
+              "kms:Decrypt",
+              "kms:GenerateDataKey",
+              "s3:*Object"
+            ],
+            "Resource": ["arn:aws:s3:::bucket-name/*"]
+        }
+    ]
+}
+```
+
+:::
+
 </details>
 
 <details>
@@ -154,21 +177,25 @@ There are two [Customer Managed Policies](https://docs.aws.amazon.com/IAM/latest
 * **Description:** `Harness S3 policy that uses EC2 permissions.`
 * **Policy JSON:**
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Sid": "VisualEditor0",
             "Effect": "Allow",
-            "Action": "ec2:DescribeRegions",
+            "Action":  [
+              "kms:Decrypt",
+              "kms:GenerateDataKey",
+              "ec2:DescribeRegions"
+            ],
             "Resource": "*"
         }
     ]
 }
 ```
 
-</details>
+</details> 
 
 ### Read and Write to AWS S3
 
@@ -179,7 +206,7 @@ You can have a single policy that reads and writes to an S3 bucket.
 
 Here is a JSON example of a policy that includes AWS console access:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -212,6 +239,46 @@ Here is a JSON example of a policy that includes AWS console access:
 }
 ```
 
+:::info note
+If the S3 bucket uses a custom AWS Key Management Service (KMS) key, you must set the `kms:GenerateDataKey` permission to allow write access. For more information, go to [S3 bucket access default encryption](https://repost.aws/knowledge-center/s3-bucket-access-default-encryption) in the AWS Knowledge Center.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ConsoleAccess",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+                "s3:GetAccountPublicAccessBlock",
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ListObjectsInBucket",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": ["arn:aws:s3:::bucket-name"]
+        },
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::bucket-name/*"]
+        }
+    ]
+}
+```
+
+:::
+
 </details>
 
 For more information, go to the following AWS documentation:
@@ -230,7 +297,7 @@ Use these policies to pull or push to ECR. For more information, go to the AWS d
 * **Description:** `Provides read-only access to Amazon EC2 Container Registry repositories.`
 * **Policy JSON:**
 
-```
+```json
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -261,7 +328,7 @@ Use these policies to pull or push to ECR. For more information, go to the AWS d
 * **Policy ARN:** `arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess`
 * **Policy JSON:**
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -302,7 +369,7 @@ The required policies depend on what you are provisioning. Here are some example
 
 This example policy gives full access to create and manage EKS clusters.
 
-```
+```json
 {
      "Version": "2012-10-17",
      "Statement": [
@@ -329,7 +396,7 @@ This example policy gives full access to create and manage EKS clusters.
 
 This example policy gives limited permission to EKS clusters.
 
-```
+```json
  {
      "Version": "2012-10-17",
      "Statement": [
@@ -390,7 +457,7 @@ Make sure you've met the following requirements to connect to the EKS cloud conn
   
   Here's a sample `kubeconfig`:
   
-  ```
+  ```yaml
   apiVersion: v1
   clusters:
   - cluster:
@@ -472,7 +539,7 @@ To create the AWS user, do the following:
 <details>
 <summary>IAMCredentials.json</summary>
 
-```
+```json
 {
     "Statement": [
         {
@@ -599,7 +666,7 @@ To install Serverless on a Kubernetes delegate, edit the delegate YAML to instal
 1. Open the delegate YAML in a text editor.
 2. Locate the environment variable `INIT_SCRIPT` in the `StatefulSet`.
 
-```
+```yaml
 ...
         - name: INIT_SCRIPT
           value: ""
@@ -608,7 +675,7 @@ To install Serverless on a Kubernetes delegate, edit the delegate YAML to instal
 
 3. Replace the `value` with the follow Serverless installation script:
 
-```
+```yaml
 ...
         - name: INIT_SCRIPT
           value: |-
@@ -683,7 +750,7 @@ The following steps assume this is a new delegate installation and a new AWS con
 5. Add the service account with access to IAM role to the delegate YAML. There are two sections in the Delegate YAML that you must update:
    1. Update the `ClusterRoleBinding` by replacing the subject name `default` with the name of the service account with the attached IAM role, for example:
 
-      ```
+      ```yaml
       ---
       apiVersion: rbac.authorization.k8s.io/v1beta1
       kind: ClusterRoleBinding
@@ -702,7 +769,7 @@ The following steps assume this is a new delegate installation and a new AWS con
 
     2. Add `serviceAccountName` to the `StatefulSet` spec. For example:
 
-      ```
+      ```yaml
       ...
           spec:
             serviceAccountName: myserviceaccount  // New line. Use the same service account name you used in the ClusterRole Binding.


### PR DESCRIPTION
Add `kms:GenerateDataKey` requirement for S3 buckets - custom AWS KMS key

For reviewers, a preview is available.

[AWS connector settings reference](https://64ff8019d0af9f61506bc5e8--harness-developer.netlify.app/docs/platform/Connectors/Cloud-providers/ref-cloud-providers/aws-connector-settings-reference)

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
