### PR TITLE
[DOC-3723] Update proxy provisioning - autostopping

### DIFF
--- a/docs/cloud-cost-management/shared/ccm-supported-platforms.md
+++ b/docs/cloud-cost-management/shared/ccm-supported-platforms.md
@@ -336,6 +336,10 @@ AutoScaling groups behind ALB running HTTP(s) workloads
   - AutoPilot mode
 - Kops
 
+:::important note
+Harness does not currently support importing a VM for AutoStopping proxy creation. Harness will provision the AutoStopping proxy.
+:::
+
 ##### Supported resources
   - Deployment
   - Statefulset
@@ -365,6 +369,11 @@ The supported Kubernetes version for AutoStopping is 1.19 or higher.
 
   - API
   - Terraform
+
+:::important note
+Harness does not currently support proxy provisioning via Terraform.
+
+:::
 
 ### **Supported Platforms**
   - SaaS


### PR DESCRIPTION
 Update proxy provisioning - autostopping in What's supported

For reviewers, a preview is available.

[What's supported](https://650212e439a87142436c168b--harness-developer.netlify.app/docs/cloud-cost-management/whats-supported)

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
