### PR TITLE
chore: [CHAOS-3571]: Adds details for linux and vmware memory stress fault

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-memory-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-memory-stress.md
@@ -15,6 +15,11 @@ Linux memory stress causes memory consumption of the target Linux machines for a
 - Induces memory consumption and exhaustion on the target Linux machines.
 - Simulates a lack of memory for processes running on the application, which degrades their performance.
 - Simulates application slowness due to memory starvation, and noisy neighbour problems due to excessive consumption of memory.
+- The fault allocates and maps the given amount of virtual address space, and then keeps on re-writing to that same memory space for the chaos duration before un-mapping it.
+
+:::note
+It should be noted that the the mapped memory space isn't un-mapped until the chaos injection is over, the same memory space is used for iteratively writing data in memory. This ensures a constant amount of memory being consumed by the fault through chaos duration.
+:::
 
 <Ossupport />
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-memory-hog.md
@@ -15,6 +15,11 @@ VMware memory hog fault consumes excessive memory resources on Linux OS based VM
 - It also simulates noisy neighbour problems due to hogging. 
 - It verifies pod priority and QoS setting for eviction purposes. 
 - It also verifies application restarts on OOM (out of memory) kills. 
+- The fault allocates and maps the given amount of virtual address space, and then keeps on re-writing to that same memory space for the chaos duration before un-mapping it.
+
+:::note
+It should be noted that the the mapped memory space isn't un-mapped until the chaos injection is over, the same memory space is used for iteratively writing data in memory. This ensures a constant amount of memory being consumed by the fault through chaos duration.
+:::
 
 :::note
 - Kubernetes > 1.16 is required to execute this fault.


### PR DESCRIPTION
# Harness Developer Pull Request
Adds details for linux and vmware memory stress fault

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
