### PR TITLE
CHAOS-3118 Group faults based on ec2, serverless and both

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-and-serverless-faults.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-and-serverless-faults.md
@@ -1,0 +1,64 @@
+---
+title: EC2-backed and serverless faults
+sidebar_position: 4
+---
+
+AWS faults are categorized into serverless, EC2-backed, and serverless combined with EC2-backed faults. Links to the respective faults are provided. 
+
+## Serverless faults
+
+These experiments primarily involve ECS Fargate and aren't dependent on EC2 instances. They focus on altering the state or resources of ECS containers without direct container interaction.
+
+Faults that belong to this category are listed below:
+
+1. [ECS Fargate CPU Hog](./ecs-fargate-cpu-hog)
+
+2. [ECS Fargate Memory Hog](./ecs-fargate-memory-hog)
+
+3. [AWS ECS Invalid Container Image](./ecs-invalid-container-image)
+
+4. [AWS ECS Update Container Resource Limit](./ecs-update-container-resource-limit)
+
+5. [AWS ECS Update Container Timeout](./ecs-update-container-timeout)
+
+6. [AWS ECS Update Task Role](./ecs-update-task-role)
+
+7. [AWS ECS Container Volume Detach](./ecs-container-volume-detach)
+
+## EC2-backed faults
+
+These experiments induce chaos within a container and depend on an EC2 instance. Typically, these are prefixed with "ECS container" and involve direct interaction with the EC2 instances hosting the ECS containers.
+
+Faults that belong to this category are listed below:
+
+1. [AWS ECS Agent Stop](./ecs-agent-stop)
+
+2. [AWS ECS Container CPU Hog](./ecs-container-cpu-hog)
+
+3. [AWS ECS Container HTTP Latency](./ecs-container-http-latency)
+
+4. [AWS ECS Container HTTP Modify Body](./ecs-container-http-modify-body)
+
+5. [AWS ECS Container HTTP Reset Peer](./ecs-container-http-reset-peer)
+
+6. [AWS ECS Container HTTP Status Code](./ecs-container-http-status-code)
+
+7. [AWS ECS Container IO Stress](./ecs-container-io-stress)
+
+8. [AWS ECS Container Memory Hog](./ecs-container-memory-hog)
+
+9. [AWS ECS Container Network Latency](./ecs-container-network-latency)
+
+10. [AWS ECS Container Network Loss](./ecs-container-network-loss)
+
+11. [AWS ECS Instance Stop](./ecs-instance-stop)
+
+## EC2-backed and serverless faults
+
+These experiments are versatile and are applicable to both serverless ECS tasks and those backed by EC2 instances. They generally involve task-level chaos or access restrictions without causing direct in-container or in-VM disruptions.
+
+Faults that belong to this category are listed below:
+
+1. [AWS ECS Task Stop](./ecs-task-stop)
+
+2. [AWS ECS Network Restrict](./ecs-network-restrict)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
@@ -10,6 +10,9 @@ ECS agent stop disrupts the state of infrastructure resources. This fault:
 
 ![ECS Agent Stop](./static/images/ecs-agent-stop.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
 ## Use cases
 ECS agent stop halts the agent that manages the task container on the ECS cluster, thereby impacting its delivery. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
@@ -10,6 +10,9 @@ ECS container CPU hog disrupts the state of infrastructure resources. It induces
 
 ![ECS Container CPU Hog](./static/images/ecs-stress-chaos.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
 ## Use cases
 ECS Container CPU hog:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-latency.md
@@ -7,6 +7,10 @@ ECS container HTTP latency induces HTTP chaos on containers running in an Amazon
 
 ![ECS Container HTTP Latency](./static/images/ecs-container-http-latency.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
+
 ## Use cases
 
 ECS container HTTP latency:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-modify-body.md
@@ -8,6 +8,10 @@ ECS container HTTP modify body injects HTTP chaos which affects the request or r
 
 ![ECS Container HTTP Modify Response](./static/images/ecs-container-http-modify-body.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
+
 ## Use cases
 ECS container HTTP modify body:
 - Tests the application's resilience to erroneous (or incorrect) HTTP response body.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-reset-peer.md
@@ -9,11 +9,14 @@ ECS container HTTP reset peer injects HTTP reset on the service whose port is sp
 
 ![ECS Container HTTP Reset Peer](./static/images/ecs-container-http-reset-peer.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
+
 ## Use cases
 ECS container HTTP reset peer:
 - Simulates premature connection loss (firewall issues or other issues) between microservices (verify connection timeout).
 - Simulates connection resets due to resource limitations on the server side like out of memory server (or process killed or overload on the server due to a high amount of traffic). 
-
 
 ## Prerequisites
 - Kubernetes >= 1.17

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-status-code.md
@@ -6,6 +6,10 @@ ECS container HTTP status code injects HTTP chaos that affects the request (or r
 
 ![ECS Container HTTP Modify Response](./static/images/ecs-container-http-status-code.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
+
 ## Use cases
 ECS container HTTP status code:
 - Tests the ECS task container resilience to erroneous code HTTP responses from the application server.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-io-stress.md
@@ -10,6 +10,10 @@ ECS container IO stress disrupts the state of infrastructure resources. It induc
 
 ![ECS Container IO Stress](./static/images/ecs-stress-chaos.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
+
 ## Usage
 
 <details>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-memory-hog.md
@@ -11,18 +11,17 @@ ECS container memory hog disrupts the state of infrastructure resources. It indu
 
 ![ECS Container Memory Hog](./static/images/ecs-stress-chaos.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
-## Usage
+## Use cases
 
-<details>
-<summary>View fault usage</summary>
-<div>
 Memory usage inside containers is subject to constraints. If the limits are specified, exceeding them can result in termination of the container (due to OOMKill of the primary process, often pid 1).
 The container is restarted, depending on the policy specified.
 When there are no limits on the memory consumption of containers, containers on the instance can be killed based on their oom_score, which extends to all the task containers running on the instance. This results in a bigger blast radius.  
 This fault launches a stress process within the target container, that causes the primary process in the container to have constraints based on resources or eat up the available system memory on the instance when limits on resources are not specified. 
-</div>
-</details>
+
 
 ## Prerequisites
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-latency.md
@@ -8,9 +8,11 @@ ECS container network latency disrupts the state of infrastructure resources. It
 - To select the Task Under Chaos (TUC), use the service name associated with the task. If you provide the service name along with the cluster name, all the tasks associated with the given service will be selected as chaos targets.
 - It tests the ECS task sanity (service availability) and recovery of the task containers subject to network stress.
 
-
 ![ECS Container Network Latency](./static/images/ecs-container-network-latency.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
 ## Usage
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-loss.md
@@ -12,12 +12,12 @@ ECS container network loss disrupts the state of infrastructure resources.
 
 ![ECS Container Network Loss](./static/images/ecs-container-network-loss.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
-## Usage
+## Use cases
 
-<details>
-<summary>View fault usage</summary>
-<div>
 This fault degrades the network of the task container without the container being marked as unhealthy/ (or unworthy) of traffic. It simulates issues within the ECS task network or communication across services in different availability zones (or regions).
 This can be resolved using middleware that switches traffic based on certain SLOs (or performance parameters).
 This can also be resolved by highlighting the degradation using notifications (or alerts).
@@ -25,8 +25,6 @@ It also determines the impact of the fault on the microservice.
 The task may stall or get corrupted while waiting endlessly for a packet. The fault limits the impact (blast radius) to only the traffic you wish to test by specifying the service to find TUC (Task Under Chaos). 
 It simulates degraded network with varied percentages of dropped packets between microservices, loss of access to specific third party (or dependent) services (or components), blackhole against traffic to a given AZ (failure simulation of availability zones), and network partitions (split-brain) between peer replicas for a stateful application. 
 This fault helps improve the resilience of the services over time.
-</div>
-</details>
 
 ## Prerequisites
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-volume-detach.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-volume-detach.md
@@ -7,6 +7,10 @@ ECS container volume detach provides a mechanism to detach and remove volumes as
 
 ![ECS Container Volume Detach](./static/images/ecs-container-volume-detach.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 
 - This experiment allows you to test and validate the behavior of your ECS tasks when volumes are detached. You can verify the resilience and performance of your application during volume detachment scenarios, ensuring that the containers continue to function as expected.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-cpu-hog.md
@@ -7,6 +7,10 @@ The ECS Fargate CPU Hog experiment enables you to intentionally increase the CPU
 
 ![ECS Fargate CPU Hog](./static/images/ecs-fargate-cpu-hog.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 
 - Tests the behavior of your ECS tasks subjected to CPU stress, and validates the resilience and performance of your ECS tasks during the stress.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-memory-hog.md
@@ -7,6 +7,10 @@ The ECS Fargate Memory Hog experiment enables you to intentionally increase the 
 
 ![ECS Fargate Memory Hog](./static/images/ecs-fargate-memory-hog.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 
 - Tests the behavior of your ECS tasks subjected to memory stress, and validates the resilience and performance of your ECS tasks during the stress.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-instance-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-instance-stop.md
@@ -8,6 +8,9 @@ ECS instance stop induces stress on an AWS ECS cluster. It derives the instance 
 
 ![ECS Instance Stop](./static/images/ecs-instance-stop.png)
 
+:::tip
+This experiment induces chaos within a container and depends on an EC2 instance. Typically, these are prefixed with ["ECS container"](./ec2-and-serverless-faults#ec2-backed-faults) and involve direct interaction with the EC2 instances hosting the ECS containers.
+:::
 
 ## Usage
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-invalid-container-image.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-invalid-container-image.md
@@ -7,6 +7,10 @@ ECS invalid container image allows you to update the Docker image used by a cont
 
 ![ECS Invalid Container Image](./static/images/ecs-invalid-container-image.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 ECS invalid container image:
 - Tests the behavior of your ECS tasks when the container images are updated, and validates the resilience and performance of your ECS tasks during image updates.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-network-restrict.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-network-restrict.md
@@ -7,6 +7,10 @@ ECS network restrict allows you to restrict the network connectivity of containe
 
 ![ECS Network restrict](./static/images/ecs-network-restrict.png)
 
+:::tip
+This experiment is applicable to both serverless ECS tasks and those backed by EC2 instances. [These experiments](./ec2-and-serverless-faults#ec2-backed-and-serverless-faults) generally involve task-level chaos or access restrictions without causing direct in-container or in-VM disruptions.
+:::
+
 ## Use cases
 ECS network restrict:
 - Tests the resilience and performance of your ECS tasks when network access is restricted.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-stop.md
@@ -7,15 +7,13 @@ ECS task stop is an AWS fault that injects chaos to stop the ECS tasks based on 
 
 ![ECS Task Stop](./static/images/ecs-task-stop.png)
 
+:::tip
+This experiment is applicable to both serverless ECS tasks and those backed by EC2 instances. [These experiments](./ec2-and-serverless-faults#ec2-backed-and-serverless-faults) generally involve task-level chaos or access restrictions without causing direct in-container or in-VM disruptions.
+:::
 
-## Usage
+## Use cases
 
-<details>
-<summary>View fault usage</summary>
-<div>
 This fault determines the resilience of an application when ECS tasks unexpectedly stop due to task being unavailable.
-</div>
-</details>
 
 ## Prerequisites
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-resource-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-resource-limit.md
@@ -7,6 +7,10 @@ ECS update container resource limits allows you to modify the CPU and memory res
 
 ![ECS Update Container Resource Limit](./static/images/ecs-update-container-resource-limit.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 ECS update container resource limit:
 - Determines the behavior of your ECS tasks when their resource limits are changed.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-timeout.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-timeout.md
@@ -7,6 +7,9 @@ ECS update container timeout modifies the start and stop timeouts for ECS contai
 
 ![ECS Update Container Timeout](./static/images/ecs-update-container-timeout.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
 
 ## Use cases
 ECS update container timeout:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-task-role.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-task-role.md
@@ -7,6 +7,10 @@ ECS update task role allows you to modify the IAM task role associated with an A
 
 ![ECS Update Task Role](./static/images/ecs-update-task-role.png)
 
+:::tip
+This experiment primarily involves ECS Fargate and doesn’t depend on EC2 instances. [They](./ec2-and-serverless-faults#serverless-faults) focus on altering the state or resources of ECS containers without direct container interaction.
+:::
+
 ## Use cases
 ECS update task role:
 - Determines the behavior of your ECS tasks when their IAM role is changed.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-svc.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-svc.yaml
@@ -1,0 +1,23 @@
+# stop the tasks of an ECS cluster
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: engine-nginx
+spec:
+  engineState: "active"
+  annotationCheck: "false"
+  chaosServiceAccount: litmus-admin
+  experiments:
+  - name: ecs-task-stop
+    spec:
+      components:
+        env:
+        # provide the name of ECS cluster
+        - name: CLUSTER_NAME
+          value: 'demo'
+        - name: SERVICE_NAME
+          vale: 'test-svc'
+        - name: REGION
+          value: 'us-east-1'
+        - name: TOTAL_CHAOS_DURATION
+          VALUE: '60'

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-task-affected.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-task-affected.yaml
@@ -1,0 +1,25 @@
+# stop the tasks of an ECS cluster
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: engine-nginx
+spec:
+  engineState: "active"
+  annotationCheck: "false"
+  chaosServiceAccount: litmus-admin
+  experiments:
+  - name: ecs-task-stop
+    spec:
+      components:
+        env:
+        # provide the name of ECS cluster
+        - name: CLUSTER_NAME
+          value: 'demo'
+        - name: SERVICE_NAME
+          vale: 'test-svc'
+        - name: TASK_REPLICA_AFFECTED_PERC
+          vale: '100'
+        - name: REGION
+          value: 'us-east-1'
+        - name: TOTAL_CHAOS_DURATION
+          VALUE: '60'

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-task.yaml
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/static/manifests/ecs-task-stop/task-stop-task.yaml
@@ -1,0 +1,23 @@
+# stop the tasks of an ECS cluster
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: engine-nginx
+spec:
+  engineState: "active"
+  annotationCheck: "false"
+  chaosServiceAccount: litmus-admin
+  experiments:
+  - name: ecs-task-stop
+    spec:
+      components:
+        env:
+        # provide the name of ECS cluster
+        - name: CLUSTER_NAME
+          value: 'demo'
+        - name: TASK_REPLICA_ID
+          vale: '1b751cf956e34e54b9d83b6a5c067f60,20d5041c044941dfb2126f1722d10558'
+        - name: REGION
+          value: 'us-east-1'
+        - name: TOTAL_CHAOS_DURATION
+          VALUE: '60'


### PR DESCRIPTION
Added manifests for ecs-task-stop
Added a page to group serverless, ec2-backed and both serverless and ec2-backed faults
Added reference links to the above
[Preview](https://65609654a9a7b1172be3ac95--harness-developer.netlify.app/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-and-serverless-faults)