### PR TITLE
FFM-9776 Remove private attributes from JS and React

### DIFF
--- a/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/java-script-sdk-references.md
@@ -171,8 +171,6 @@ interface Options {
   pollingEnabled?: boolean
   streamEnabled?: boolean
   debug?: boolean
-  allAttributesPrivate?: boolean // **Depreacated**
-  privateAttributeNames?: string[] // **Depreacated**
 }
 ```
 
@@ -186,8 +184,6 @@ interface Options {
 | streamEnabled         | Set to `true` to enable streaming mode. Set to `false` to disable streaming mode.                                                 | `true`                                                 |
 | pollingEnabled        | Set to `true` to enable polling mode. Set to `false` to disable polling mode.                                                     | `true`                                                 |
 | debug                 | Set to `true` to enable SDK debug level logging. Set to `false` to disable debug level logging                                    | `false`                                                |
-| allAttributesPrivate  | **Deprecated** no longer has any effect                                                                                           | No default - deprecated                                |
-| privateAttributeNames | **Deprecated** no longer has any effect                                                                                           | No default - deprecated                                |
 
 
 ### Complete the initialization

--- a/docs/feature-flags/ff-sdks/client-sdks/react-client.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/react-client.md
@@ -161,8 +161,6 @@ options={{ // OPTIONAL: advanced options
         baseUrl: 'https://url-to-access-flags.com',
         eventUrl: 'https://url-for-events.com',
         streamEnabled: true,
-        allAttributesPrivate: false,
-        privateAttributeNames: ['customAttribute'],
         debug: true
       }}
 ```


### PR DESCRIPTION
# What
These attributes have now been annotated as deprecated in the code, so remove them from public facing docs