### PR TITLE
[PL-42597] Update release note version numbers

### DIFF
--- a/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes.md
+++ b/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes.md
@@ -43,7 +43,7 @@ If the required image and AMI upgrades are not complete by **November 14, 2023**
 
 :::
 
-### Latest: November 15, 2023, Version 81401
+### Latest: November 15, 2023, Version 81405
 
 #### Fixed issues
 
@@ -58,7 +58,7 @@ If the required image and AMI upgrades are not complete by **November 14, 2023**
 
   This issue has been resolved. Instance Sync V1 will now show the actual instance count after you have redeployed the service. However, Harness might require about 10 min to show the updated instance count. 
 
-  This item requires Harness Delegate version 81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 ### November 3, 2023, Version 81307
 

--- a/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes.md
+++ b/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes.md
@@ -58,7 +58,7 @@ If the required image and AMI upgrades are not complete by **November 14, 2023**
 
   This issue has been resolved. Instance Sync V1 will now show the actual instance count after you have redeployed the service. However, Harness might require about 10 min to show the updated instance count. 
 
-  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 ### November 3, 2023, Version 81307
 

--- a/release-notes/continuous-delivery.md
+++ b/release-notes/continuous-delivery.md
@@ -120,25 +120,25 @@ import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-noti
 
   This issue has been fixed. 
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate). 
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate). 
 
 - When using the Generic repository format to fetch artifacts from Artifactory, if you used an artifact filter and a non-Regex value for the artifact path, an issue occurred. The issue caused the metadata URL in the service outcome to be incorrect; the URL did not include the repository name. (CDS-82579)
 
   This issue is fixed. 
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 - HorizontalPodAutoscaler (HPA) and PodDisruptionBudget (PDB) could not be used in Kubernetes deployments if they contained fields that are not supported by the Kubernetes schema. (CDS-82370)
   
   This issue has been fixed by the addition of support for such fields.
   
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 - Harness did not honor the working directories specified in script units in the Command steps used in WinRM deployments. Instead, Harness used the default directory configured for the user profile on the target VM. (CDS-82105)
   
   This issue has been fixed. Harness now uses the working directory that you specify in script units. However, the fix has been deployed behind the feature flag `CDS_PRESERVE_WINRM_WORKING_DIR_FOR_COMMAND_UNITS`. Contact [Harness Support](mailto:support@harness.io) to enable the fix.
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 - The services dashboard did not correctly show primary and canary instances in a Kubernetes deployment. (CDS-81869, ZD-52262, ZD-52930)
 
@@ -146,25 +146,25 @@ import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-noti
 
   This issue has been resolved. Now, Harness splits the canary instances and primary instances into two groups and updates each group with the deployment details that are relevant to them. 
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate). 
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate). 
 
 - If connectivity issues between Harness and the Git provider cause a file that existed in the repository to not be found on the file system after performing a fetch, the Update Release Repo step creates a new file. (CDS-80902, ZD-51818)
 
   This issue has been fixed. If Harness experiences a connectivity issue with a Git provider when executing a step, it fails the step after a few retries.
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 - Secrets that are referenced in a service variable are displayed on the secret's **References** tab but secrets that are referenced in an environment’s service overrides are not. (CDS-80615)
 
   This issue has been fixed.
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 - When the Update Release Repo step failed on the delegate, the error message was not propagated to the Harness user interface, and you had to search the delegate logs to determine the cause of the issue. 
 
   This issue has been fixed. The error message is now propagated from the delegate to the Harness user interface. (CDS-79094)
 
-  This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+  This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 ### Version 81308 
 <!-- November 3 -->

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -32,11 +32,10 @@ import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-noti
 
 ## November 2023
 
-### Harness version 81401, Harness Delegate version 23.11.81403
+### Harness version 81401, Harness Delegate version 23.11.81405
 
 #### New features and enhancements 
 
-<!--
 - Harness has introduced stage-level timeouts for the following stage types: (CDS-81225)
   - Deploy
   - Build
@@ -44,7 +43,6 @@ import Kustomizedep from '/release-notes/shared/kustomize-3-4-5-deprecation-noti
   - Security Test
   - Pipeline
   - Custom Stage 
- -->
 
 - Harness updated the delegate metrics count names to include the suffix `_total`. (PL-42354, ZD-52167)
 

--- a/release-notes/platform.md
+++ b/release-notes/platform.md
@@ -34,7 +34,7 @@ The following deprecated API endpoints will no longer be supported:
 
 ## November 2023
 
-### Version 81403
+### Version 81401
 
 #### New features and enhancements
 
@@ -49,7 +49,7 @@ The following deprecated API endpoints will no longer be supported:
    - `io_harness_custom_metric_task_failed` is now `io_harness_custom_metric_task_failed_total`
    - `io_harness_custom_metric_task_rejected` is now `io_harness_custom_metric_task_rejected_total`
 
-   This item requires Harness Delegate version 23.11.81403. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
+   This item requires Harness Delegate version 23.11.81405. For information about features that require a specific delegate version, go to the [Delegate release notes](/release-notes/delegate).
 
 #### Fixed issues
 


### PR DESCRIPTION
Met with @bharatgoelharness, updating release note version numbers based on:

https://harness.atlassian.net/wiki/spaces/PD/pages/21545484350/QA+Build+Release+Sign+off+November+6th+-+build+814xx+-+2023

For reviewers, previews are available.

https://65577a52554dd3327c7cf7e5--harness-developer.netlify.app/docs/first-gen/firstgen-release-notes/harness-saa-s-release-notes#latest-november-15-2023-version-81405

[Continuous Delivery & GitOps](https://65577a52554dd3327c7cf7e5--harness-developer.netlify.app/release-notes/continuous-delivery)

[Delegate](https://65577a52554dd3327c7cf7e5--harness-developer.netlify.app/release-notes/delegate)

[Platform](https://65577a52554dd3327c7cf7e5--harness-developer.netlify.app/release-notes/platform)


## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
