### PR TITLE
Fix structure

### DIFF
--- a/docs/chaos-engineering/configure-chaos-experiments/chaos-hubs/add-chaos-hub.md
+++ b/docs/chaos-engineering/configure-chaos-experiments/chaos-hubs/add-chaos-hub.md
@@ -3,7 +3,17 @@ title: Add a custom chaos hub
 sidebar_position: 5
 ---
 
-A chaos hub is a collection of experiment templates and faults you can use to launch chaos experiments. CE provides a default **Enterprise Chaos Hub** that includes a wide array of templates and faults out of the box. You can also add your own custom chaos hubs to maintain and share private experiments and faults within your organization.
+## Chaos hub
+
+This section introduces you to chaos hub, and how you can add a chaos hub to your project.
+
+A chaos hub is a collection of experiment templates and faults that you can use to create and launch chaos experiments. 
+Experiments are templates to create new chaos experiments, which contain a collection of chaos faults and certain custom actions ordered in a specific sequence. Faults refer to the failures injected as part of an experiment. Both experiments and faults are stored as manifests in an appropriate directory structure. Hence, you can add new experiment templates and faults directly to the repository as files. In addition, you can derive the experiment templates from the existing experiments and save them to the Chaos Hub from the UI.
+
+Chaos hub is a collection of manifests and charts that represents the experiments and faults which exist as a part of the hub.
+You can add Chaos Hub using a Git service provider such as GitHub, where Chaos Hub exists as a repository. This allows native version control and management of the faults and experiment artifacts.
+
+HCE provides a default **Enterprise Chaos Hub** that includes a wide array of templates and faults out of the box. You can also add your own custom chaos hubs to maintain and share private experiments and faults within your organization.
 
 There are several reasons for adding a custom chaos hub. A custom hub lets you:
 
@@ -17,7 +27,7 @@ There are several reasons for adding a custom chaos hub. A custom hub lets you:
 
 This topic shows how to add and connect a custom chaos hub. 
 
-## Prerequisites
+## Prerequisites to adding a custom chaos hub
 
 1. Be sure you have a Git repository for your custom chaos hub, where you will store experiments and faults. The repository must include two folders: `experiments` and `faults`. Here's an example repo:
 

--- a/docs/chaos-engineering/configure-chaos-experiments/experiments/experiment-execution.md
+++ b/docs/chaos-engineering/configure-chaos-experiments/experiments/experiment-execution.md
@@ -29,16 +29,3 @@ The below diagram shows the flow of control when a user creates a new chaos expe
 
    The chaos experiment execution is now concluded.
 
-## Chaos hub
-
-Chaos hub is a collection of experiment templates and faults that helps create new chaos experiments.
-
-- In essence, Chaos Hub is a collection of manifests and charts, which represent the experiments and faults that exist as part of the hub.
-- You can add Chaos Hub using a Git service provider such as GitHub, where Chaos Hub exists as a repository. This allows native version control and management of the faults and experiment artifacts.
-- Apart from an Enterprise Chaos Hub (out of the box), you can also add custom Chaos Hubs to maintain and distribute private faults and experiments within your organization.
-
-Experiments are templates to create new chaos experiments, which contain a collect of chaos faults and certain custom actions ordered in a specific sequence. Faults refer to the failures injected as part of an experiment.
-
-Both experiments and faults are stored as manifests in an appropriate directory structure. Hence, you can add new experiment templates and faults directly to the repository as files. In addition, you can derive the experiment templates from the existing experiments and save them to the Chaos Hub from the UI.
-
-You can also create your own custom chaos hub, where you can maintain and share your custom experiments and faults. For more information, go to [Add a custom chaos hub](/docs/chaos-engineering/configure-chaos-experiments/chaos-hubs/add-chaos-hub).


### PR DESCRIPTION
"Introduction to chaos hub" was in the [flow of execution](https://developer.harness.io/docs/chaos-engineering/configure-chaos-experiments/experiments/experiment-execution) page. Added the intro of chaos hub to  [add custom hub](https://developer.harness.io/docs/chaos-engineering/configure-chaos-experiments/chaos-hubs/add-chaos-hub) page 
Preview
1. [Flow of execution](https://6581d9a06717f3421017a745--harness-developer.netlify.app/docs/chaos-engineering/configure-chaos-experiments/experiments/experiment-execution)
2. [Chaoshub](https://6581d9a06717f3421017a745--harness-developer.netlify.app/docs/chaos-engineering/configure-chaos-experiments/chaos-hubs/add-chaos-hub)