### PR TITLE
chore: use googleTagManager instead of gtag [HDH-198]

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,9 +70,12 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'), // we could also use scss here
         },
-        gtag: {
-          trackingID: 'G-46758J5H8P',
-          anonymizeIP: false,
+        // gtag: { // use GTM instead
+        //   trackingID: 'G-46758J5H8P',
+        //   anonymizeIP: false,
+        // },
+        googleTagManager: {
+          containerId: 'GTM-MJB7HPB',
         },
       }),
     ],


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 

<img width="546" alt="Screen Shot 2023-11-30 at 5 16 45 PM" src="https://github.com/harness/developer-hub/assets/75070418/df2b1872-6aad-40d2-89bc-d33be5db0ec4">
