### PR TITLE
FFM-9593 Add table of options for JS SDK

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -161,8 +161,7 @@ The characters can be lowercase or uppercase and can include accented letters, f
 
 ### Configure the SDK
 
-To configure the SDK, you can add `Options`, for example:
-
+When initializing the SDK, you also have the option of providing alternative configurations by using the `Options` interface.
 
 ```
 interface Options {
@@ -177,6 +176,21 @@ interface Options {
   debug?: boolean
 }
 ```
+
+|                       |                                                                                                                                   |                                                        |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| Name                  | Description                                                                                                                       | Default value                                          |
+| baseURL               | The URL used to fetch Feature Flag Evaluations. When using the Relay Proxy, change this to: http://localhost:7000                 | `https://config.ff.harness.io/api/1.0`                 |
+| eventUrl              | The URL for posting metrics data to the Feature Flag service. When using the Relay Proxy, change this to: `http://localhost:7000` | `https://events.ff.harness.io/api/1.0`                 |
+| eventsSyncInterval    | The interval **in milliseconds** that we post flag evaluation metrics.                                                            | `60000` (milliseconds)                                 |
+| pollingInterval       | The interval **in milliseconds** that we poll for changes when the SDK is running in polling mode.                                | `60000` (milliseconds)                                 |
+| streamEnabled         | Set to `true` to enable streaming mode.Set to `false` to disable streaming mode.                                                  | `true`                                                 |
+| pollingEnabled        | Set to `true` to enable polling mode.Set to `false` to disable polling mode.                                                      | `true`                                                 |
+| debug                 | Set to `true` to enable SDK debug level logging. Set to `false` to disable debug level logging                                    | `false`                                                |
+| allAttributesPrivate  | **Deprecated** no longer has any effect                                                                                           | No default - deprecated                                |
+| privateAttributeNames | **Deprecated** no longer has any effect                                                                                           | No default - deprecated                                |
+
+
 ### Complete the initialization
 
 Complete the initialization using the FeatureFlagSDKKey, target, and Options variables:


### PR DESCRIPTION
# What
- Add table which explains FF JavaScript SDK Options

# Why
Customer raised unclear docs in this area, and 2 of the options are invalid and I've marked them as deprecated. 
We can't remove them from the interface as that would technically be a breaking change, so the best option is to mark them as deprecated.

CC @ethangj 