### PR TITLE
techdebt: [CDS-82108]: secret type variables must be non-empty

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
@@ -154,12 +154,13 @@ While you can simply declare a variable in your script using a Harness expressio
 
 * You can more easily identify and manage the Harness expressions used in your script.
 * You can template your script.
+* Variables of Secret type must have a non-empty value.
 
 ### Script output variables
 
 To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
 
-Shell Script step output variables have a maximum size of 512KB.
+Variables of Secret type must have a non-empty value. Shell Script step output variables have a maximum size of 512KB.
 
 ### Include Infrastructure Selectors
 
@@ -277,6 +278,7 @@ While you can simply declare a variable in your script using a Harness expressio
 
 * You can more easily identify and manage the Harness expressions used in your script.
 * You can template your script.
+* Variables of Secret type must have a non-empty value.
 
 You can declare the variable using **Name** and **Value** in **Script Input Variables** and then reference the variable in the script just as you would any other variable: `$var_name`.
 
@@ -294,6 +296,8 @@ At deployment runtime, Harness evaluates the expression and the variable contain
 ### Specify output variables
 
 Shell Script step Output Variables have a maximum size of 512KB.To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
+
+Variables of Secret type must have a non-empty value.
 
 Let's look at a simple example of a script with the variable **name**:
 

--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
@@ -159,9 +159,9 @@ While you can simply declare a variable in your script using a Harness expressio
 
 To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
 
-Variables of Secret type must have a non-empty value. Shell Script step output variables have a maximum size of 512KB.
-
->**NOTE: Please note that variables of Secret type must have a non-empty value.**
+:::note
+Variables of type Secret must have a non-empty value. Additionally, Shell Script step output variables have a maximum size of 512KB.
+:::
 
 ### Include Infrastructure Selectors
 
@@ -295,7 +295,7 @@ At deployment runtime, Harness evaluates the expression and the variable contain
 
 ### Specify output variables
 
-Shell Script step Output Variables have a maximum size of 512KB.To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
+Shell Script step Output Variables have a maximum size of 512KB. To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
 
 Let's look at a simple example of a script with the variable **name**:
 
@@ -368,7 +368,9 @@ When you run the Pipeline, the resolved output variable expression is sanitized:
 
 ![](./static/using-shell-scripts-25.png)
 
->**NOTE: Please note that variables of Secret type must have a non-empty value.**
+:::note
+Variables of type Secret must have a non-empty value.
+:::
 
 ### Harness expressions in variables
 

--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/shell-script-step.md
@@ -154,13 +154,14 @@ While you can simply declare a variable in your script using a Harness expressio
 
 * You can more easily identify and manage the Harness expressions used in your script.
 * You can template your script.
-* Variables of Secret type must have a non-empty value.
 
 ### Script output variables
 
 To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
 
 Variables of Secret type must have a non-empty value. Shell Script step output variables have a maximum size of 512KB.
+
+>**NOTE: Please note that variables of Secret type must have a non-empty value.**
 
 ### Include Infrastructure Selectors
 
@@ -278,7 +279,6 @@ While you can simply declare a variable in your script using a Harness expressio
 
 * You can more easily identify and manage the Harness expressions used in your script.
 * You can template your script.
-* Variables of Secret type must have a non-empty value.
 
 You can declare the variable using **Name** and **Value** in **Script Input Variables** and then reference the variable in the script just as you would any other variable: `$var_name`.
 
@@ -296,8 +296,6 @@ At deployment runtime, Harness evaluates the expression and the variable contain
 ### Specify output variables
 
 Shell Script step Output Variables have a maximum size of 512KB.To export variables from the script to other steps in the stage, you use the **Script Output Variables** option.
-
-Variables of Secret type must have a non-empty value.
 
 Let's look at a simple example of a script with the variable **name**:
 
@@ -369,6 +367,8 @@ echo "my secret: " <+execution.steps.CreateScript.output.outputVariables.myvar>
 When you run the Pipeline, the resolved output variable expression is sanitized:
 
 ![](./static/using-shell-scripts-25.png)
+
+>**NOTE: Please note that variables of Secret type must have a non-empty value.**
 
 ### Harness expressions in variables
 


### PR DESCRIPTION
techdebt: [[CDS-82108](https://harness.atlassian.net/browse/CDS-82108)]: secret type variables must be non-empty for step input and output variables

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the maintainers. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 


[CDS-82108]: https://harness.atlassian.net/browse/CDS-82108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ