### PR TITLE
CI-9848, CI-9847 - local runner build infra and daemon troubleshooting

### DIFF
--- a/docs/continuous-integration/troubleshoot-ci/troubleshooting-ci.md
+++ b/docs/continuous-integration/troubleshoot-ci/troubleshooting-ci.md
@@ -66,6 +66,10 @@ For more information about self-signed certificates, delegates, and delegate env
 * [Install delegates](/docs/category/install-delegates)
 * [Configure a Kubernetes build farm to use self-signed certificates](/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md)
 
+## Clone codebase errors
+
+For troubleshooting information related to cloning codebases, go to [Create and configure a codebase - Troubleshooting](/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md#troubleshooting).
+
 ## Truncated execution logs
 
 Each CI step supports a maximum log size of 5MB. Harness truncates logs larger than 5MB.
@@ -151,3 +155,11 @@ To change the connector's connectivity settings:
 ## Can't connect to Docker daemon
 
 <DindTrbs />
+
+## Troubleshoot AWS VM build infrastructures
+
+For troubleshooting information for AWS VM build infrastructures, go to [Set up an AWS VM build infrastructure - Troubleshooting](/docs/continuous-integration/use-ci/set-up-build-infrastructure/vm-build-infrastructure/set-up-an-aws-vm-build-infrastructure.md#troubleshooting).
+
+## Troubleshoot local runner build infrastructures
+
+For troubleshooting information for local runner build infrastructures, go to [Set up a local runner build infrastructure - Troubleshooting](/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md#troubleshooting-the-delegate-connection).

--- a/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
@@ -213,3 +213,15 @@ properties:
           memory: 4G ## Set the maximum memory to use. You can express memory as a plain integer or as a fixed-point number using the suffixes `G` or `M`. You can also use the power-of-two equivalents `Gi` and `Mi`. The default is `500Mi`.
           cpu: "2" ## Set the maximum number of cores to use. CPU limits are measured in CPU units. Fractional requests are allowed; for example, you can specify one hundred millicpu as `0.1` or `100m`.
 ```
+
+### Initial Git clone fails due to missing plugin
+
+This error can occur in build infrastructures that use a Harness Docker Runner, such as the [local runner build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md) or the [VM build infrastructures](/docs/category/set-up-vm-build-infrastructures).
+
+If Git clone fails during stage setup (the **Initialize** step in build logs) and the runner's logs contain `Error response from daemon: plugin \"<plugin>\" not found`, this means a required plugin is missing from your build infrastructure container's Docker installation. The plugin is required to configure Docker networks.
+
+To resolve this issue:
+
+1. On the machine where the runner is running, stop the runner.
+2. Set the `NETWORK_DRIVER` environment variable to your preferred network driver plugin, such as `export NETWORK_DRIVER="nat"` or `export NETWORK_DRIVER="bridge"`.
+3. Restart the runner.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -17,51 +17,73 @@ import TabItem from '@theme/TabItem';
 
 You can define a CI build infrastructure on a Linux, macOS, or Windows host by installing a Harness Docker Delegate and local Harness Docker Runner. When the pipeline runs, the Harness Docker Runner runs the build actions in the environment where it is installed. The delegate handles communication between the Harness Platform and the Harness Docker Runner.
 
+* [Set up a Linux local runner build infrastructure](#set-up-a-linux-local-runner)
+* [Set up a macOS local runner build infrastructure](#set-up-a-macos-local-runner)
+* [Set up a Windows local runner build infrastructure](#set-up-a-windows-local-runner)
+
 Local runner build infrastructure is recommended for small, limited builds, such as a one-off build on your local machine. Consider [other build infrastructure options](/docs/category/set-up-build-infrastructure) for builds-at-scale.
 
-## Docker delegate requirements
+## Set up a Linux local runner
 
-The Harness Docker Delegate is limited by the total amount of memory and CPU on the local host. Builds can fail if the host runs out of CPU or memory when running multiple builds. The Harness Docker Delegate has the following system requirements:
+### Prepare machines
 
-* Default 0.5 CPU.
-* Default 1.5GB. Ensure that you provide the minimum memory for the delegate and enough memory for the host/node system.
+Review the following requirements for local runner build infrastructures:
+
+* There is a one-to-one relationship between Harness Docker Runners and Harness Delegates. If you need to run three local hosts, each host needs a runner and a delegate.
+* The Harness Docker Delegate is limited by the total amount of memory and CPU on the local host. Builds can fail if the host runs out of CPU or memory when running multiple builds. The Harness Docker Delegate has the following system requirements:
+   * Default 0.5 CPU.
+   * Default 1.5GB. Ensure that you provide the minimum memory for the delegate and enough memory for the host/node system.
 * The machine where the delegate runs must have Docker installed.
 
-## Install the delegate and runner
+### Install the delegate
 
-```mdx-code-block
-<Tabs>
-  <TabItem value="Linux" label="Linux" default>
-```
-#### Install the delegate
+1. In Harness, go to **Account Settings**, select **Account Resources**, and then select **Delegates**.
 
-Use the following modifications along with the **Docker** instructions in [Install the default delegate on Kubernetes or Docker](/docs/platform/delegates/install-delegates/overview/):
+   You can also create delegates at the project scope. To do this, go to your Harness CI project, select **Project Setup**, and then select **Delegates**.
 
-* Add `--net=host` to the first line.
-* Add `-e DELEGATE_TAGS="<delegate-tag>"`. Use the tag for your Docker environment's architecture: `linux-amd64` or `linux-arm64`.
+2. Select **New Delegate** or **Install Delegate**.
+3. Select **Docker**.
+4. Enter a **Delegate Name**.
+5. Copy the delegate install command and modify it as follows:
 
-Here's an example of an install script for Linux arm64:
+   * Add `--net=host` to the first line.
+   * Add `-e DELEGATE_TAGS="DELEGATE_OS_ARCH"`, and replace `DELEGATE_OS_ARCH` with the tag corresponding to your Docker environment's architecture: `linux-amd64` or `linux-arm64`.
 
-```
-docker run --cpus=1 --memory=2g --net=host \
-  -e DELEGATE_NAME=docker-delegate \
-  -e NEXT_GEN="true" \
-  -e DELEGATE_TYPE="DOCKER" \
-  -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
-  -e DELEGATE_TOKEN=YOUR_API_TOKEN \
-  -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/log-service/ \
-  -e DELEGATE_TAGS="linux-arm64" \
-  -e MANAGER_HOST_AND_PORT=https://app.harness.io/ harness/delegate:23.02.78306
-```
+   Here's an example of an install script for Linux arm64:
 
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+   ```
+   docker run --cpus=1 --memory=2g --net=host \
+     -e DELEGATE_NAME=docker-delegate \
+     -e NEXT_GEN="true" \
+     -e DELEGATE_TYPE="DOCKER" \
+     -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
+     -e DELEGATE_TOKEN=YOUR_API_TOKEN \
+     -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/log-service/ \
+     -e DELEGATE_TAGS="linux-arm64" \
+     -e MANAGER_HOST_AND_PORT=https://app.harness.io/ harness/delegate:23.02.78306
+   ```
 
-#### Install the Harness Docker Runner
+6. Run the modified install command on your build host machine.
+
+:::tip
+
+The delegate install command uses the default authentication token for your Harness account. If you want to use a different token, you can create a token and then specify it in the delegate install command:
+
+1. In Harness, go to **Account Settings**, then **Account Resources**, and then select **Delegates**.
+2. Select **Tokens** in the header, and then select **New Token**.
+3. Enter a token name and select **Apply** to generate a token.
+4. Copy the token and paste it in the value for `DELEGATE_TOKEN`.
+
+:::
+
+For more information about delegates and delegate installation, go to [Delegate installation overview](/docs/platform/delegates/install-delegates/overview).
+
+### Install the Harness Docker Runner
 
 The Harness Docker Runner service performs the build work. The delegate needs the runner to run CI builds.
 
 1. Download a [Harness Docker Runner executable](https://github.com/harness/harness-docker-runner/releases) corresponding to your build farm's OS and architecture.
-2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
+2. (Optional) To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
    export CI_MOUNT_VOLUMES="[path/to/local/cert];/etc/ssl/certs/ca-certificates.crt,[path/to/local/cert2];/etc/ssl/certs/cacerts.pem"
@@ -93,40 +115,68 @@ sudo chmod +x harness-docker-runner-linux-arm64
 ./harness-docker-runner-linux-arm64 server
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="macOS" label="macOS">
-```
-#### Install the delegate
+## Set up a macOS local runner
 
-Use the following modifications along with the **Docker** instructions in [Install the default delegate on Kubernetes or Docker](/docs/platform/delegates/install-delegates/overview/):
+### Prepare machines
 
-* Add `-e DELEGATE_TAGS="<delegate-tag>"`. Use the tag for your Docker environment's architecture: `macos-amd64` or `macos-arm64`.
-* Add `-e RUNNER_URL=http://host.docker.internal:3000`.
+Review the following requirements for local runner build infrastructures:
 
-Here's an example of an install script for macOS amd64:
+* There is a one-to-one relationship between Harness Docker Runners and Harness Delegates. If you need to run three local hosts, each host needs a runner and a delegate.
+* The Harness Docker Delegate is limited by the total amount of memory and CPU on the local host. Builds can fail if the host runs out of CPU or memory when running multiple builds. The Harness Docker Delegate has the following system requirements:
+   * Default 0.5 CPU.
+   * Default 1.5GB. Ensure that you provide the minimum memory for the delegate and enough memory for the host/node system.
+* The machine where the delegate runs must have Docker installed.
 
-```
-docker run --cpus=1 --memory=2g \
-  -e DELEGATE_NAME=docker-delegate \
-  -e NEXT_GEN="true" \
-  -e DELEGATE_TYPE="DOCKER" \
-  -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
-  -e DELEGATE_TOKEN=YOUR_API_TOKEN \
-  -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/gratis/log-service/ \
-  -e DELEGATE_TAGS="macos-amd64" \
-  -e RUNNER_URL=http://host.docker.internal:3000 \
-  -e MANAGER_HOST_AND_PORT=https://app.harness.io/gratis harness/delegate:23.02.78306
-```
+### Install the delegate
 
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
+1. In Harness, go to **Account Settings**, select **Account Resources**, and then select **Delegates**.
 
-#### Install the Harness Docker Runner
+   You can also create delegates at the project scope. To do this, go to your Harness CI project, select **Project Setup**, and then select **Delegates**.
+
+2. Select **New Delegate** or **Install Delegate**.
+3. Select **Docker**.
+4. Enter a **Delegate Name**.
+5. Copy the delegate install command and modify it as follows:
+
+   * Add `-e DELEGATE_TAGS="DELEGATE_OS_ARCH"`, and replace `DELEGATE_OS_ARCH` with the tag corresponding to your Docker environment's architecture: `macos-amd64` or `macos-arm64`.
+   * Add `-e RUNNER_URL=http://host.docker.internal:3000`.
+
+   Here's an example of an install script for macOS amd64:
+
+   ```
+   docker run --cpus=1 --memory=2g \
+     -e DELEGATE_NAME=docker-delegate \
+     -e NEXT_GEN="true" \
+     -e DELEGATE_TYPE="DOCKER" \
+     -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
+     -e DELEGATE_TOKEN=YOUR_API_TOKEN \
+     -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/gratis/log-service/ \
+     -e DELEGATE_TAGS="macos-amd64" \
+     -e RUNNER_URL=http://host.docker.internal:3000 \
+     -e MANAGER_HOST_AND_PORT=https://app.harness.io/gratis harness/delegate:23.02.78306
+   ```
+
+6. Run the modified install command on your build host machine.
+
+:::tip
+
+The delegate install command uses the default authentication token for your Harness account. If you want to use a different token, you can create a token and then specify it in the delegate install command:
+
+1. In Harness, go to **Account Settings**, then **Account Resources**, and then select **Delegates**.
+2. Select **Tokens** in the header, and then select **New Token**.
+3. Enter a token name and select **Apply** to generate a token.
+4. Copy the token and paste it in the value for `DELEGATE_TOKEN`.
+
+:::
+
+For more information about delegates and delegate installation, go to [Delegate installation overview](/docs/platform/delegates/install-delegates/overview).
+
+### Install the Harness Docker Runner
 
 The Harness Docker Runner service performs the build work. The delegate needs the runner to run CI builds.
 
 1. Download a [Harness Docker Runner executable](https://github.com/harness/harness-docker-runner/releases) corresponding to your build farm's OS and architecture.
-2. To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
+2. (Optional) To use self-signed certificates, export `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
    export CI_MOUNT_VOLUMES="[path/to/local/cert];/etc/ssl/certs/ca-certificates.crt,[path/to/local/cert2];/etc/ssl/certs/cacerts.pem"
@@ -177,51 +227,71 @@ sudo chmod +x harness-docker-runner-darwin-arm64
 ./harness-docker-runner-darwin-arm64 server
 ```
 
-```mdx-code-block
-  </TabItem>
-  <TabItem value="windows" label="Windows">
-```
+## Set up a Windows local runner
 
-#### Prepare machines
+### Prepare machines
 
-To configure a local runner build infrastructure for Windows, you need two machines:
+Review the following requirements for Windows local runner build infrastructures:
 
-* A Windows machine where the Harness Docker Runner will run. This machine must have Docker for Windows. The Harness Docker Runner runs as a container.
-* A Linux or macOS machine where the Harness Delegate will run. This machine must have Docker. The delegate runs as a container.
+* You need two machines *for each build host*:
+   * A Windows machine where the Harness Docker Runner will run. **This machine must have Docker for Windows installed.** The Harness Docker Runner runs as a container.
+   * A Linux or macOS machine where the Harness Delegate will run. **This machine must have Docker installed.** The delegate runs as a container.
+* There is a one-to-one relationship between Harness Docker Runners and Harness Delegates. If you need to run three local hosts, each host needs a runner machine and a delegate machine.
+* The Harness Docker Delegate is limited by the total amount of memory and CPU on the local host. Builds can fail if the host runs out of CPU or memory when running multiple builds. The Harness Docker Delegate has the following system requirements:
+   * Default 0.5 CPU.
+   * Default 1.5GB. Ensure that you provide the minimum memory for the delegate and enough memory for the host/node system.
 
-There is a one-to-one relationship between Harness Docker Runners and Harness Delegates. If you need to run three local hosts, each must have a runner and a delegate.
+### Install the delegate
 
-#### Install the delegate
+1. In Harness, go to **Account Settings**, select **Account Resources**, and then select **Delegates**.
 
-On the Linux or macOS machine where you want to run the delegate, use the following modifications along with the **Docker** instructions in [Install the default delegate on Kubernetes or Docker](/docs/platform/delegates/install-delegates/overview/):
+   You can also create delegates at the project scope. To do this, go to your Harness CI project, select **Project Setup**, and then select **Delegates**.
 
-* Add `-e DELEGATE_TAGS="windows-amd64"`.
-* Add `-e RUNNER_URL=http://WINDOWS_MACHINE_HOSTNAME_OR_IP:3000`.
+2. Select **New Delegate** or **Install Delegate**.
+3. Select **Docker**.
+4. Enter a **Delegate Name**.
+5. Copy the delegate install command and modify it as follows:
 
-:::caution
+   * Add `-e DELEGATE_TAGS="windows-amd64"`.
+   * Add `-e RUNNER_URL=http://WINDOWS_MACHINE_HOSTNAME_OR_IP:3000`.
 
-The `RUNNER_URL` must point to the Windows machine where the Harness Docker Runner will run.
+   :::caution
+
+   The `RUNNER_URL` must point to the Windows machine where the Harness Docker Runner will run.
+
+   :::
+
+   Here's an example of the delegate install script for a local runner Windows build infrastructure:
+
+   ```
+   docker run --cpus=1 --memory=2g \
+     -e DELEGATE_NAME=docker-delegate \
+     -e NEXT_GEN="true" \
+     -e DELEGATE_TYPE="DOCKER" \
+     -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
+     -e DELEGATE_TOKEN=YOUR_API_TOKEN \
+     -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/gratis/log-service/ \
+     -e DELEGATE_TAGS="windows-amd64" \
+     -e RUNNER_URL=http://WINDOWS_MACHINE_HOSTNAME_OR_IP:3000 \
+     -e MANAGER_HOST_AND_PORT=https://app.harness.io/gratis harness/delegate:23.02.78306
+   ```
+
+6. Run the modified install command on the Linux or macOS machine where you want to run the delegate.
+
+:::tip
+
+The delegate install command uses the default authentication token for your Harness account. If you want to use a different token, you can create a token and then specify it in the delegate install command:
+
+1. In Harness, go to **Account Settings**, then **Account Resources**, and then select **Delegates**.
+2. Select **Tokens** in the header, and then select **New Token**.
+3. Enter a token name and select **Apply** to generate a token.
+4. Copy the token and paste it in the value for `DELEGATE_TOKEN`.
 
 :::
 
-Here's an example of the delegate install script for a local runner Windows build infrastructure:
+For more information about delegates and delegate installation, go to [Delegate installation overview](/docs/platform/delegates/install-delegates/overview).
 
-```
-docker run --cpus=1 --memory=2g \
-  -e DELEGATE_NAME=docker-delegate \
-  -e NEXT_GEN="true" \
-  -e DELEGATE_TYPE="DOCKER" \
-  -e ACCOUNT_ID=H5W8iol5TNWc4G9h5A2MXg \
-  -e DELEGATE_TOKEN=YOUR_API_TOKEN \
-  -e LOG_STREAMING_SERVICE_URL=https://app.harness.io/gratis/log-service/ \
-  -e DELEGATE_TAGS="windows-amd64" \
-  -e RUNNER_URL=http://WINDOWS_MACHINE_HOSTNAME_OR_IP:3000 \
-  -e MANAGER_HOST_AND_PORT=https://app.harness.io/gratis harness/delegate:23.02.78306
-```
-
-Make sure to create the delegate at the appropriate scope, such as the project level or account level.
-
-#### Install the Harness Docker Runner
+### Install the Harness Docker Runner
 
 The Harness Docker Runner service performs the build work. The delegate needs the runner to run CI builds.
 
@@ -235,7 +305,7 @@ Use PowerShell to run these commands.
 
 1. On the target Windows machine where you want to run the Harness Docker Runner, download the Windows [Harness Docker Runner executable](https://github.com/harness/harness-docker-runner/releases).
 2. Open a terminal with Administrator privileges.
-3. To use self-signed certificates, set `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
+3. (Optional) To use self-signed certificates, set `CI_MOUNT_VOLUMES` along with a comma-separated list of source paths and destination paths formatted as `path/to/source:path/to/destination`, for example:
 
    ```
    $env:CI_MOUNT_VOLUMES="C:\Users\installer\Downloads\certs;C:/Users/ContainerAdministrator/.jfrog/security/certs"
@@ -259,11 +329,6 @@ Here is an example of the two commands to install the Windows amd64 Harness Dock
 ```
 $env:CI_MOUNT_VOLUMES="C:\Users\installer\Downloads\certs;C:/Users/ContainerAdministrator/.jfrog/security/certs"
 harness-docker-runner-windows-amd64.exe server
-```
-
-```mdx-code-block
-  </TabItem>
-</Tabs>
 ```
 
 ## Set the pipeline's build infrastructure
@@ -331,7 +396,9 @@ For example, assume you have a pipeline with three stages called `alpha`, `beta`
 
 :::
 
-## Troubleshooting the delegate connection
+## Troubleshooting
+
+### Check the delegate status
 
 The delegate should connect to your instance after you finish the installation workflow above. If the delegate does not connect after a few minutes, run the following commands to check the status:
 
@@ -343,3 +410,36 @@ docker logs --follow <docker-delegate-container-id>
 The container ID should be the container with image name `harness/delegate:latest`.
 
 Successful setup is indicated by a message such as `Finished downloading delegate jar version 1.0.77221-000 in 168 seconds`.
+
+### Clone codebase fails due to missing plugin
+
+If [clone codebase](../codebase-configuration/create-and-configure-a-codebase.md) fails during stage setup (the **Initialize** step in build logs) and the runner's logs contain `Error response from daemon: plugin \"<plugin>\" not found`, this means a required plugin is missing from your build infrastructure container's Docker installation. The plugin is required to configure Docker networks.
+
+To resolve this issue:
+
+1. On the machine where the runner is running, stop the runner.
+2. Set the `NETWORK_DRIVER` environment variable to your preferred network driver plugin, such as `export NETWORK_DRIVER="nat"` or `export NETWORK_DRIVER="bridge"`.
+3. Restart the runner.
+
+### Windows daemon fails with invalid working directory path
+
+The following error can occur in Windows local runner build infrastructures:
+
+```
+Error response from daemon: the working directory 'C:\harness-DIRECTORY_ID' is invalid, it needs to be an absolute path
+```
+
+This error indicates there may be a problem with the Docker installation on the host machine.
+
+1. Run the following command (or a similar command) to check if the same error occurs:
+
+   ```
+   docker run -w C:\blah -it -d mcr.microsoft.com/windows/servercore:ltsc2022
+   ```
+
+2. If you get the `working directory is invalid` error again, uninstall Docker and follow the instructions in the Windows documentation to [Prepare Windows OS containers for Windows Server](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=dockerce#windows-server-1).
+3. Restart the host machine.
+
+### Check if the Docker daemon is running
+
+To check if the Docker daemon is running, use the `docker info` command. An error response indicates the daemon is not running. For more information, go to the Docker documentation on [Troubleshooting the Docker daemon](https://docs.docker.com/config/daemon/troubleshoot/)


### PR DESCRIPTION
* [Set up a local runner build infrastructure](https://65259954ed03f717c915fc5d--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure):
   * Change layout
   * Group machine requirements under each OS's instructions
   * Revise delegate install steps
   * Mark self-signed certs as optional
   * Add several troubleshooting items
* Add network driver error to codebase config troubleshooting: [Initial Git clone fails due to missing plugin](https://65259954ed03f717c915fc5d--harness-developer.netlify.app/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase#initial-git-clone-fails-due-to-missing-plugin)