### PR TITLE
[CDS-80906] Add CD service hooks to 0.9.1 patch rn

### DIFF
--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -740,6 +740,12 @@ gsutil -m cp \
 
    This fix requires Harness Delegate version 23.08.80308 or later. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
+- You can now use service hooks to fetch Helm Chart dependencies from Git and other repositories and install them with the main Helm Chart for Kubernetes and Helm deployments. (CDS-50552)
+
+   This feature is behind the feature flag `CDS_K8S_SERVICE_HOOKS_NG`. Contact [Harness Support](mailto:support@harness.io) to enable this feature. 
+
+   For more information, go to [Service hooks](/docs/continuous-delivery/deploy-srv-diff-platforms/helm/deploy-helm-charts/#service-hooks).
+
 ## Previous releases
 
 <details>


### PR DESCRIPTION
Add CD service hooks to 0.9.1 patch rn

For reviewers, a preview is available.

https://6525c7c27d422a44215c9d13--harness-developer.netlify.app/release-notes/self-managed-enterprise-edition#patches

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
