### PR TITLE
CI-7017 add info about uploading logs larger than 5mb

### DIFF
--- a/docs/continuous-integration/troubleshoot-ci/troubleshooting-ci.md
+++ b/docs/continuous-integration/troubleshoot-ci/troubleshooting-ci.md
@@ -72,6 +72,22 @@ Each CI step supports a maximum log size of 5MB. Harness truncates logs larger t
 
 Furthermore, there is a single-line limit of 70KB. If an individual line exceeds this limit, it is truncated and ends with `(log line truncated)`.
 
+### Export full logs
+
+If your log files are larger than 5MB, you can export execution logs to an external cache and examine the full logs there.
+
+1. Add a step to your pipeline that records each step's complete logs into one or more files.
+2. If you have a lot of log files or your logs are large, add a step to compress the log files into an archive.
+3. Use an [Upload Artifact step](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact.md#upload-artifacts) to upload the log files to cloud storage.
+4. Repeat the above process for each stage in your pipeline for which you want to export the full logs.
+5. Examine the log files in your cloud storage. If you used the **S3 Upload and Publish** or **Artifact Metadata Publisher** plugins, you can find direct links to your uploaded files on the **Artifacts** tab on the [Build detail page](../use-ci/viewing-builds.md).
+
+:::tip Log forwarding
+
+You can also use a service, such as [env0](https://docs.env0.com/docs/logs-forwarding), to forward logs to platforms suited for ingesting large logs.
+
+:::
+
 ## Step logs disappear
 
 If step logs disappear from pipelines that are using a Kubernetes cluster build infrastructure, you must either allow outbound communication with `storage.googleapis.com` or contact [Harness Support](mailto:support@harness.io) to enable the `CI_INDIRECT_LOG_UPLOAD` feature flag.

--- a/docs/continuous-integration/use-ci/viewing-builds.md
+++ b/docs/continuous-integration/use-ci/viewing-builds.md
@@ -24,19 +24,39 @@ The **Builds** page provides the following information about current and past bu
 
 On the **Build details** page, you can investigate a variety of details about a specific build.
 
-* **Pipeline:** This tab shows the build stages and steps.
-
-  Select a step to investigate logs, inputs, outputs, and errors (if any) for that steps. If enabled, [AIDA](../troubleshoot-ci/aida.md) can provide troubleshooting assistance.
-
-  When troubleshooting failed builds, you can switch to **Console View** to allocate more screen space to logs. Once you've identified a potential cause, select **Edit Pipeline** to go directly to the Pipeline Studio.
-
-* **Inputs**: This tab lists pipeline-level inputs. Step-level inputs are reported in the step details on the **Pipeline** tab.
-* **Artifacts:** This tab provides links to artifacts, such as images or reports, produced during the build. Availability of artifact details depends on the upload location, build configuration, or build infrastructure. For an example and more information, go to [View tests - View reports on the Artifacts tab](./run-tests/viewing-tests.md#view-reports-on-the-artifacts-tab).
-* **Commits:** This tab provides a list of commits that triggered the build, along with [source code repo links](#source-code-repository-links), if applicable.
-* **Tests:** This tab presents test results from **Run** or **Run Tests** steps. For more information, go to [View tests](./run-tests/viewing-tests.md).
-* **Policy Evaluations**, **Security Tests**, and **Error Tracking**: These tabs report [Error Tracking](#error-tracking-run-tests-step) information and information from other Harness modules and features, such as [Harness Policy As Code](/docs/platform/governance/Policy-as-code/harness-governance-quickstart#step-6-review-policy-evaluations), if these are enabled and included in the pipeline.
-
 ![The Build details page.](./static/ci-build-details-page.png)
+
+### Pipeline tab (logs)
+
+This tab shows the build stages and steps.
+
+Select a step to investigate logs, inputs, outputs, and errors (if any) for that steps. If enabled, [AIDA](../troubleshoot-ci/aida.md) can provide troubleshooting assistance.
+
+When troubleshooting failed builds, you can switch to **Console View** to allocate more screen space to logs. Once you've identified a potential cause, select **Edit Pipeline** to go directly to the Pipeline Studio.
+
+Logs are limited to 5MB, if you need to examine logs larger than 5MB, you need to [export full logs](../troubleshoot-ci/troubleshooting-ci.md#export-full-logs).
+
+### Inputs tab
+
+This tab lists pipeline-level inputs. Step-level inputs are reported in the step details on the [Pipeline tab](#pipeline-tab-logs).
+
+### Artifacts tab
+
+This tab provides links to artifacts, such as images or reports, produced during the build.
+
+Availability of artifact details depends on the upload location, build configuration, or build infrastructure. For an example and more information, go to [View tests - View reports on the Artifacts tab](./run-tests/viewing-tests.md#view-reports-on-the-artifacts-tab).
+
+### Commits tab
+
+This tab provides a list of commits that triggered the build, along with [source code repo links](#source-code-repository-links), if applicable.
+
+### Tests tab
+
+This tab presents test results from **Run** or **Run Tests** steps. For more information, go to [View tests](./run-tests/viewing-tests.md).
+
+### Other tabs
+
+The **Policy Evaluations**, **Security Tests**, and **Error Tracking** tabs report [Error Tracking](#error-tracking-run-tests-step) information and information from other Harness modules and features, such as [Harness Policy As Code](/docs/platform/governance/Policy-as-code/harness-governance-quickstart#step-6-review-policy-evaluations), if these are enabled and included in the pipeline.
 
 ## Source code repository links
 


### PR DESCRIPTION
Add [Export full logs](https://65246d524b0bda497f61fe29--harness-developer.netlify.app/docs/continuous-integration/troubleshoot-ci/troubleshooting-ci#export-full-logs) to Troubleshoot CI with existing truncated log info.
Add link to export full logs steps in Build details - [Pipeline tab (logs)](https://65246d524b0bda497f61fe29--harness-developer.netlify.app/docs/continuous-integration/use-ci/viewing-builds#pipeline-tab-logs)