### PR TITLE
Revert pr 3480

### DIFF
--- a/docs/continuous-integration/shared/docker-hub-rate-limiting-trbs.md
+++ b/docs/continuous-integration/shared/docker-hub-rate-limiting-trbs.md
@@ -1,5 +1,7 @@
 By default, Harness uses anonymous Docker access to connect to [pull Harness images](/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md). If you experience rate limiting issues when pulling images, try one of these solutions:
 
-* Use credentialed access, rather than anonymous access, to pull Harness CI images. For instructions, go to [Connect to the Harness container image registry](/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md).
-* Configure the default Docker connector to pull images from the public [Harness GCR project](https://console.cloud.google.com/gcr/images/gcr-prod/global/harness) instead of Docker Hub. For instructions, go to [Connect to the Harness container image registry](/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md).
-* Sync the Harness images to your own private registry, [specify the images that you want Harness to use](/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md#specify-the-harness-ci-images-used-in-your-pipelines), and then configure a Docker connector to pull the images from your private repo. For an example demonstrating how to do this, go to [Configure STO to download images from a private registry](/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry.md).
+* Use credentialed access, rather than anonymous access, to pull Harness CI images.
+* Configure the default Docker connector to pull images from the public [Harness GCR project](https://console.cloud.google.com/gcr/images/gcr-prod/global/harness) instead of Docker Hub.
+* Pull Harness images from your own private registry.
+
+For instructions on each of these options, go to [Connect to the Harness container image registry](/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md).

--- a/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
@@ -243,7 +243,7 @@ API key authentication is required. You need a [Harness API key](/docs/platform/
 Get metadata about the cache, such as the size and path.
 
 ```
-curl --location --request GET 'https://app.harness.io/gateway/ci/cache/info' \
+curl --location --request GET 'https://app.harness.io/gateway/ci/cache/info?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID' \
 --header 'Accept: application/json' \
 --header 'X-API-KEY: $API_KEY'
 ```
@@ -253,7 +253,7 @@ curl --location --request GET 'https://app.harness.io/gateway/ci/cache/info' \
 Delete the entire cache, or use the optional `path` parameter to delete a specific subdirectory in the cache.
 
 ```
-curl --location --request DELETE 'https://app.harness.io/gateway/ci/cache?path=/path/to/deleted/directory' \
+curl --location --request DELETE 'https://app.harness.io/gateway/ci/cache?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID&path=/path/to/deleted/directory' \
 --header 'Accept: application/json' \
 --header 'X-API-KEY: $API_KEY'
 ```

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
@@ -49,7 +49,7 @@ If you don't want the Harness Delegate to pull images anonymously, you can use c
 
 ### I don't want to pull images from a public registry
 
-Harness CI images are stored in a public container registry. If you don't want to pull the images directly from the public registry, you can download the images to your own private registry, [specify the images that you want Harness to use](#specify-the-harness-ci-images-used-in-your-pipelines), and then configure a Docker connector to pull the images from your private registry. For an example demonstrating how to do this, go to [Configure STO to download images from a private registry](/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry).
+Harness CI images are stored in a public container registry. If you don't want to pull the images directly from the public registry, you can pull Harness images from your own private registry. For instructions on each of these options, go to [Connect to the Harness container image registry](/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md).
 
 ### Docker Hub rate limiting
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md
@@ -79,7 +79,7 @@ API key authentication is required. For more information about API keys, go to [
 1. Send a `get-default-config` request to get a list of the latest Harness CI build images and tags. You can use the `infra` parameter to get `k8` images or `VM` images.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?infra=K8" \
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-default-config?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID&infra=K8" \
    --header 'X-API-KEY: $API_KEY'
    ```
 
@@ -110,7 +110,7 @@ API key authentication is required. For more information about API keys, go to [
 2. Send a `get-customer-config` request to get the build images that your CI pipelines currently use. When `overridesOnly` is `true`, which is the default value, this endpoint returns the non-default images that your pipeline uses.
 
    ```
-   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?infra=K8&overridesOnly=true" \
+   curl --location --request GET "https://app.harness.io/gateway/ci/execution-config/get-customer-config?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID&infra=K8&overridesOnly=true" \
    --header 'X-API-KEY: $API_KEY'
    ```
 
@@ -128,7 +128,7 @@ API key authentication is required. For more information about API keys, go to [
 3. Send an `update-config` (POST) request with a list of the images you want to update and the new tags to apply.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?infra=K8" \
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/update-config?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID&infra=K8" \
    --header 'X-API-KEY: $API_KEY' \
    --header 'Content-Type: application/json' \
    --data-raw '[
@@ -146,7 +146,7 @@ API key authentication is required. For more information about API keys, go to [
 4. To reset one or more images to their defaults, send a `reset-config` (POST) request with a list of the images to reset.
 
    ```
-   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?infra=K8" \
+   curl --location --request POST "https://app.harness.io/gateway/ci/execution-config/reset-config?accountIdentifier=$YOUR_HARNESS_ACCOUNT_ID&infra=K8" \
    --header 'X-API-KEY: $API_KEY' \
    --header 'Content-Type: application/json' \
    --data-raw '[

--- a/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
+++ b/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
@@ -17,6 +17,8 @@ The default behavior uses anonymous access and pulls images from a public contai
 * [Use credentials for specific stages](#use-credentials-to-pull-harness-images-for-specific-stages)
 * [Pull images from a private registry](#pull-harness-images-from-a-private-registry)
 
+All of these options require [permissions](../../role-based-access-control/permissions-reference) to create, edit, and view connectors at the account [scope](/docs/platform/role-based-access-control/rbac-in-harness.md#permissions-hierarchy-scopes).
+
 :::tip Rate Limiting
 
 To prevent rate limiting or throttling issues when pulling images, using credentials, instead of anonymous access, and configure the default Harness Docker connector to pull images from GRC. For instructions, go to [Configure Harness to always use credentials to pull Harness images](#configure-harness-to-always-use-credentials-to-pull-harness-images).
@@ -28,8 +30,6 @@ To prevent rate limiting or throttling issues when pulling images, using credent
 If you don't want to connect anonymously, you can configure Harness to always use credentials, instead of anonymous access, to pull the Harness images. This option changes the behavior for your entire account by editing the credentials of the built-in **Harness Docker Connector**. This is useful if your organization's security policies don't allow anonymous connections to public image repos.
 
 If you don't want to change the behavior for your entire account, you can [Use credentials to pull Harness images for specific stages](#use-credentials-to-pull-harness-images-for-specific-stages).
-
-This option requires [permissions](../../role-based-access-control/permissions-reference) to create, edit, and view connectors at the account [scope](/docs/platform/role-based-access-control/rbac-in-harness.md#permissions-hierarchy-scopes).
 
 1. Go to **Account Settings**, select **Account Resources**, and then select **Connectors**.
 2. Select the **Harness Docker Connector** (Id: `harnessImage`).
@@ -61,8 +61,6 @@ This option requires [permissions](../../role-based-access-control/permissions-r
 If you don't want to connect anonymously, you can configure Harness to use credentials, instead of anonymous access, to pull the Harness images for specific stages in your pipelines. This option lets you override the Harness image pull behavior in individual [Build stages](/docs/continuous-integration/use-ci/prep-ci-pipeline-components.md#stages) by creating a dedicated [Docker connector](/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference) you can use for these specific use cases. This is useful when the delegate for that stage's build infrastructure can't anonymously access the public repo. For example, if the build infrastructure is running in a private cloud.
 
 If you want to change the behavior for your entire account, you can [configure Harness to always use credentials to pull Harness images](#configure-harness-to-always-use-credentials-to-pull-harness-images).
-
-This option requires [permissions](../../role-based-access-control/permissions-reference) to create, edit, and view connectors at the account [scope](/docs/platform/role-based-access-control/rbac-in-harness.md#permissions-hierarchy-scopes).
 
 1. Go to **Account Settings**, select **Account Resources**, and then select **Connectors**.
 
@@ -102,4 +100,48 @@ This option requires [permissions](../../role-based-access-control/permissions-r
 
 ## Pull Harness images from a private registry
 
-Harness CI images are stored in a public container registry. If you don't want to pull the images directly from the public registry, you can download the images to your own private registry, [specify the images that you want Harness to use](/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md#specify-the-harness-ci-images-used-in-your-pipelines), and then configure a Docker connector to pull the images from your private registry. For an example demonstrating how to do this, go to [Configure STO to download images from a private registry](/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry).
+Harness CI images are stored in a public container registry. If you don't want to pull the images directly from the public registry, you can download the images you need, perform any necessary security checks, upload them to your private registry, and then configure your CI pipelines to pull the Harness CI images from your private registry.
+
+You can also [use a private registry for STO scanner images](/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry).
+
+### Download Harness images to your registry
+
+1. Download the images you need from the [Harness project on GCR](https://console.cloud.google.com/gcr/images/gcr-prod/global/harness), perform any tests or validations necessary for your organization's security policies, and then store the images in your private registry.
+
+   :::caution
+
+   Do not change the image names in your private registry. The image names must match the names specified by Harness.
+
+   :::
+
+2. If your registry automatically downloads the latest images from the public Harness registry, you might want to [specify the images to use in your pipelines](/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci.md#specify-the-harness-ci-images-used-in-your-pipelines). This ensures your pipelines use specific image versions that you have validated, rather than automatically using the latest version. You must update this specification when you want to adopt a new version of an image.
+
+### Create a Docker connector for your registry
+
+Create a [Docker connector](/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference) that connects to your private registry.
+
+1. Go to **Account Settings**, select **Account Resources**, and then select **Connectors**. You must create the Docker connector at the account scope.
+2. Select **New Connector**, and, under **Artifact Repositories**, select the **Docker Registry** connector.
+3. Enter a **Name** for the connector. The **Description** and **Tags** are optional.
+
+   Harness automatically creates an **Id** ([entity identifier](../../references/entity-identifier-reference.md)) based on the **Name**. You can edit the **Id** while creating the connector only. After saving the connector, the **Id** can't be changed.
+
+4. Select **Continue**.
+5. For **Provider Type**, select **Other (Docker V2 compliant)**.
+6. For **Docker Registry URL**, enter the path for your container registry. For example, the path for the public Harness GCR project is `gcr.io/gcr-prod`.
+7. For **Authentication**, select **Username and Password**, and provide a username and token to access your registry. The token needs **Read, Write, Delete** permissions.
+8. Select **Continue** to go to **Select Connectivity Mode**, and then configure the connector to connect through a Harness Delegate or the Harness Platform.
+
+   * If you plan to use this connector with [Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md), you must select **Connect through Harness Platform**.
+   * If you select **Connect through a Harness Delegate**, you can allow Harness to use any available delegate or specify delegates based on tags. For more information about how Harness selects delegates, go to [Delegate overview](/docs/platform/delegates/delegate-concepts/delegate-overview.md) and [Use delegates selectors](/docs/platform/delegates/manage-delegates/select-delegates-with-selectors.md).
+   * For delegate installation instructions, go to [Delegate installation overview](../../delegates/install-delegates/overview).
+
+9. Select **Save and Continue**, wait for the connectivity test to run, and then select **Finish**.
+
+   If the connectivity test fails, make sure your connector's credentials are configured correctly and that the token has the necessary permissions.
+
+10. Configure your pipelines to download Harness images from your private registry. In each **Build** stage where you want to pull from your private registry, go to the [Infrastructure settings](/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings.md#infrastructure), and select your Docker connector in the **Override Image Connector** field.
+
+   When the pipeline runs, Harness will use the specified connector to download images from your private registry.
+
+   ![](../../connectors/static/connect-to-harness-container-image-registry-using-docker-connector-49.png)

--- a/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry.md
+++ b/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry.md
@@ -76,7 +76,7 @@ USER 1000
 
 ## Create a connector to your private registry
 
-You need a Docker connector that points to your private container registry. For more information, go to [Docker Connector Settings Reference](/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference/).
+You need a Docker connector that points to your private container registry. For more information, go to [Docker Connector Settings Reference](/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference).
 
 ## Configure the pipeline to download images from your registry
 


### PR DESCRIPTION
- Add account id parameter back into curl commands
- Create generic steps to pull Harness CI images from a private registry (separate from the STO topic).
