### PR TITLE
feat [CET-2066] Add documentation for generating CET source attach manifest attributes using gradle and maven.

### DIFF
--- a/docs/continuous-error-tracking/get-started/cet-source-attach.md
+++ b/docs/continuous-error-tracking/get-started/cet-source-attach.md
@@ -35,7 +35,7 @@ Learn how to connect your code repository to the monitored service. Help your de
 
 2. Add source attach information for the agent
 
-The following agent environment variables can be added so that your code repository can map to the service you want to track. Alternatively, if your project generates multiple jars, you can attach source information with each jar by adding following attributes in the `META-INF/MANIFEST.MF` file in the jar.
+The following agent environment variables can be added so that your code repository can map to the service you want to track. Alternatively, if your project generates multiple jars, you can attach source information with each jar by adding the following attributes in the `META-INF/MANIFEST.MF` file in the jar.
 
 
   | **Required Environment Variable** | **Manifest Attribute** |  **Description** | **Example** |
@@ -61,7 +61,7 @@ ENV ET_ENV_ID=env1
 ENV ET_TOKEN=b34*****-****-****-****-***********42a
 ENV ET_REPOSITORY_CONNECTOR_ID=coderepoconnector
 ENV ET_REPOSITORY_BRANCH=pre-prod
-ENV ET_REPOSITORY_SOURCES_ROOT=event-generator/tree/harness/src/main/java
+ENV ET_REPOSITORY_SOURCES_ROOT=event-generator/backend/src/main/java
 ```
 </TabItem>
 <TabItem value="Maven" label="Maven">

--- a/docs/continuous-error-tracking/get-started/cet-source-attach.md
+++ b/docs/continuous-error-tracking/get-started/cet-source-attach.md
@@ -43,8 +43,14 @@ The following agent environment variables can be added so that your code reposit
 | `ET_REPOSITORY_CONNECTOR_ID` | `Harness-Repository-Connector-Id` | ID for the code repository conenctor you created | `coderepoconnector`|
 | `ET_REPOSITORY_COMMIT` | `Harness-Repository-Commit` | CommitHashOrReleaseTag for the code you are want to track. Note that commit and branch both are not required. Only one of them is required. If both fields are provided, then commit takes a higher priority. | `12a69d4c668ce126fc104f4d58f3d7ed85403v1h`|
 | `ET_REPOSITORY_BRANCH` | `Harness-Repository-Branch` | Name of the branch you are tracking | `pre-prod` |
-| `ET_REPOSITORY_SOURCES_ROOT` | `Harness-Repository-Sources-Root` | Requires a reference to the repository name; optionally, you can provide additional paths to prepend to the file you want to track | `event-generator/tree/harness/src/main/java` |
+| `ET_REPOSITORY_SOURCES_ROOT` | `Harness-Repository-Sources-Root` | Requires a reference to the repository name; optionally, you can provide additional paths to prepend to the file you want to track | `event-generator/backend/src/main/java` |
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Examples:
+<Tabs>
+  <TabItem value="Environment Variables" label="Environment Variables" default>
   Example of adding environment variables:
 
 ```
@@ -57,12 +63,31 @@ ENV ET_REPOSITORY_CONNECTOR_ID=coderepoconnector
 ENV ET_REPOSITORY_BRANCH=pre-prod
 ENV ET_REPOSITORY_SOURCES_ROOT=event-generator/tree/harness/src/main/java
 ```
-
+</TabItem>
+<TabItem value="Maven" label="Maven">
   Example of adding manifest attributes using maven :
 
   Add this in the `<build>/<plugins>` section of your `pom.xml`
 
   ```
+<plugin>
+  <groupId>pl.project13.maven</groupId>
+  <artifactId>git-commit-id-plugin</artifactId>
+  <version>${git-commit-id-plugin.version}</version>
+  <executions>
+      <execution>
+          <id>get-the-git-infos</id>
+          <goals>
+              <goal>revision</goal>
+          </goals>
+          <phase>validate</phase>
+      </execution>
+  </executions>
+  <configuration>
+      <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+  </configuration>
+</plugin>
+
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-jar-plugin</artifactId>
@@ -70,13 +95,15 @@ ENV ET_REPOSITORY_SOURCES_ROOT=event-generator/tree/harness/src/main/java
       <archive>
           <manifestEntries>
               <Harness-Repository-Connector-Id>coderepoconnect</Harness-Repository-Connector-Id>
-              <Harness-Repository-Branch>pre-prod</Harness-Repository-Branch>
-              <Harness-Repository-Sources-Root>event-generator/tree/harness/src/main/java</Harness-Repository-Sources-Root>
+              <Harness-Repository-Commit>${git.commit.id}</Harness-Repository-Commit>
+              <Harness-Repository-Sources-Root>event-generator/backend/src/main/java</Harness-Repository-Sources-Root>
           </manifestEntries>
       </archive>
   </configuration>
 <plugin>
   ```
+</TabItem>
+<TabItem value="Gradle" label="Gradle">
   Example of adding manifest attributes using gradle:
 
   Add this in the `build.gradle` file:
@@ -88,7 +115,7 @@ jar {
       'Main-Class': 'com.harness.ExceptionGenerator',
       'Harness-Repository-Connector-Id': 'coderepoconnect',
       'Harness-Repository-Commit' : "${gitRevision}",
-      'Harness-Repository-Sources-Root': 'event-generator/tree/harness/src/main/java'
+      'Harness-Repository-Sources-Root': 'event-generator/backend/src/main/java'
     ) 
   }
 }
@@ -114,7 +141,8 @@ ext {
     gitRevision = git.head().id
 }
 ```
-
+  </TabItem>
+</Tabs>
 3. Restart your application after installing the Error Tracking Agent.
 
 4. Navigate to the ARC Screen by selecting an event on the Event Summary page. Clicking on the repository URL takes you to the code repository.


### PR DESCRIPTION
CET's source attach mechanism has two ways to operate:

Using parameters to the agent - those will apply to all user classes that participate in an event and that we could find other source information for them from other sources.

Using parameters in the manifest of the jar that included the classes

The second option is the one that should be very usable for most users where there are many jars in the application and each is being built from different repos or paths inside the same repo.


# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [x] Feature
- [ ] Maintenance/Chore


## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [x] *Optional* Screen Shoot. 
![Screenshot 2023-12-12 at 1 28 20 PM](https://github.com/harness/developer-hub/assets/7688389/699d0ca1-6c48-48d6-a3e1-02895e0849b7)
![Screenshot 2023-12-12 at 1 28 32 PM](https://github.com/harness/developer-hub/assets/7688389/e952ee3b-e8b4-40c5-85a6-a6896e8ce998)

