### PR TITLE
Fixing Delegate namespace for IRSA

### DIFF
--- a/docs/shared/aws-connector-auth-options.md
+++ b/docs/shared/aws-connector-auth-options.md
@@ -16,7 +16,7 @@ Setting up IRSA credentials requires a few more steps than other methods, but it
    ```
    eksctl create iamserviceaccount \
        --name=cdp-admin \
-       --namespace=default \
+       --namespace=harness-delegate-ng \
        --cluster=test-eks \
        --attach-policy-arn=<policy-arn> \
        --approve \


### PR DESCRIPTION
replaced `default with `harness-delegate-ng` in the eksctl command. SAs are namespaced. We need it to be created in the same ns as the delegate. We should enhance this docs, as AWS's docs is confusing per see. At least explain the IAM OIDC provider step - item1: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [X] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
