### PR TITLE
Update add-use-text-secrets.md - remove invisible characters

### DIFF
--- a/docs/platform/secrets/add-use-text-secrets.md
+++ b/docs/platform/secrets/add-use-text-secrets.md
@@ -97,13 +97,13 @@ You can reference a secret at the Org scope using an expression with `org`:
 
 
 ```
-<+secrets.getValue("org.Docker_Hub_MRC")>​
+<+secrets.getValue("org.Docker_Hub_MRC")>
 ```
 You can reference a secret at the Account scope using an expression with `account`:
 
 
 ```
-<+secrets.getValue("account.Docker_Hub_MRC")>​​
+<+secrets.getValue("account.Docker_Hub_MRC")>
 ```
 Avoid using `$` in your secret value. If your secret value includes `$`, you must use single quotes when you use the expression in a script.  
 For example, if your secret in the Project scope has a value `'my$secret'`, and identifier `Docker_Hub_MRC`, to echo, use single quotes:  


### PR DESCRIPTION
remove hidden characters that show up when using copy string functionality. When you copy these two secrets and paste them into an editor (e.g. harness pipeline YAML editor, you get a warning "The character U+200b is invisible")

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [x] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
