### PR TITLE
FFM-9030 Update JS SDK docs for polling, and correct install script

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -243,7 +243,6 @@ To provide a set of evaluations:
   ```
 
 ## Streaming and Polling Mode
-
 By default, Harness Feature Flags SDK has streaming enabled and polling enabled. Both modes can be toggled according to your preference using the SDK's configuration.
 
 ### Streaming Mode
@@ -296,22 +295,66 @@ The `cf` method allows you to listen for the different events triggered by SDK a
 
 
 ```
-cf.on(Event.READY, flags => {  
-  // Event happens when connection to server is established  
-  // flags contains all evaluations against SDK key  
-})  
-  
-cf.on(Event.CHANGED, flagInfo => {  
-  // Event happens when a changed event is pushed  
-  // flagInfo contains information about the updated feature flag  
-})  
-  
-cf.on(Event.DISCONNECTED, () => {  
-  // Event happens when connection is disconnected  
-})  
-  
-cf.on(Event.ERROR, () => {  
-  // Event happens when a connection error has occurred  
+client.on(Event.READY, flags => {
+  // Event happens when connection to server is established
+  // flags contains all evaluations against SDK key
+})
+
+client.on(Event.FLAGS_LOADED, evaluations => {
+  // Event happens when flags are loaded from the server
+})
+
+client.on(Event.CACHE_LOADED, evaluations => {
+  // Event happens when flags are loaded from the cache
+})
+
+client.on(Event.CHANGED, flagInfo => {
+  // Event happens when a changed event is pushed
+  // flagInfo contains information about the updated feature flag
+})
+
+client.on(Event.DISCONNECTED, () => {
+  // Event happens when connection is disconnected
+})
+
+client.on(Event.CONNECTED, () => {
+  // Event happens when connection established
+})
+
+client.on(Event.RESUMED, () => {
+  // Event happens when a connection has disconnected but then reconnected
+})
+
+client.on(Event.POLLING, () => {
+  // Event happens when polling begins
+})
+
+client.on(Event.POLLING_STOPPED, () => {
+  // Event happens when polling stops
+})
+
+client.on(Event.ERROR, error => {
+  // Event happens when connection some error has occurred
+})
+
+client.on(Event.ERROR_AUTH, error => {
+  // Event happens when unable to authenticate
+})
+
+client.on(Event.ERROR_FETCH_FLAGS, error => {
+  // Event happens when unable to fetch flags from the service
+})
+
+client.on(Event.ERROR_FETCH_FLAG, error => {
+  // Event happens when unable to fetch an individual flag from the service
+})
+
+client.on(Event.ERROR_METRICS, error => {
+  // Event happens when unable to report metrics back to the service
+})
+
+client.on(Event.ERROR_STREAM, error => {
+  // Event happens when the stream returns an error
 })
 ```
 ### Close the event listener

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -321,10 +321,6 @@ client.on(Event.CONNECTED, () => {
   // Event happens when connection established
 })
 
-client.on(Event.RESUMED, () => {
-  // Event happens when a connection has disconnected but then reconnected
-})
-
 client.on(Event.POLLING, () => {
   // Event happens when polling begins
 })

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -237,26 +237,25 @@ To provide a set of evaluations:
 
 ## Streaming and Polling Mode
 
-By default, Harness Feature Flags SDK has streaming enabled and polling disabled. Both modes can be toggled according to your preference using the SDK's configurations.
+By default, Harness Feature Flags SDK has streaming enabled and polling enabled. Both modes can be toggled according to your preference using the SDK's configuration.
 
 ### Streaming Mode
-Streaming mode establishes a continuous connection between your application and Harness' servers. This allows for real-time updates on feature flags without requiring periodic checks. If an error occurs while streaming and `pollingEnabled` is set to `true`, the SDK will automatically fall back to polling mode until streaming can be reestablished. If `pollingEnabled` is `false`, streaming will attempt to reconnect without falling back to polling.
+Streaming mode establishes a continuous connection between your application and the Feature Flags service.
+This allows for real-time updates on feature flags without requiring periodic checks.
+If an error occurs while streaming and `pollingEnabled` is set to `true`,
+the SDK will automatically fall back to polling mode until streaming can be reestablished.
+If `pollingEnabled` is `false`, streaming will attempt to reconnect without falling back to polling.
 
 ### Polling Mode
-In polling mode, the SDK will periodically check with the Harness servers to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
+In polling mode, the SDK will periodically check with the Feature Flags service to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
 
 ### No Streaming or Polling
 If both streaming and polling modes are disabled (`streamEnabled: false` and `pollingEnabled: false`),
-the SDK will not automatically fetch feature flag updates after the initial fetch. This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.
+the SDK will not automatically fetch feature flag updates after the initial fetch.
+This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.
 
 This configuration might be useful in specific scenarios where you want to ensure a consistent set of feature flags
 for a session or when the application operates in an environment where regular updates are not necessary. However, it's essential to be aware that this configuration can lead to outdated flag evaluations if the flags change on the server.
-
-To use the SDK with both modes disabled:
-
-### Configurations
-While both streaming and polling can be enabled, if both are active, streaming takes precedence.
-If streaming encounters an issue and `pollingEnabled` is set to `true`, the SDK will switch to polling mode as a backup until streaming is recovered. If `pollingEnabled` is set to `false`, the SDK will continue attempting to reconnect via streaming.
 
 To configure the modes:
 
@@ -264,7 +263,7 @@ To configure the modes:
 
 const options = {
   streamEnabled: true, // Enable or disable streaming - default is enabled
-  pollingEnabled: false, // Enable or disable polling - default is disabled. Enable to fallback to polling if streaming encounters an issue.
+  pollingEnabled: true, // Enable or disable polling - default is enabled if stream enabled, or disabled if stream disabled.
 }
 
 const client = initialize(
@@ -276,8 +275,7 @@ const client = initialize(
             host: location.href
           }
         },
-        options,
-
+        options
 )
 ```
 

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -83,14 +83,14 @@ Run the following script:
 
 ```
 <script type="module">  
-  import { initialize, Event } from 'https://unpkg.com/@harnessio/ff-javascript-client-sdk@1.8.0/dist/sdk.client.js'  
+  import { initialize, Event } from 'https://unpkg.com/@harnessio/ff-javascript-client-sdk/dist/sdk.client.js'  
 </script>
 ```
 Make sure you install the latest version of the SDK, which you can view in [GitHub](https://github.com/harness/ff-javascript-client-sdk) and in [Version](#version).If you need to support browsers that no longer support ES modules, run the following script instead:
 
 
 ```
-<script src="https://unpkg.com/@harnessio/ff-javascript-client-sdk@1.8.0/dist/sdk.client.js"></script>  
+<script src="https://unpkg.com/@harnessio/ff-javascript-client-sdk/dist/sdk.client-iife.js"></script>  
 <script>  
   var initialize = HarnessFFSDK.initialize  
   var Event = HarnessFFSDK.Event  
@@ -235,6 +235,51 @@ To provide a set of evaluations:
   }
   ```
 
+## Streaming and Polling Mode
+
+By default, Harness Feature Flags SDK has streaming enabled and polling disabled. Both modes can be toggled according to your preference using the SDK's configurations.
+
+### Streaming Mode
+Streaming mode establishes a continuous connection between your application and Harness' servers. This allows for real-time updates on feature flags without requiring periodic checks. If an error occurs while streaming and `pollingEnabled` is set to `true`, the SDK will automatically fall back to polling mode until streaming can be reestablished. If `pollingEnabled` is `false`, streaming will attempt to reconnect without falling back to polling.
+
+### Polling Mode
+In polling mode, the SDK will periodically check with the Harness servers to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
+
+### No Streaming or Polling
+If both streaming and polling modes are disabled (`streamEnabled: false` and `pollingEnabled: false`),
+the SDK will not automatically fetch feature flag updates after the initial fetch. This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.
+
+This configuration might be useful in specific scenarios where you want to ensure a consistent set of feature flags
+for a session or when the application operates in an environment where regular updates are not necessary. However, it's essential to be aware that this configuration can lead to outdated flag evaluations if the flags change on the server.
+
+To use the SDK with both modes disabled:
+
+### Configurations
+While both streaming and polling can be enabled, if both are active, streaming takes precedence.
+If streaming encounters an issue and `pollingEnabled` is set to `true`, the SDK will switch to polling mode as a backup until streaming is recovered. If `pollingEnabled` is set to `false`, the SDK will continue attempting to reconnect via streaming.
+
+To configure the modes:
+
+```typescript
+
+const options = {
+  streamEnabled: true, // Enable or disable streaming - default is enabled
+  pollingEnabled: false, // Enable or disable polling - default is disabled. Enable to fallback to polling if streaming encounters an issue.
+}
+
+const client = initialize(
+        'YOUR_SDK_KEY',
+        {
+          identifier: 'Harness1',
+          attributes: {
+            lastUpdated: Date(),
+            host: location.href
+          }
+        },
+        options,
+
+)
+```
 
 ## Listen for events
 

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -165,9 +165,16 @@ To configure the SDK, you can add `Options`, for example:
 
 
 ```
-interface Options {  
-  baseUrl?: string  
-  debug?: boolean  
+interface Options {
+  baseUrl?: string
+  eventUrl?: string
+  eventsSyncInterval?: number
+  pollingInterval?: number
+  pollingEnabled?: boolean
+  streamEnabled?: boolean
+  allAttributesPrivate?: boolean
+  privateAttributeNames?: string[]
+  debug?: boolean
 }
 ```
 ### Complete the initialization

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -264,6 +264,8 @@ To configure the modes:
 const options = {
   streamEnabled: true, // Enable or disable streaming - default is enabled
   pollingEnabled: true, // Enable or disable polling - default is enabled if stream enabled, or disabled if stream disabled.
+  pollingInterval: 60000, // Polling interval in ms, default is 60000ms which is the minimum. If set below this, will default to 60000ms.
+
 }
 
 const client = initialize(

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -325,6 +325,12 @@ client.on(Event.POLLING, () => {
   // Event happens when polling begins
 })
 
+client.on(Event.POLLING_CHANGED, flagInfo => {
+  // Event happens when SDK polls for flags
+  // flagInfo contains the polled feature flags
+})
+
+
 client.on(Event.POLLING_STOPPED, () => {
   // Event happens when polling stops
 })

--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -242,20 +242,20 @@ To provide a set of evaluations:
   }
   ```
 
-## Streaming and Polling Mode
+## Streaming and polling mode
 By default, Harness Feature Flags SDK has streaming enabled and polling enabled. Both modes can be toggled according to your preference using the SDK's configuration.
 
-### Streaming Mode
+### Streaming mode
 Streaming mode establishes a continuous connection between your application and the Feature Flags service.
 This allows for real-time updates on feature flags without requiring periodic checks.
 If an error occurs while streaming and `pollingEnabled` is set to `true`,
 the SDK will automatically fall back to polling mode until streaming can be reestablished.
 If `pollingEnabled` is `false`, streaming will attempt to reconnect without falling back to polling.
 
-### Polling Mode
+### Polling mode
 In polling mode, the SDK will periodically check with the Feature Flags service to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
 
-### No Streaming or Polling
+### No streaming or polling
 If both streaming and polling modes are disabled (`streamEnabled: false` and `pollingEnabled: false`),
 the SDK will not automatically fetch feature flag updates after the initial fetch.
 This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.


### PR DESCRIPTION
# What
To Support FFM-9030 this adds polling documentation for the JavaScript SDK

Also minor correction for install step to reference the correct distribution for non es module browsers