### PR TITLE
[SMP-1839] K8s external secrets - SMP

### DIFF
--- a/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
+++ b/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
@@ -6,7 +6,13 @@ sidebar_position: 1
 
 Kubernetes External Secrets enable Kubernetes resources to use external data stores securely. You can use Kubernetes-based external secrets for Harness Self-Managed Enterprise Edition license values in your Helm charts.
 
-   The following values are available in `global.license.secrets.kubernetesSecrets`.
+:::info note
+
+Contact [Harness Support](mailto:support@harness.io) to get your Harness Self-Managed Enterprise Edition license files.
+
+:::
+
+The following values are available in `global.license.secrets.kubernetesSecrets`.
    - `secretName`: Name of the Kubernetes secrets containing Harness license keys
    - `keys.CG_LICENSE`: Name of the secret key containing a FirstGen License
    - `keys.NG_LICENSE`: Name of the secret key containing a NextGen License

--- a/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
+++ b/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
@@ -8,6 +8,9 @@ Kubernetes External Secrets enable Kubernetes resources to use external data sto
 
 :::info note
 
+:::info important
+This feature is currently in beta. For more information about beta features, go to [Beta, public preview, and GA definitions](/docs/get-started/beta-preview-ga/).
+
 Contact [Harness Support](mailto:support@harness.io) to get your Harness Self-Managed Enterprise Edition license files.
 
 :::

--- a/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
+++ b/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
@@ -6,8 +6,6 @@ sidebar_position: 1
 
 Kubernetes External Secrets enable Kubernetes resources to use external data stores securely. You can use Kubernetes-based external secrets for Harness Self-Managed Enterprise Edition license values in your Helm charts.
 
-:::info note
-
 :::info important
 This feature is currently in beta. For more information about beta features, go to [Beta, public preview, and GA definitions](/docs/get-started/beta-preview-ga/).
 

--- a/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
+++ b/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values.md
@@ -1,0 +1,44 @@
+---
+title: Use external secrets for license values
+description: Harness Self-Managed Enterprise Edition supports Kubernetes-based external secrets for Harness license values.
+sidebar_position: 1
+---
+
+Kubernetes External Secrets enable Kubernetes resources to use external data stores securely. You can use Kubernetes-based external secrets for Harness Self-Managed Enterprise Edition license values in your Helm charts.
+
+   The following values are available in `global.license.secrets.kubernetesSecrets`.
+   - `secretName`: Name of the Kubernetes secrets containing Harness license keys
+   - `keys.CG_LICENSE`: Name of the secret key containing a FirstGen License
+   - `keys.NG_LICENSE`: Name of the secret key containing a NextGen License
+   
+      ```yaml
+         global:
+           license:
+             cg: ''
+             ng: ''
+             secrets:
+               kubernetesSecrets:
+                 - secretName: ""
+                   keys:
+                     CG_LICENSE: ""
+                     NG_LICENSE: ""
+      ```
+
+## Configure an external secret as a Harness license value
+
+To configure a Kubernetes-based external secret as a a NextGen Harness license value, do the following:
+
+1. Create a Kubernetes secret that includes your NextGen Harness license.
+
+2. Update your `override.yaml` file to include the following.
+   
+   ```yaml
+         global:
+           license:
+             secrets:
+               kubernetesSecrets:
+                 - secretName: "harness-license"
+                   keys:
+                     NG_LICENSE: "ng"
+    ```
+


### PR DESCRIPTION
K8s external secrets - SMP

For reviewers, a preview is available.

[Use external secrets for license values](https://654181405f367a0099210f51--harness-developer.netlify.app/docs/self-managed-enterprise-edition/advanced-configurations/use-external-secrets-for-license-values)

## What Type of PR is This?

- [ ] Issue
- [x] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
