### PR TITLE
FFM-9486 Add FF SDK Error Codes to Golang and Android SDKs

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/android-sdk-reference.md
@@ -431,3 +431,32 @@ class MainActivity : AppCompatActivity() {
     }  
 }
 ```
+
+## Troubleshooting
+The SDK logs the following codes for certain lifecycle events, for example authentication, which can aid troubleshooting.
+
+| **Code** | **Description**                                          |
+|----------|:---------------------------------------------------------|
+| **1000** | Successfully initialized                                 |
+| **1001** | Failed to initialize due to authentication error         |
+| **1002** | Failed to initialize due to a missing or empty API key   |
+| **2000** | Successfully authenticated                               |
+| **2001** | Authentication failed with a non-recoverable error       |
+| **2002** | Authentication failed and is retrying                    |
+| **2003** | Authentication failed and max retries have been exceeded |
+| **3000** | SDK closing                                              |
+| **3001** | SDK closed successfully                                  |
+| **4000** | Polling service started                                  |
+| **4001** | Polling service stopped                                  |
+| **5000** | Streaming service started                                |
+| **5001** | Streaming service stopped                                |
+| **5002** | Streaming event received                                 |
+| **5003** | Streaming disconnected and is retrying to connect        |
+| **5004** | Streaming stopped                                        |
+| **5005** | Stream is still retrying to connect after 4 attempts     |
+| **6000** | Evaluation was successful                                |
+| **6001** | Evaluation failed and the default value was returned     |
+| **7000** | Metrics service has started                              |
+| **7001** | Metrics service has stopped                              |
+| **7002** | Metrics posting failed                                   |
+| **7003** | Metrics posting success                                  |

--- a/docs/feature-flags/ff-sdks/server-sdks/feature-flag-sdks-go-application.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/feature-flag-sdks-go-application.md
@@ -375,3 +375,33 @@ package main
         cancel()  
 }
 ```
+
+## Troubleshooting
+The SDK logs the following codes for certain lifecycle events, for example authentication, which can aid troubleshooting.
+
+| **Code** | **Description**                                                                                               |
+|----------|:--------------------------------------------------------------------------------------------------------------|
+| **1000** | Successfully initialized                                                                                      |
+| **1001** | Failed to initialize due to authentication error                                                              |
+| **1002** | Failed to initialize due to a missing or empty API key                                                        |
+| **1003** | `WaitForInitialization` configuration option was provided and the SDK is waiting for initialization to finish |
+| **2000** | Successfully authenticated                                                                                    |
+| **2001** | Authentication failed with a non-recoverable error                                                            |
+| **2002** | Authentication failed and is retrying                                                                         |
+| **2003** | Authentication failed and max retries have been exceeded                                                      |
+| **3000** | SDK closing                                                                                                   |
+| **3001** | SDK closed successfully                                                                                       |
+| **4000** | Polling service started                                                                                       |
+| **4001** | Polling service stopped                                                                                       |
+| **5000** | Streaming service started                                                                                     |
+| **5001** | Streaming service stopped                                                                                     |
+| **5002** | Streaming event received                                                                                      |
+| **5003** | Streaming disconnected and is retrying to connect                                                             |
+| **5004** | Streaming stopped                                                                                             |
+| **5005** | Stream is still retrying to connect after 4 attempts                                                          |
+| **6000** | Evaluation was successful                                                                                     |
+| **6001** | Evaluation failed and the default value was returned                                                          |
+| **7000** | Metrics service has started                                                                                   |
+| **7001** | Metrics service has stopped                                                                                   |
+| **7002** | Metrics posting failed                                                                                        |
+| **7003** | Metrics posting success                                                                                       |


### PR DESCRIPTION
# What
Adds SDK codes to Golang and Android

# Why
We are rolling out SDK codes across the FF SDKs, one by one
