### PR TITLE
fix: [CDS-85940]: Remove examples of <+trigger.sourceRepo> expression

### DIFF
--- a/docs/platform/pipelines/looping-strategies/additional-matrix-examples.md
+++ b/docs/platform/pipelines/looping-strategies/additional-matrix-examples.md
@@ -375,7 +375,7 @@ For example:
 ```yaml
  strategy:
     matrix:
-        payload: [<+trigger.payload.user.username>, <+trigger.sourceRepo>, <+trigger.prNumber>]
+        payload: [<+trigger.payload.user.username>, <+trigger.prNumber>]
 ```
 
 You can use `<+trigger.payload.PATH_IN_JSON>` to [reference any field in the trigger's JSON payload](/docs/platform/triggers/triggers-reference#referencing-payload-fields), such as `<+trigger.payload.pull_request.user.login>`.

--- a/docs/platform/triggers/triggers-reference.md
+++ b/docs/platform/triggers/triggers-reference.md
@@ -240,8 +240,6 @@ To create dynamic triggers, Harness includes built-in Git payload expressions fo
 * Main expressions:
   * `<+trigger.type>`
     * Webhook
-  * `<+trigger.sourceRepo>`
-    * Github, Gitlab, Bitbucket, Custom
   * `<+trigger.event>`
     * PR, PUSH, etc.
 * PR and Issue Comment expressions

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -1739,8 +1739,6 @@ For example:
 
 * `<+trigger.type>`
 	+ Webhook.
-* `<+trigger.sourceRepo>`
-	+ Github, Gitlab, Bitbucket, Custom
 * `<+trigger.event>`
 	+ PR, PUSH, etc.
 


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 
Currently we don't support `<+trigger.sourceRepo>` expression in trigger executions. Removing it from the docs until support is added. 

## What Type of PR is This?

- [x] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:


* *Issue(s)*
* https://harness.atlassian.net/browse/CDS-85940

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
