### PR TITLE
update cache intel endpoints

### DIFF
--- a/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
@@ -230,24 +230,29 @@ The following YAML example uses `<+input>`, which prompts the user to supply a c
 
 You can use the Cache Intelligence API to get information about the cache or delete the cache.
 
-To invoke these APIs, you must have an API key with [core_account_edit](/docs/platform/automation/api/api-permissions-reference) permissions. For information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
+To invoke these APIs, you must:
+
+* Have an API key with [core_account_edit](/docs/platform/automation/api/api-permissions-reference) permissions.
+* Use either `X-API-KEY: $API_KEY` or `Authorization: Bearer $token` for authentication.
+
+For information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
 
 ### Get cache metadata
 
 Get metadata about the cache, such as the size and path.
 
 ```
-curl --location --request GET 'https://app.harness.io/gateway/ci/cache/info?accountIdentifier=$HARNESS_ACCOUNT_ID' \
+curl --location --request GET 'https://app.harness.io/gateway/ci/cache/info' \
 --header 'Accept: application/json' \
---header 'Authorization: Bearer $AUTH_TOKEN'
+--header 'X-API-KEY: $API_KEY'
 ```
 
 ### Delete cache
 
-Delete the cache. You can include an optional `path` parameter to delete a specific sub-directory in the cache.
+Delete the entire cache, or use the optional `path` parameter to delete a specific subdirectory in the cache.
 
 ```
-curl --location --request DELETE 'https://app.harness.io/gateway/ci/cache/info?accountIdentifier=$HARNESS_ACCOUNT_ID&path=/path/to/deleted/directory' \
+curl --location --request DELETE 'https://app.harness.io/gateway/ci/cache?path=/path/to/deleted/directory' \
 --header 'Accept: application/json' \
---header 'Authorization: Bearer $AUTH_TOKEN'
+--header 'X-API-KEY: $API_KEY'
 ```

--- a/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
@@ -230,12 +230,7 @@ The following YAML example uses `<+input>`, which prompts the user to supply a c
 
 You can use the Cache Intelligence API to get information about the cache or delete the cache.
 
-To invoke these APIs, you must:
-
-* Have an API key with [core_account_edit](/docs/platform/automation/api/api-permissions-reference) permissions.
-* Use either `X-API-KEY: $API_KEY` or `Authorization: Bearer $token` for authentication.
-
-For information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
+API key authentication is required. You need a [Harness API key](/docs/platform/automation/api/add-and-manage-api-keys) with [core_account_edit](/docs/platform/automation/api/api-permissions-reference) permission. For more information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys). For more information about authentication, go to the [Harness API documentation](https://apidocs.harness.io/#section/Introduction/Authentication).
 
 ### Get cache metadata
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
@@ -68,7 +68,8 @@ API key authentication is required. For more information about API keys, go to [
 1. Send a `get-default-config` request to get a list of the latest Harness CI build images and tags. You can use the `infra` parameter to get `k8` images or `VM` images.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY'
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?infra=K8" \
+   --header 'X-API-KEY: $API_KEY'
    ```
 
    The response payload shows the latest supported images and their tags, for example:
@@ -98,7 +99,8 @@ API key authentication is required. For more information about API keys, go to [
 2. Send a `get-customer-config` request to get the build images that your CI pipelines currently use. When `overridesOnly` is `true`, which is the default value, this endpoint returns the non-default images that your pipeline uses.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?accountIdentifier=$ACCOUNT_ID&infra=K8&overridesOnly=true" --header 'X-API-KEY: $API_KEY'
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?infra=K8&overridesOnly=true" \
+   --header 'X-API-KEY: $API_KEY'
    ```
 
    If the response contains `null`, your pipeline is using all default images, for example:
@@ -115,7 +117,9 @@ API key authentication is required. For more information about API keys, go to [
 3. Send an `update-config` (POST) request with a list of the images you want to update and the new tags to apply.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY' --header 'Content-Type: application/json'
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?infra=K8" \
+   --header 'X-API-KEY: $API_KEY' \
+   --header 'Content-Type: application/json' \
    --data-raw '[
        {
            "field": "gitCloneTag",
@@ -131,7 +135,9 @@ API key authentication is required. For more information about API keys, go to [
 4. To reset one or more images to their defaults, send a `reset-config` (POST) request with a list of the images to reset.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?accountIdentifier=$ACCOUNT_ID&infra=K8" --header 'X-API-KEY: $API_KEY' --header 'Content-Type: application/json'
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?infra=K8" \
+   --header 'X-API-KEY: $API_KEY' \
+   --header 'Content-Type: application/json' \
    --data-raw '[
        {
            "field": "gitCloneTag"

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
@@ -65,7 +65,9 @@ You can use the Harness CI `execution-config` API to update the images used in y
 
 :::info Authentication
 
-You can use either `X-API-KEY: $API_KEY` or `Authorization: Bearer $token` for authentication. For more information, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
+You can use either `X-API-KEY: $API_KEY` or `Authorization: Bearer $token` for authentication.
+
+For more information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
 
 :::
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
@@ -63,13 +63,7 @@ Drone images are updated as needed. All Drone image updates are backward-compati
 
 You can use the Harness CI `execution-config` API to update the images used in your infrastructure.
 
-:::info Authentication
-
-You can use either `X-API-KEY: $API_KEY` or `Authorization: Bearer $token` for authentication.
-
-For more information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys).
-
-:::
+API key authentication is required. For more information about API keys, go to [Manage API keys](/docs/platform/automation/api/add-and-manage-api-keys). For more information about authentication, go to the [Harness API documentation](https://apidocs.harness.io/#section/Introduction/Authentication).
 
 1. Send a `get-default-config` request to get a list of the latest Harness CI build images and tags. You can use the `infra` parameter to get `k8` images or `VM` images.
 


### PR DESCRIPTION
[Cache Intelligence API](https://651315125ab14b02de4b68c1--harness-developer.netlify.app/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence#cache-intelligence-api)
[Update the images used in your pipelines](https://651315125ab14b02de4b68c1--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci#update-the-images-used-in-your-pipelines)

* x-api-key is preferred auth method.
* x-api-key doesn't require accountIdentifier parameter.
* Delete cache endpoint is not a subpath of /info.