### PR TITLE
[PL-42355] Update delegate metric names for 23.11.81403

### DIFF
--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -14,17 +14,21 @@ The delegate is instrumented for the collection of the following delegate agent 
 | :-- | :-- |
 | `io_harness_custom_metric_task_execution_time` | The time it takes to complete a task (in seconds). |
 | `io_harness_custom_metric_tasks_currently_executing` | The number of tasks underway. |
-| `io_harness_custom_metric_task_timeout_total` | The number of tasks that time out before completion. |
-| `io_harness_custom_metric_task_completed_total` | The number of tasks completed. |
-| `io_harness_custom_metric_task_failed_total` | The number of failed tasks. |
-| `io_harness_custom_metric_task_rejected_total`* | The number of tasks rejected because of a high load on the delegate. |
+| `io_harness_custom_metric_task_timeout_total` # | The number of tasks that time out before completion. |
+| `io_harness_custom_metric_task_completed_total` # | The number of tasks completed. |
+| `io_harness_custom_metric_task_failed_total` # | The number of failed tasks. |
+| `io_harness_custom_metric_task_rejected_total` * #| The number of tasks rejected because of a high load on the delegate. |
 | `io_harness_custom_metric_delegate_connected` | Indicates whether the delegate is connected. Values are 0 (disconnected) and 1 (connected). |
 | `io_harness_custom_metric_resource_consumption_above_threshold`* | Delegate cpu/memory is above a threshold (defaults to 80%). Provide `DELEGATE_RESOURCE_THRESHOLD` as the env variable in the delegate YAML to configure the threshold. For more information, go to [Configure delegate resource threshold](#configure-delegate-resource-threshold). |
 
 :::info note
-Metrics notated with * above only visible if you start your delegate with `DYNAMIC_REQUEST_HANDLING` set to `true` in your delegate YAML. Go to [Configure delegate resource threshold](#configure-delegate-resource-threshold) for more information.
+Metrics with * above are only visible if you start your delegate with `DYNAMIC_REQUEST_HANDLING` set to `true` in your delegate YAML. Go to [Configure delegate resource threshold](#configure-delegate-resource-threshold) for more information.
 
 Also note that the above metrics are available only if your delegate version is later than 23.05.79311.
+:::
+
+::: info note
+Metrics with # above include the include the suffix `_total` as of Harness Delegate 23.11.81403. Delegate versions earlier than 23.11.81403 do not include the suffix `_total` in the metric name.
 :::
 
 This topic includes example YAML files you can use to create application manifests for your Prometheus and Grafana configurations.

--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -27,8 +27,9 @@ Metrics with * above are only visible if you start your delegate with `DYNAMIC_R
 Also note that the above metrics are available only if your delegate version is later than 23.05.79311.
 :::
 
-::: info note
+:::info note
 Metrics with # above include the include the suffix `_total` as of Harness Delegate 23.11.81403. Delegate versions earlier than 23.11.81403 do not include the suffix `_total` in the metric name.
+
 :::
 
 This topic includes example YAML files you can use to create application manifests for your Prometheus and Grafana configurations.

--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -14,10 +14,10 @@ The delegate is instrumented for the collection of the following delegate agent 
 | :-- | :-- |
 | `io_harness_custom_metric_task_execution_time` | The time it takes to complete a task (in seconds). |
 | `io_harness_custom_metric_tasks_currently_executing` | The number of tasks underway. |
-| `io_harness_custom_metric_task_timeout` | The number of tasks that time out before completion. |
-| `io_harness_custom_metric_task_completed` | The number of tasks completed. |
-| `io_harness_custom_metric_task_failed` | The number of failed tasks. |
-| `io_harness_custom_metric_task_rejected`* | The number of tasks rejected because of a high load on the delegate. |
+| `io_harness_custom_metric_task_timeout_total` | The number of tasks that time out before completion. |
+| `io_harness_custom_metric_task_completed_total` | The number of tasks completed. |
+| `io_harness_custom_metric_task_failed_total` | The number of failed tasks. |
+| `io_harness_custom_metric_task_rejected_total`* | The number of tasks rejected because of a high load on the delegate. |
 | `io_harness_custom_metric_delegate_connected` | Indicates whether the delegate is connected. Values are 0 (disconnected) and 1 (connected). |
 | `io_harness_custom_metric_resource_consumption_above_threshold`* | Delegate cpu/memory is above a threshold (defaults to 80%). Provide `DELEGATE_RESOURCE_THRESHOLD` as the env variable in the delegate YAML to configure the threshold. For more information, go to [Configure delegate resource threshold](#configure-delegate-resource-threshold). |
 


### PR DESCRIPTION
I originally merged https://github.com/harness/developer-hub/pull/3981 before seeing Prateek's question below. Original topic content is now back in place on HDH. This PR is pending an answer from eng. After we hear back, I'll make the appropriate updates, if any are required.

@VikasMaddukuriHarness How do we handle the metric names for delegate versions earlier than 23.11.80403?

Do we need to call out naming differences based on delegate version in the doc?

Thanks.

cc @pratmit 

Updated with recommendation from @raghuAtWings. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
