### PR TITLE
[PL-43470] Build a custom image with non-root access that includes custom certificates

### DIFF
--- a/docs/platform/delegates/install-delegates/overview.md
+++ b/docs/platform/delegates/install-delegates/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Delegate installation overview
-description: How to install Harness delegates using Helm, Terraform, Kubernetes, or Docker
+title: Delegate installation options
+description: Install Harness Delegates using Helm, Terraform, Kubernetes, or Docker
 sidebar_position: 1
 ---
 ```mdx-code-block
@@ -105,3 +105,36 @@ To install the Docker delegate using Podman, do the following:
    ```
 
 7. Run the command.
+
+### Install a non-root Docker delegate with custom certificates
+
+If the delegate cannot run the delegate container as a root user but requires a custom CA, you can add custom CA bundle files to the delegate image and run a `load_certificates.sh` script on the files.
+
+The `load_certificates.sh` script ensures that your CA certificates are:
+
+- Added to the delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`.
+- Added to the Red Hat OS trust store.
+- Applied to Harness CI pipelines.
+
+To build your custom delegate image, do the following:
+
+1. Add all of your CA certificates to a local directory.
+
+2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
+
+   ```
+   RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATEVERSION/delegate.jar
+   
+   + COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
+   
+   + RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
+   
+   USER 1001
+   ```
+
+   :::info caution
+   Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
+
+   :::
+
+3. Build your Docker image.

--- a/docs/platform/delegates/install-delegates/overview.md
+++ b/docs/platform/delegates/install-delegates/overview.md
@@ -106,35 +106,3 @@ To install the Docker delegate using Podman, do the following:
 
 7. Run the command.
 
-### Install a non-root Docker delegate with custom certificates
-
-If the delegate cannot run the delegate container as a root user but requires a custom CA, you can add custom CA bundle files to the delegate image and run a `load_certificates.sh` script on the files.
-
-The `load_certificates.sh` script ensures that your CA certificates are:
-
-- Added to the delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`.
-- Added to the Red Hat OS trust store.
-- Applied to Harness CI pipelines.
-
-To build your custom delegate image, do the following:
-
-1. Add all of your CA certificates to a local directory.
-
-2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
-
-   ```
-   RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATEVERSION/delegate.jar
-   
-   + COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
-   
-   + RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
-   
-   USER 1001
-   ```
-
-   :::info caution
-   Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
-
-   :::
-
-3. Build your Docker image.

--- a/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
+++ b/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
@@ -88,7 +88,9 @@ To build your custom delegate image, do the following:
    
    USER 1001
    ```
-
+   
+   This copies all the certificates from the local ./my-custom-ca directory to /opt/harness-delegate/my-ca-bundle/ directory inside the container.
+   
    :::info caution
    Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
 

--- a/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
+++ b/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
@@ -79,14 +79,13 @@ To build your custom delegate image, do the following:
 
 1. Add all of your CA certificates to a local directory.
 
-2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
+2. Add the lines below to your delegate Dockerfile after the `RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATEVERSION/delegate.jar` line and before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
 
    ```
    COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
    
    RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
    
-   USER 1001
    ```
    
    This copies all the certificates from the local `./my-custom-ca` directory to `/opt/harness-delegate/my-ca-bundle/` directory inside the container.

--- a/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
+++ b/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
@@ -89,12 +89,12 @@ To build your custom delegate image, do the following:
    USER 1001
    ```
    
-   This copies all the certificates from the local ./my-custom-ca directory to /opt/harness-delegate/my-ca-bundle/ directory inside the container.
-   
+   This copies all the certificates from the local `./my-custom-ca` directory to `/opt/harness-delegate/my-ca-bundle/` directory inside the container.
+
    :::info caution
    Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
 
    :::
 
-3. Build your Docker image.
+3. Build your custom image.
 

--- a/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
+++ b/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile.md
@@ -82,9 +82,9 @@ To build your custom delegate image, do the following:
 2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
 
    ```
-   + COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
+   COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
    
-   + RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
+   RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
    
    USER 1001
    ```

--- a/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
+++ b/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
@@ -724,7 +724,7 @@ To add self-signed certificates for delegate upgrader, do the following:
                    defaultMode: 400
       ```
 
-### Install a non-root Docker delegate with custom certificates
+## Install a non-root Docker delegate with custom certificates
 
 If the delegate cannot run the delegate container as a root user but requires a custom CA, you can add custom CA bundle files to the delegate image and run a `load_certificates.sh` script on the files.
 

--- a/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
+++ b/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
@@ -724,4 +724,35 @@ To add self-signed certificates for delegate upgrader, do the following:
                    defaultMode: 400
       ```
 
+### Install a non-root Docker delegate with custom certificates
 
+If the delegate cannot run the delegate container as a root user but requires a custom CA, you can add custom CA bundle files to the delegate image and run a `load_certificates.sh` script on the files.
+
+The `load_certificates.sh` script ensures that your CA certificates are:
+
+- Added to the delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`.
+- Added to the Red Hat OS trust store.
+- Applied to Harness CI pipelines.
+
+To build your custom delegate image, do the following:
+
+1. Add all of your CA certificates to a local directory.
+
+2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
+
+   ```
+   RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATE_VERSION/delegate.jar
+   
+   + COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
+   
+   + RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
+   
+   USER 1001
+   ```
+
+   :::info caution
+   Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
+
+   :::
+
+3. Build your Docker image.

--- a/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
+++ b/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
@@ -724,35 +724,3 @@ To add self-signed certificates for delegate upgrader, do the following:
                    defaultMode: 400
       ```
 
-## Install a non-root Docker delegate with custom certificates
-
-If the delegate cannot run the delegate container as a root user but requires a custom CA, you can add custom CA bundle files to the delegate image and run a `load_certificates.sh` script on the files.
-
-The `load_certificates.sh` script ensures that your CA certificates are:
-
-- Added to the delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`.
-- Added to the Red Hat OS trust store.
-- Applied to Harness CI, STO, and delegate pipelines.
-
-To build your custom delegate image, do the following:
-
-1. Add all of your CA certificates to a local directory.
-
-2. Add the lines below to your delegate Docker file before the `USER 1001` line because root access is required to run the script. Replace the directory paths with your local directory locations.
-
-   ```
-   RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATE_VERSION/delegate.jar
-   
-   + COPY <PATH_TO_LOCAL_CERTS_DIRECTORY> <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>
-   
-   + RUN bash -c "/opt/harness-delegate/load_certificates.sh <PATH_TO_DIRECTORY_OF_CERTS_IN_THE_CONTAINER>"
-   
-   USER 1001
-   ```
-
-   :::info caution
-   Don't copy your certificates to the folder `/opt/harness-delegate/ca-bundle` folder. This folder is reserved for storing additional certificates to install the delegate.
-
-   :::
-
-3. Build your Docker image.

--- a/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
+++ b/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs.md
@@ -732,7 +732,7 @@ The `load_certificates.sh` script ensures that your CA certificates are:
 
 - Added to the delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`.
 - Added to the Red Hat OS trust store.
-- Applied to Harness CI pipelines.
+- Applied to Harness CI, STO, and delegate pipelines.
 
 To build your custom delegate image, do the following:
 


### PR DESCRIPTION
Build a custom image with non-root access that includes custom certificates

For reviewers, a preview is available.

https://6577814d56128f47afb6dfb9--harness-developer.netlify.app/docs/platform/delegates/manage-delegates/build-custom-images-delegate-dockerfile#build-a-custom-image-with-non-root-access-that-includes-custom-certificates

## What Type of PR is This?

- [ ] Issue
- [x] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 


[PL-43470]: https://harness.atlassian.net/browse/PL-43470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ