### PR TITLE
Caution to warning refactor

### DIFF
--- a/docs/chaos-engineering/chaos-infrastructure/upgrade-infra.md
+++ b/docs/chaos-engineering/chaos-infrastructure/upgrade-infra.md
@@ -5,7 +5,7 @@ sidebar_position: 25
 
 If a Harness CE release is not backward compatible, you must upgrade your chaos infrastructure. This applies only to releases that have breaking changes, which will be clearly indicated in [release notes](/release-notes/chaos-engineering). 
 
-:::caution
+:::warning
 If you don't upgrade your infrastructure for these types of releases, chaos experiments will start to fail.
 :::
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp.md
@@ -60,7 +60,7 @@ To create the service account and secret:
     client_x509_cert_url: "<client-x509-cert-url>"
   ```
 
-  :::caution
+  :::warning
   Newline (\n) characters within the private key are crucial. Avoid using double quotes to prevent their loss.
   :::
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/shared/io-faults-caution.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/shared/io-faults-caution.md
@@ -1,4 +1,4 @@
-:::caution
+:::warning
 - Due to the large blast radius of this fault, we recommend you do not execute it in the production environment.
 - Through the fault execution, the application pod can potentially fail to perform successful IO writes if the `write` system call is being targeted. This can cause any data produced in this duration to be lost.
 - Any data produced before the execution of the fault is not harmed as a result of its execution.

--- a/docs/cloud-cost-management/3-use-ccm-cost-reporting/2-ccm-cost-categories/2-cost-categories-usage.md
+++ b/docs/cloud-cost-management/3-use-ccm-cost-reporting/2-ccm-cost-categories/2-cost-categories-usage.md
@@ -65,7 +65,7 @@ You can use Group By and filters together. For example, your filter could select
 
 ![](./static/use-ccm-cost-categories-08.png)
 
-:::caution
+:::warning
 When including multiple cost categories in your filter, it is important to check for any shared cost buckets between them. If you have shared cost buckets with overlapping rules in both cost categories, the cost of these buckets is counted twice, resulting in duplication of costs. Therefore, it is recommended not to have multiple cost category filter in a Perspective. However, if you must add a multiple cost category filter, avoid overlapping shared cost buckets between cost categories to prevent any potential errors.
 :::
 

--- a/docs/cloud-cost-management/3-use-ccm-cost-reporting/5-currency-preferences.md
+++ b/docs/cloud-cost-management/3-use-ccm-cost-reporting/5-currency-preferences.md
@@ -50,7 +50,7 @@ To standardize the currency in which your cloud cost data is displayed, perform 
 
 
 
-:::caution
+:::warning
 Once configured, you cannot change the currency settings. It takes up to 24 hours for data to be shown in your preferred currency. Historical data is also converted and displayed in the preferred currency.
 :::
 

--- a/docs/code-repository/work-in-repos/branch.md
+++ b/docs/code-repository/work-in-repos/branch.md
@@ -57,7 +57,7 @@ For more information about creating and managing PRs, go to [pull requests](/doc
 
 By default, branches are not automatically deleted when you [merge PRs](../pull-requests/merge-pr.md) in Harness Code. It is a good idea to clean up branches periodically, but make sure you don't delete any active branches or inactive work-in-progress branches.
 
-:::caution
+:::warning
 
 You can't recover branches that are deleted directly in Harness Code because these are your [remote branches](https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches).
 

--- a/docs/code-repository/work-in-repos/clone-repos.md
+++ b/docs/code-repository/work-in-repos/clone-repos.md
@@ -14,7 +14,7 @@ After [creating a repository](../config-repos/create-repo.md), you can work dire
 
    When you select **Generate Clone Credentials**, Harness Code automatically creates an [API token](/docs/platform/automation/api/add-and-manage-api-keys) in your user profile.
 
-   :::caution
+   :::warning
 
    Tokens carry many privileges; treat your user tokens as passwords and store them securely.
 

--- a/docs/code-repository/work-in-repos/tag.md
+++ b/docs/code-repository/work-in-repos/tag.md
@@ -42,7 +42,7 @@ You can create branches from tags.
 
 ## Delete a tag
 
-:::caution
+:::warning
 
 You can't recover tags that are deleted from Harness Code.
 

--- a/docs/continuous-delivery/deploy-srv-diff-platforms/aws/aws-sam-deployments.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/aws/aws-sam-deployments.md
@@ -245,7 +245,7 @@ To configure the SAM Build step, do the following:
 
 The [--use-container](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html) option is set up by Harness automatically. This command ensures that AWS SAM packages and builds the application code inside a Docker container that is configured with the necessary dependencies and runtime environment specified in the AWS SAM template.
 
-:::caution
+:::warning
 
 Do not remove this command. It is required for the current beta of this feature. It will be optional in future releases.
 
@@ -255,7 +255,7 @@ Do not remove this command. It is required for the current beta of this feature.
 
 In **SAM Build Docker Container Registry**, you can use the same Harness Docker Registry connector automatically set up in the **Container Registry** setting or add/select your own connector.
 
-:::caution
+:::warning
 
 Do not remove this connector. It is required for the current beta of this feature. It will be optional in future releases.
 

--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/containerized-steps/run-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/containerized-steps/run-step.md
@@ -247,7 +247,7 @@ In the following YAML example, step `alpha` exports an output variable called `m
 
 </details>
 
-:::caution
+:::warning
 
 If an output variable value contains a secret, be aware that the secret will be visible in the following areas of the pipeline execution:
 

--- a/docs/continuous-integration/shared/output-var.md
+++ b/docs/continuous-integration/shared/output-var.md
@@ -29,7 +29,7 @@ In the following YAML example, step `alpha` exports an output variable called `m
 
 </details>
 
-:::caution
+:::warning
 
 * **Secrets in output variables exposed in logs:** If an output variable value contains a secret, be aware that the secret will be visible in the [build details](/docs/continuous-integration/use-ci/viewing-builds.md). Such secrets are visible on the **Output** tab of the step where the output variable originates and in the build logs for any later steps that reference that variable. For information about best practices for using secrets in pipelines, go to the [Secrets documentation](/docs/category/secrets).
 * **64KB length limit:** If an output variable's length is greater than 64KB, steps can fail or truncate the output. If you need to export large amounts of data, consider [uploading artifacts](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact#upload-artifacts) or [exporting artifacts by email](/docs/continuous-integration/use-ci/use-drone-plugins/drone-email-plugin.md).
@@ -170,7 +170,7 @@ This means that Harness looks for the referenced variable within the current ste
 
 If multiple output variables from previous steps have the same name, the last-produced variable takes priority. For example, assume a stage has three steps, and steps one and two both produce output variables called `NAME`. If step three calls `NAME`, the value of `NAME` from step two is pulled into step three because that is last-produced instance of the `NAME` variable.
 
-:::caution Unpredictability with parallelism
+:::warning Unpredictability with parallelism
 
 For stages that use [looping strategies](/docs/platform/pipelines/looping-strategies/looping-strategies-matrix-repeat-and-parallelism), particularly parallelism, the last-produced instance of a variable can differ between runs. Depending on how quickly the parallel steps execute during each run, the last step to finish might not always be the same.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-to-gcr.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-:::caution
+:::warning
 
 Due to the [GCR deprecation](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr). The Build and Push to GCR step is pending deprecation. Instead, use the [Build and Push to GAR step](./build-and-push-to-gar.md).
 

--- a/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs.md
@@ -14,7 +14,7 @@ In addition to loading dependencies faster, you can also use caching to share da
 
 This topic explains how you can use the **Save Cache to GCS** and **Restore Cache from GCS** steps in your CI pipelines to save and retrieve cached data from Google Cloud Storage (GCS) buckets. For more information about caching in GCS, go to the Google Cloud documentation on [caching](https://cloud.google.com/storage/docs/caching). In your pipelines, you can also [save and restore cached data from S3](saving-cache.md) or use Harness [Cache Intelligence](./cache-intelligence.md).
 
-:::caution
+:::warning
 
 You can't share access credentials or other [Text Secrets](/docs/platform/secrets/add-use-text-secrets) across stages.
 

--- a/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/saving-cache.md
@@ -68,7 +68,7 @@ Here is an example of an S3 cache bucket policy:
 }
 ```
 
-:::caution
+:::warning
 
 You must use a dedicated bucket for your Harness CI cache operations. Do not save files to the bucket manually. The Restore Cache operation will fail if the bucket includes any files that do not have a Harness cache key.
 
@@ -247,7 +247,7 @@ Here is a YAML example of a **Restore Cache From S3** step.
 ...
 ```
 
-:::caution
+:::warning
 
 The `key` value in this step must match the `key` value in your **Save Cache to S3** step.
 

--- a/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
@@ -12,7 +12,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-:::caution
+:::warning
 
 You must configure branch protections and checks, such as protection rules, CODEOWNERS, linting, and other checks or restrictions, in your source control provider.
 

--- a/docs/continuous-integration/use-ci/manage-dependencies/configure-service-dependency-step-settings.md
+++ b/docs/continuous-integration/use-ci/manage-dependencies/configure-service-dependency-step-settings.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-:::caution
+:::warning
 
 The Configure Service Dependency step is deprecated. Instead, use the [Background step](./background-step-settings.md).
 

--- a/docs/continuous-integration/use-ci/run-tests/speed-up-ci-test-pipelines-using-parallelism.md
+++ b/docs/continuous-integration/use-ci/run-tests/speed-up-ci-test-pipelines-using-parallelism.md
@@ -421,7 +421,7 @@ If you [define a parallelism strategy](#define-a-parallelism-strategy) on a **Ru
 2. Make sure your test tool's commands produce test results. The specific commands required to produce test results files depends on the specific language, test runner, and formatter you use.
 3. Use an [expression](/docs/platform/Variables-and-Expressions/harness-variables) or variable in the results file name, such as `result_<+strategy.iteration>.xml` or `result_${HARNESS_NODE_INDEX}.xml`, to ensure each parallel instance produces a uniquely-named results file.
 
-   :::caution
+   :::warning
 
    If you [defined the parallelism strategy](#define-a-parallelism-strategy) on a step (instead of a stage), you *must* use an [expression](/docs/platform/Variables-and-Expressions/harness-variables) or variable in the results file name, such as `result_<+strategy.iteration>.xml` or `result_${HARNESS_NODE_INDEX}.xml`, to ensure each parallel instance produces a uniquely-named results file. If you don't use an expression or variable in the results file name, the files overwrite each other or fail due to same-name conflicts.
 
@@ -445,7 +445,7 @@ If you [define a parallelism strategy](#define-a-parallelism-strategy) on a **Ru
 2. Make sure your test tool's commands produce test results. The specific commands required to produce test results files depends on the specific language, test runner, and formatter you use.
 3. Use an [expression](/docs/platform/Variables-and-Expressions/harness-variables) or variable in the results file name, such as `result_<+strategy.iteration>.xml` or `result_${HARNESS_NODE_INDEX}.xml`, to ensure each parallel instance produces a uniquely-named results file.
 
-   :::caution
+   :::warning
 
    If you [defined the parallelism strategy](#define-a-parallelism-strategy) on a step (instead of a stage), you *must* use an [expression](/docs/platform/Variables-and-Expressions/harness-variables) or variable in the results file name, such as `result_<+strategy.iteration>.xml` or `result_${HARNESS_NODE_INDEX}.xml`, to ensure each parallel instance produces a uniquely-named results file. If you don't use an expression or variable in the results file name, the files overwrite each other or fail due to same-name conflicts.
 

--- a/docs/continuous-integration/use-ci/run-tests/test-intelligence/ti-test-splitting.md
+++ b/docs/continuous-integration/use-ci/run-tests/test-intelligence/ti-test-splitting.md
@@ -47,7 +47,7 @@ If you are using the Visual editor, **Parallelism** is found under **Looping Str
 
 For more information about parallelism strategies and optimizing parallelism, go to [Split tests - Define a parallelism strategy](../speed-up-ci-test-pipelines-using-parallelism.md#define-a-parallelism-strategy) and [Split tests - Optimize parallelism](../speed-up-ci-test-pipelines-using-parallelism.md#optimize-parallelism).
 
-:::caution
+:::warning
 
 If you use step-level parallelism, you must ensure that your test runners won't interfere with each other because all parallel steps work in the same directory.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/ci-stage-settings.md
@@ -204,7 +204,7 @@ Configure the [Security Context](https://kubernetes.io/docs/tasks/configure-pod-
 
 You can use the **Run as Non-Root** and **Run as User** settings to run builds as a non-root user or a specific user ID.
 
-:::caution
+:::warning
 
 Using a non-root user can require other changes to your pipeline.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/define-a-docker-build-infrastructure.md
@@ -263,7 +263,7 @@ Review the following requirements for Windows local runner build infrastructures
    * Add `-e DELEGATE_TAGS="windows-amd64"`.
    * Add `-e RUNNER_URL=http://WINDOWS_MACHINE_HOSTNAME_OR_IP:3000`.
 
-   :::caution
+   :::warning
 
    The `RUNNER_URL` must point to the Windows machine where the Harness Docker Runner will run.
 
@@ -303,7 +303,7 @@ For more information about delegates and delegate installation, go to [Delegate 
 
 The Harness Docker Runner service performs the build work. The delegate needs the runner to run CI builds.
 
-:::caution
+:::warning
 
 Run the Harness Docker Runner executable on the Windows machine that you specified in the delegate's `RUNNER_URL`.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
@@ -72,7 +72,7 @@ CI build infrastructure pods can interact with servers using self-signed certifi
 
    Both CI build pods and the SCM client on the delegate support this method.
 
-   :::caution
+   :::warning
 
    Make sure the destination path is not same as the default CA certificate path of the corresponding container image.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
@@ -212,7 +212,7 @@ Specify a Kubernetes service account that you want step containers to use when c
 
 Use the **Run as Non-Root** and **Run as User** settings to override the default Linux user ID for containers running in the build infrastructure. This is useful if your organization requires containers to run as a specific user with a specific set of permissions.
 
-:::caution
+:::warning
 
 Using a non-root user can require other changes to your pipeline.
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -59,7 +59,7 @@ If a Harness Cloud image has multiple versions of a tool pre-installed, you can 
 sudo xcode-select -switch /Applications/Xcode_14.1.0.app
 ```
 
-:::caution
+:::warning
 
 Harness Cloud machine images can change. If your pipeline relies on a specific version of a software, tool, or environment, use the instructions in [Lock versions or install additional tools](#lock-versions-or-install-additional-tools) to prevent your pipeline from failing when the image changes.
 

--- a/docs/continuous-integration/use-ci/use-drone-plugins/ci-github-action-step.md
+++ b/docs/continuous-integration/use-ci/use-drone-plugins/ci-github-action-step.md
@@ -322,7 +322,7 @@ For each expression:
 * Replace `[varName]` with the relevant variable name, wrapped in quotes.
 * In cross-stage references, replace `[stageID]` with the ID of the stage where the GitHub Actions step exists.
 
-:::caution
+:::warning
 
 GitHub Actions settings keys can include `-`, which is not supported by JEXL. Therefore, you must wrap these variable names in quotes when using them in Harness expressions.
 

--- a/docs/faqs/continuous-integration-ci-faqs.md
+++ b/docs/faqs/continuous-integration-ci-faqs.md
@@ -36,7 +36,7 @@ When configuring permissions for a GitHub personal access token (PAT) that you'l
 
 ![](./static/continuous-integration-ci-faqs-20.png)
 
-:::caution
+:::warning
 
 When you enable API authentication in a GitHub connector (recommended), use the same personal access token for both [Authentication](/docs/platform/connectors/code-repositories/ref-source-repo-provider/git-hub-connector-settings-reference#personal-access-token) and [API authentication](/docs/platform/connectors/code-repositories/ref-source-repo-provider/git-hub-connector-settings-reference#enable-api-access).
 

--- a/docs/faqs/harness-security-faqs.md
+++ b/docs/faqs/harness-security-faqs.md
@@ -192,7 +192,7 @@ For more information, go to:
 
 File secrets *are not masked* in Harness logs. These can be encoded in different formats, but they are not masked in logs.
 
-:::caution
+:::warning
 
 If an output variable value contains a secret, be aware that the secret will be visible in the [build details](/docs/continuous-integration/use-ci/viewing-builds.md):
 

--- a/docs/feature-flags/ff-sdks/client-sdks/react-client.md
+++ b/docs/feature-flags/ff-sdks/client-sdks/react-client.md
@@ -305,7 +305,7 @@ function MyComponent({ flags, loading }) {
 }
 const MyComponentWithFlags = withFeatureFlags(MyComponent)
 ```
-:::caution
+:::warning
 When using async mode, the default value is returned until the flags are retrieved. If you use the `useFeatureFlag` or `useFeatureFlags` hooks, the default value is undefined unless you change it when evaluating the flag. If you are using `withFeatureFlags`, you will receive an empty object. 
 :::
 

--- a/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
@@ -13,7 +13,7 @@ import Sixty from '/docs/feature-flags/shared/p-sdk-run60seconds.md'
 import Closeclient from '../shared/close-sdk-client.md'
 
 
-:::caution 
+:::warning 
 In Version 1.1.4 of the .NET SDK, the package name for installing the SDK changed from **ff-netF48-server-sdk** to **ff-dotnet-server-sdk**. To use this version, make sure you remove the old package name and use the new one. You can do this by using the following commands:
 **Remove the old package**  
 `dotnet remove package ff-netF48-server-sdk`  
@@ -63,7 +63,7 @@ Install the SDK by using the `dotnet add package` command, for example: 
 ```
 dotnet add package ff-dotnet-server-sdk --version 1.4.0
 ```
-:::caution
+:::warning
 In Version 1.1.4 of the .NET SDK, the package name for installing the SDK changed from **ff-netF48-server-sdk** to **ff-dotnet-server-sdk**. To use this version, make sure you remove the old package name and use the new one. You can do this by using the following commands:
 **Remove the old package**  
 `dotnet remove package ff-netF48-server-sdk`  

--- a/docs/feature-flags/manage-featureflags-in-git-repos.md
+++ b/docs/feature-flags/manage-featureflags-in-git-repos.md
@@ -22,7 +22,7 @@ import git_6 from './static/4-git-blue-circle.png'
 import git_7 from './static/5-manage-featureflags-in-git-repos-09.png' 
 import git_8 from './static/8-git-off.png' 
 
-:::caution
+:::warning
  There is a known issue with this feature. When you turn on a Feature Flag, some target rules may be reordered in your Git repo. This doesn't affect the functionality of your Feature Flag or targets and we are working to fix this issue as soon as possible.
 :::
 
@@ -58,7 +58,7 @@ The synchronization between the Harness Platform and the `flags.yaml` file works
 
 If you don’t see the changes you made in Git reflected on the Harness Platform after approxymately 5 min, refresh the page.
 
-:::caution
+:::warning
  Syncing changes between a remote file and the Harness Platform can take up to 5 mins. During this window the changes are commited to the remote file but not yet pulled and synced by the Harness Platform. Any changes made to the Harness Platform within that window trigger remote file updates, which overwrite the content of the remote file.
 :::
 
@@ -93,7 +93,7 @@ You can create the connector beforehand in Harness, or you can create it while s
 
 You must set up Git Experience before you can turn on syncing with Git in your Feature Flags project. 
 
-:::caution
+:::warning
 Do not use **Git Management** in Project Setup. This is an older version of Git Experience that does not work with Feature Flags.
 :::
 
@@ -129,7 +129,7 @@ To set up Git Experience:
 
 You can turn the synchronization between the Harness Platform and Git on or off. The Git Experience icon is displayed on many pages, and you can toggle it on or off from any page where it appears.
 
-:::caution
+:::warning
  Turning sync on triggers an immediate attempt to sync Harness content to the remote file.
  Any changes you made to the remote file before syncing are overwritten. This can result in losing content or configurations that are not yet synced to Harness.
 :::

--- a/docs/first-gen/firstgen-platform/account/manage-connectors/add-amazon-web-services-cloud-provider.md
+++ b/docs/first-gen/firstgen-platform/account/manage-connectors/add-amazon-web-services-cloud-provider.md
@@ -16,7 +16,7 @@ This topic explains how to set up the AWS Cloud Provider, and the IAM roles and 
 **Recommended:** Install and run a Harness Delegate (ECS Delegate in an ECS cluster, Shell Script Delegate on an EC2 instance, etc) in the same VPC as the AWS resources you will use, and then use the Delegate for the AWS Cloud Provider credentials. This is the easiest method to connect to AWS. For more information, see [Delegate Installation and Management](../manage-delegates/delegate-installation.md).
 :::
 
-:::caution
+:::warning
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Cloud Providers regardless of what AWS service you are using for your target infrastructure.
 :::
 
@@ -75,7 +75,7 @@ Choose a name for this provider. This is to differentiate AWS providers in Harne
 :::note
 Ensure that the AWS IAM roles applied to the credentials you use (the Harness Delegate or the access key) includes the policies needed by Harness to deploy to the target AWS service. See [Review: AWS Permissions](add-amazon-web-services-cloud-provider.md#review-aws-permissions) below.
 :::
-:::caution
+:::warning
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Cloud Providers regardless of what AWS service you are using for your target infrastructure.
 :::
 
@@ -225,7 +225,7 @@ When you install the Delegate in the cluster, the serviceAccount you added is us
 :::note
 Assume STS Role is supported for EC2 and ECS. It is supported for EKS if you use the IRSA option, described above.
 :::
-:::caution
+:::warning
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Cloud Providers regardless of what AWS service you are using for your target infrastructure.
 :::
 
@@ -279,7 +279,7 @@ You cannot access AWS GovCloud with standard AWS credentials. Likewise, you cann
 
 ## Review: AWS IAM Roles and Policies
 
-:::caution
+:::warning
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Cloud Providers regardless of what AWS service you are using for your target infrastructure.
 :::
 
@@ -297,7 +297,7 @@ As described below, `DescribeRegions` is required for all AWS Cloud Provider con
 
 ## All AWS Cloud Providers: DescribeRegions Required
 
-:::caution
+:::warning
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS Cloud Providers regardless of what AWS service you are using for your target infrastructure.
 :::
 

--- a/docs/first-gen/firstgen-platform/account/manage-delegates/delegate-installation.md
+++ b/docs/first-gen/firstgen-platform/account/manage-delegates/delegate-installation.md
@@ -134,7 +134,7 @@ spec:
       harness.io/app: harness-delegate  
 ...
 ```
-:::caution
+:::warning
 For the Kubernetes Delegate, you only need one Delegate in the cluster. Simply increase the number of replicas, and nothing else. Do not add another Delegate to the cluster in an attempt to achieve HA.
 :::
 

--- a/docs/first-gen/firstgen-platform/account/manage-delegates/run-scripts-on-the-delegate-using-profiles.md
+++ b/docs/first-gen/firstgen-platform/account/manage-delegates/run-scripts-on-the-delegate-using-profiles.md
@@ -8,7 +8,7 @@ helpdocs_is_private: false
 helpdocs_is_published: true
 ---
 
-:::caution
+:::warning
 Using Profiles is Deprecated. Please use [Run Initialization Scripts on Delegates](run-initialization-scripts-on-delegates.md).
 :::
 

--- a/docs/first-gen/firstgen-platform/account/manage-delegates/use-a-secret-in-a-delegate-profile.md
+++ b/docs/first-gen/firstgen-platform/account/manage-delegates/use-a-secret-in-a-delegate-profile.md
@@ -13,7 +13,7 @@ import image_1 from './static/use-a-secret-in-a-delegate-profile-24.png'
 import image_2 from './static/use-a-secret-in-a-delegate-profile-29.png'
 import image_3 from './static/use-a-secret-in-a-delegate-profile-30.png'
 
-:::caution
+:::warning
 Using Profiles is Deprecated. Please use [Run Initialization Scripts on Delegates](run-initialization-scripts-on-delegates.md).
 :::
 

--- a/docs/first-gen/firstgen-platform/account/tags/manage-tags.md
+++ b/docs/first-gen/firstgen-platform/account/tags/manage-tags.md
@@ -59,7 +59,7 @@ This menu provides the following options:
 
 * Click **Delete** to delete the Tag key from Harness. (This also frees up its name for reuse.) You will see the confirmation message box below.![](./static/manage-tags-12.png)
 
-:::caution
+:::warning
 There is no automatic undo. To restore a removed Tag key, you will need to manually re-enter it, along with any Allowed Values.
 :::
 

--- a/docs/internal-developer-portal/get-started/onboarding-guide.md
+++ b/docs/internal-developer-portal/get-started/onboarding-guide.md
@@ -48,7 +48,7 @@ This guide describes the steps a Harness account admin can take to set up the ID
 
 7. Connector setup 
 
-:::caution
+:::warning
 ### Limitations
 - Only the following set of connectors are supported  
   - GitHub

--- a/docs/internal-developer-portal/scorecards/checks-datasources.md
+++ b/docs/internal-developer-portal/scorecards/checks-datasources.md
@@ -30,7 +30,7 @@ There's a tab called `Data Sources` available in `Scorecards` page to check for 
 
 :::
 
-:::caution
+:::warning
 
 The git (GitHub, GitLab, Bitbucket) datasources doesn't support monorepos.
 

--- a/docs/internal-developer-portal/whats-supported.md
+++ b/docs/internal-developer-portal/whats-supported.md
@@ -20,7 +20,7 @@ Any software component can be registered in the catalog by using a YAML file sto
 * Bitbucket
 * Azure Repos
 
-:::caution
+:::warning
 
 Backstage doesn't support SSH auth type for integrations, hence only HTTP connection is supported for all the git provider based connectors in IDP 
 

--- a/docs/platform/automation/api/add-and-manage-api-keys.md
+++ b/docs/platform/automation/api/add-and-manage-api-keys.md
@@ -41,7 +41,7 @@ Use these steps to create an API key and personal access token (PAT) for your pe
 7. If you want to set an expiration date for the token, select **Set Expiration Date** and enter an expiration date in `mm/dd/yyyy` format.
 8. Select **Generate Token** and copy the token.
 
-   :::caution
+   :::warning
 
    The token is only displayed once. Store the token somewhere secure that you can access when you make API requests.
 
@@ -70,7 +70,7 @@ Use these steps to create an API key and service account token (SAT) for a servi
 9. If you want to set an expiration date for the token, select **Set Expiration Date** and enter an expiration date in `mm/dd/yyyy` format.
 10. Select **Generate Token** and copy the token.
 
-   :::caution
+   :::warning
 
    The token is only displayed once. Store the token somewhere secure that you can access when you make API requests.
 
@@ -172,7 +172,7 @@ As a security best practice, rotate tokens periodically. You can rotate tokens i
 </Tabs>
 
 
-:::caution
+:::warning
 
 The token is only displayed once. Store the token somewhere secure that you can access when you make API requests.
 

--- a/docs/platform/automation/api/api-quickstart.md
+++ b/docs/platform/automation/api/api-quickstart.md
@@ -51,7 +51,7 @@ You need to use API keys to authenticate requests. Create an API key in your Har
 7. Select **Set Expiration Date** and enter an expiration date in `mm/dd/yyyy` format.
 8. Select **Generate Token** and copy the token.
 
-   :::caution
+   :::warning
 
    The token is only displayed once. Store the token somewhere secure that you can access when you make API requests.
 

--- a/docs/platform/automation/terraform/automate-harness-onboarding.md
+++ b/docs/platform/automation/terraform/automate-harness-onboarding.md
@@ -303,7 +303,7 @@ Harness passes the terraform plan that was generated based on the Harness Terraf
 
 ![](./static/terraformapply.png)
 
-:::caution
+:::warning
 Ensure the **Terraform Plan** step is configured before the apply step.
 :::
 

--- a/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
+++ b/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
@@ -108,7 +108,7 @@ You can also [use a private registry for STO scanner images](/docs/security-test
 
 1. Download the images you need from the [Harness project on GCR](https://console.cloud.google.com/gcr/images/gcr-prod/global/harness), perform any tests or validations necessary for your organization's security policies, and then store the images in your private registry.
 
-   :::caution
+   :::warning
 
    Do not change the image names in your private registry. The image names must match the names specified by Harness.
 

--- a/docs/platform/connectors/cloud-providers/add-aws-connector.md
+++ b/docs/platform/connectors/cloud-providers/add-aws-connector.md
@@ -18,7 +18,7 @@ The necessary IAM roles and policies needed by the AWS account used in the conne
 
 AWS connectors can also inherit IAM roles from Harness delegates running in AWS. If you want your connector to inherit from a delegate, make sure the delegate has the necessary roles.
 
-:::caution
+:::warning
 
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS connectors regardless of what AWS service you are using for your target infrastructure.
 

--- a/docs/platform/connectors/cloud-providers/ref-cloud-providers/aws-connector-settings-reference.md
+++ b/docs/platform/connectors/cloud-providers/ref-cloud-providers/aws-connector-settings-reference.md
@@ -25,7 +25,7 @@ Consider the following user and access type requirements:
 :::important
 Amazon requires the Amazon EKS Pod execution role to run pods on the AWS Fargate infrastructure. For more information, go to [Amazon EKS Pod execution IAM role](https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html) in the AWS documentation.
 
-:::caution
+:::warning
 
 The [DescribeRegions](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) action is required for all AWS connectors regardless of what AWS service you are using for your target or build infrastructure.
 
@@ -1096,7 +1096,7 @@ The following steps assume this is a new delegate installation and a new AWS con
 
 </details>
 
-:::caution
+:::warning
 
 Ensure that the AWS IAM roles applied to the credentials you use (the Harness delegate or the access key) includes the policies needed by Harness to deploy to the target AWS service.
 

--- a/docs/platform/connectors/cloud-providers/ref-cloud-providers/gcs-connector-settings-reference.md
+++ b/docs/platform/connectors/cloud-providers/ref-cloud-providers/gcs-connector-settings-reference.md
@@ -24,7 +24,7 @@ For instructions on adding roles to your service account, go to the Google docum
 
 Alternately, you can use a service account that has only the **Storage Object Viewer** permission needed to query GCR, and then use either an in-cluster Kubernetes delegate or a direct [Kubernetes Cluster Connector](kubernetes-cluster-connector-settings-reference.md) with the Kubernetes service account token for performing deployment.
 
-:::caution
+:::warning
 
 Harness supports GKE 1.19 and later. If you use a version prior to GKE 1.19, please enable Basic Authentication. If Basic authentication is inadequate for your security requirements, use the [Kubernetes Cluster Connector](/docs/platform/connectors/cloud-providers/add-a-kubernetes-cluster-connector).
 

--- a/docs/platform/connectors/code-repositories/ref-source-repo-provider/bitbucket-connector-settings-reference.md
+++ b/docs/platform/connectors/code-repositories/ref-source-repo-provider/bitbucket-connector-settings-reference.md
@@ -189,7 +189,7 @@ In the **Personal Access Token** field, provide a Bitbucket account-level [App p
 
 You must provide an account-level app password or token. Repo-level tokens are not supported.
 
-:::caution
+:::warning
 
 For **HTTP** Connection Types, use the same password you used earlier, and make sure the **Username** fields are both plain-text or both encrypted. Don't use a plain-text username for one field and a secret for the other.
 

--- a/docs/platform/delegates/delegate-concepts/delegate-overview.md
+++ b/docs/platform/delegates/delegate-concepts/delegate-overview.md
@@ -216,7 +216,7 @@ The delegate logs are available in the Harness UI. When a pipeline runs and an e
 
 Delegate logs are also sent to Harness by default. These Stackdriver logs are stored in Harness's GCP account.
 
-:::caution
+:::warning
 **Not Recommended:** You can stop delegates from sending delegate logs to Harness by setting the `STACK_DRIVER_LOGGING_ENABLED` environment variable to `false` for the delegate. This will disable all remote logging.
 
 :::

--- a/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
+++ b/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
@@ -22,7 +22,7 @@ mTLS is an advanced feature. Contact [Harness Support](mailto:support@harness.io
 
 Harness does not create or distribute the CA and client certificates that are used for mTLS. You must set up the certificates and explicitly provide them to the delegate by mounting a Kubernetes secret.
 
-:::caution Important note
+:::warning Important note
 Project-level certificates are not supported for mTLS delegates.
 
 :::

--- a/docs/platform/git-experience/configure-git-experience-for-harness-entities.md
+++ b/docs/platform/git-experience/configure-git-experience-for-harness-entities.md
@@ -239,7 +239,7 @@ Harness loads your pipeline depending on where you saved your remote pipeline.
 - If you saved your pipeline on a non-default branch, Harness uses the metadata of this pipeline to load it from the non-default branch.
 - If you saved your pipeline in a branch that is no longer available, Harness throws an error. You must select a branch to load your pipeline in this case.
 
-:::caution
+:::warning
 Harness fetches your pipeline details from the default branch if you created your remote pipeline before version 77808. Select the corresponding branch and proceed to load a pipeline residing in a branch other than the default branch.
 
 :::

--- a/docs/platform/git-experience/move-inline-entities-to-git.md
+++ b/docs/platform/git-experience/move-inline-entities-to-git.md
@@ -20,7 +20,7 @@ Moving inline entities like pipelines to a Git repository can provide several be
   
 - Security: Only authorized users can access them.
 
-:::caution
+:::warning
 When you move an inline pipeline to Git, the pipeline's associated entities aren't automatically moved to a Git repository. You must also move the corresponding input sets to the remote repository.
 
 If your pipeline has a trigger, you must modify the YAML of the trigger to add a new field `pipelineBranchName`. This will ensure that your trigger works seamlessly with your pipeline.

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -39,7 +39,7 @@ The following list is optional. You can allowlist these IPs if needed.
 34.168.179.66
 ```
 
-:::caution
+:::warning
 Harness will not change IPs without 30 days notice to all customers. If a security emergency requires a change, all customers are notified.
 :::
 

--- a/docs/platform/role-based-access-control/add-manage-roles.md
+++ b/docs/platform/role-based-access-control/add-manage-roles.md
@@ -21,7 +21,7 @@ Roles are applied together with [resource groups](/docs/platform/role-based-acce
 * You can assign the **Organization Admin** role with a resource group that is limited to specific projects or specific organizations.
 * You can assign the **Pipeline Executor** role with a resource group that only allows access to specific pipelines, rather than all pipelines in the project.
 
-:::caution Least privilege
+:::warning Least privilege
 
 RBAC is additive. The total expanse of a user/service account's permissions and access is the sum of all the roles and resource groups from all user groups they belong to, as well as any roles and resource groups assigned directly to them as an individual user/service account.
 

--- a/docs/platform/role-based-access-control/add-resource-groups.md
+++ b/docs/platform/role-based-access-control/add-resource-groups.md
@@ -19,7 +19,7 @@ Harness includes some [built-in resource groups](#built-in-resource-groups), and
 * You can assign the **Organization Admin** role with a resource group that is limited to specific projects or specific organizations.
 * You can assign the **Pipeline Executor** role with a resource group that only allows access to specific pipelines, rather than all pipelines in the project.
 
-:::caution Least privilege
+:::warning Least privilege
 
 RBAC is additive. The total expanse of a user/service account's permissions and access is the sum of all the roles and resource groups from all user groups they belong to, as well as any roles and resource groups assigned directly to them as an individual user/service account.
 

--- a/docs/platform/role-based-access-control/add-user-groups.md
+++ b/docs/platform/role-based-access-control/add-user-groups.md
@@ -99,7 +99,7 @@ When viewing user groups at higher scopes, you can find a list of **Organization
 
 Initially, user groups have no permissions or access. You assign [roles](./add-manage-roles.md) and [resource groups](./add-resource-groups.md) to user groups, and then the permissions and access granted by the assigned roles and resource groups are applied to all group members. For more information about assigning roles and resource groups, go to [RBAC in Harness: Role binding](./rbac-in-harness.md#role-binding).
 
-:::caution Least privilege
+:::warning Least privilege
 
 RBAC is additive. The total expanse of a user/service account's permissions and access is the sum of all the roles and resource groups from all user groups they belong to, as well as any roles and resource groups assigned directly to them as an individual user/service account.
 

--- a/docs/platform/role-based-access-control/add-users.md
+++ b/docs/platform/role-based-access-control/add-users.md
@@ -81,7 +81,7 @@ When you add a user, Harness checks your [authentication method](/docs/platform/
 
 You assign [roles](./add-manage-roles.md) and [resource groups](./add-resource-groups.md) to users to grant them permissions and access in Harness. Users can inherit roles and resource groups from [group membership](./add-user-groups.md), or you can assign roles and resource groups directly to individual users. For more information about assigning roles and resource groups, go to [RBAC in Harness: Role binding](./rbac-in-harness.md#role-binding).
 
-:::caution Least privilege
+:::warning Least privilege
 
 RBAC is additive. The total expanse of a user/service account's permissions and access is the sum of all the roles and resource groups from all user groups they belong to, as well as any roles and resource groups assigned directly to them as an individual user/service account.
 

--- a/docs/platform/role-based-access-control/provision-users-and-groups-with-one-login-scim.md
+++ b/docs/platform/role-based-access-control/provision-users-and-groups-with-one-login-scim.md
@@ -14,7 +14,7 @@ If OneLogin is your identity provider, you can efficiently provision and manage 
 
 This topic describes how to use a OneLogin SCIM integration for automated provisioning in Harness. To configure this integration, you must take steps in both OneLogin and Harness.
 
-:::caution
+:::warning
 
 With the OneLogin SCIM integration, don't change provisioned users' email addresses in OneLogin. Once a user is provisioned in Harness, the user's email address *must remain the same*. If you change the email address in OneLogin and then try to remove the user from Harness, the removal will fail.
 
@@ -62,7 +62,7 @@ To allow users to log in through your OneLogin SCIM integration, you must also s
 
 ## Provision individual users
 
-:::caution
+:::warning
 
 With the OneLogin SCIM integration, don't change a provisioned user's email address in OneLogin. Once a user is provisioned in Harness, the user's email address *must remain the same*. If you change the email address in OneLogin and then try to remove the user from Harness, the removal will fail.
 
@@ -102,7 +102,7 @@ If an error prevents adding, deleting, or updating an individual user in Harness
 
 ## Provision OneLogin roles as Harness user groups
 
-:::caution
+:::warning
 
 With the OneLogin SCIM integration, don't change a provisioned user's email address in OneLogin. Once a user is provisioned in Harness, the user's email address *must remain the same*. If you change the email address in OneLogin and then try to remove the user from Harness, the removal will fail.
 

--- a/docs/platform/role-based-access-control/provision-users-with-okta-scim.md
+++ b/docs/platform/role-based-access-control/provision-users-with-okta-scim.md
@@ -242,7 +242,7 @@ To delete a user provisioned through a group, remove them from the group in Okta
 
 To delete a user from Harness and all other provisioned apps, deactivate the user's Okta profile.
 
-:::caution
+:::warning
 
 Deactivating a user removes them from *all provisioned apps*, including Harness. While a user account is deactivated, you can't change it.
 

--- a/docs/platform/role-based-access-control/rbac-in-harness.md
+++ b/docs/platform/role-based-access-control/rbac-in-harness.md
@@ -149,7 +149,7 @@ The following table describes the role bindings (permissions and access) that re
 
 RBAC is an additive model; therefore, role and resource group assignments in Harness are additive. The total expanse of a principal's permissions and access is the sum of all the roles and resource groups from all user groups they belong to, as well as any roles and resource groups assigned directly to them as an individual user or service account.
 
-:::caution Least privilege
+:::warning Least privilege
 
 It is important to follow the principle of least privilege (PoLP). This is a security principle that means users are granted the absolute minimum access/permissions necessary to complete their tasks and nothing more.
 

--- a/docs/platform/shared/delegate-legacy-eos.md
+++ b/docs/platform/shared/delegate-legacy-eos.md
@@ -1,4 +1,4 @@
-:::caution Delegate-Legacy End of Support (EOS) notice
+:::warning Delegate-Legacy End of Support (EOS) notice
 
 This is an End of Support (EOS) notice for the Delegate-Legacy image type. This image type will reach End of Support (EOS) as of **January 31, 2024**.
 

--- a/docs/platform/templates/templates-best-practices.md
+++ b/docs/platform/templates/templates-best-practices.md
@@ -434,7 +434,7 @@ You can create versions of your templates in Harness and Git.
 
 - When you reference a pipeline with a template, ensure the pipeline branch matches the template branch.
 
-:::caution
+:::warning
 When tracking template changes, Harness versioning should not be combined with GitHub versioning.
 :::
 

--- a/docs/platform/triggers/triggering-pipelines.md
+++ b/docs/platform/triggers/triggering-pipelines.md
@@ -52,7 +52,7 @@ These steps assume you're familiar with [creating CD pipelines](/docs/continuous
 
 ### Configure the trigger
 
-:::caution
+:::warning
 
 All triggers in a Harness account have the same URL: `https://app.harness.io/gateway/ng/api/webhook?accountIdentifier=ACCOUNT_ID`. This means that you must set up your trigger conditions carefully to ensure that triggers start pipelines for relevant events only.
 

--- a/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry.md
+++ b/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/download-images-from-private-registry.md
@@ -83,7 +83,7 @@ You need a Docker connector that points to your private container registry. For 
 
 1. Download the scan images you need from the [Harness project on GCR](https://console.cloud.google.com/gcr/images/gcr-prod/global/harness), test and validate the images, and store them in your private registry.
 
-   :::caution
+   :::warning
 
    Do not change the image names in your private registry. The image names must match the names specified by Harness.
 

--- a/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/optimize-sto-pipelines.md
+++ b/docs/security-testing-orchestration/use-sto/set-up-sto-pipelines/optimize-sto-pipelines.md
@@ -34,7 +34,7 @@ Increasing the CPU will enable the DinD to pull images from the registry faster,
 
 In this example, the stage scans an image target using Aqua Trivy and Prisma Cloud. The two steps run in parallel within a [step group](/docs/continuous-integration/use-ci/optimize-and-more/group-ci-steps-using-step-groups). 
 
-:::caution
+:::warning
 
 The stage must have enough memory and CPU to run all parallel steps at the same time. If the stage lacks resources, running the steps in parallel could [cause your pipeline executions to fail](/docs/continuous-integration/use-ci/optimize-and-more/group-ci-steps-using-step-groups#parallelism-impacts-resource-consumption).
 

--- a/docs/security-testing-orchestration/use-sto/view-and-troubleshoot-vulnerabilities/jira-integrations.md
+++ b/docs/security-testing-orchestration/use-sto/view-and-troubleshoot-vulnerabilities/jira-integrations.md
@@ -23,7 +23,7 @@ You can set up STO to create Jira tickets for issues detected by STO scans. This
 * This feature is supported for both [STO SecOps and Developer](/docs/platform/role-based-access-control/add-manage-roles/#module-specific-roles) roles.  
 :::
 
-:::caution
+:::warning
 This integration has a separate setup path that is unrelated to other Jira-related integrations in Harness pipelines. To open Jira tickets for security findings in STO, you must set up the integration as documented below. You cannot use other Jira workflows to create Jira tickets in STO. For example, you cannot integrate Jira with STO using Custom steps with Jira Create or other related steps.
 :::
 

--- a/docs/self-managed-enterprise-edition/monitor-harness-on-prem.md
+++ b/docs/self-managed-enterprise-edition/monitor-harness-on-prem.md
@@ -261,7 +261,7 @@ Follow the below steps on your Kubernetes cluster to deploy Grafana:
 
   `http://my-release-kube-prometheus-prometheus.default.svc.cluster.local:9090/`
 
-  :::caution
+  :::warning
   The final URL should be similar to the above URL, according to your system specifications. Any extra space or character in the URL field causes the data source testing to fail. 
   :::
 

--- a/docs/software-engineering-insights/sei-metrics-and-reports/quality-metrics-reports/testrail-reports.md
+++ b/docs/software-engineering-insights/sei-metrics-and-reports/quality-metrics-reports/testrail-reports.md
@@ -17,7 +17,7 @@ sidebar_position: 60
 
 When configuring this widget, on the **Metrics** tab, you can select either **Test Cases** (number of test cases) or **Tests** (number of test executions).
 
-:::caution
+:::warning
 
 Each metric has different options for **Columns**, **Filters**, **Stacks**, and **Aggregations**. Switching from **Test Cases** to **Tests** and vice versa resets the linked settings.
 

--- a/docs/software-engineering-insights/sei-metrics-and-reports/trellis-score.md
+++ b/docs/software-engineering-insights/sei-metrics-and-reports/trellis-score.md
@@ -55,7 +55,7 @@ Speed measures the pace at which developers are writing and submitting code. Spe
 * **Average PR Cycle Time:** This represents the time elapsed from PR creation to closing. The average PR cycle time should be less than 7 days. This metric is calculated as the elapsed time between PR creation and closure.
 * **Average Time Spent Working On Issues:** This is the average time spent on each issue resolved in the last 30 days or any specified time period. This typically doesn't include time spent in the **Done** status. Time is counted only when the developer is assigned to an issue. The average time spent working on issues should be between 3 and 5 days. This metric is calculated by dividing the total time by the total number of issues recorded in the period.
 
-:::caution
+:::warning
 
 It is not recommended to change these metrics from their default values, because they are based on industry standards.
 

--- a/release-notes/chaos-engineering.md
+++ b/release-notes/chaos-engineering.md
@@ -569,7 +569,7 @@ The release notes describe recent changes to Harness Chaos Engineering.
 
 #### New features and enhancements
 
-:::caution
+:::warning
 This release breaks backward compatibility with older chaos infrastructures. You must update chaos infrastructures and the chaosnative/go-runner image in experiment definitions. If you don't upgrade, then chaos experiments will start to fail.
 
 To upgrade chaos infrastructures and experiments:

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -116,7 +116,7 @@ Due to the [GCR deprecation](https://cloud.google.com/artifact-registry/docs/tra
 
 The Harness Cloud Windows image has been upgraded to Windows Server 2022. This includes major and minor version upgrades for many components. For a complete list of component versions, go to the [Harness Cloud image specifications](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#platforms-and-image-specifications).
 
-:::caution
+:::warning
 
 If you have pipelines running on Harness Cloud that rely on specific component versions, you might need to [lock versions or install additional tools](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#lock-versions-or-install-additional-tools) to prevent your pipeline from failing due to image changes.
 
@@ -442,7 +442,7 @@ Addressed regressions that caused existing pipelines to fail.
 
 The Harness Cloud Linux amd64 image has new major and minor versions for multiple components. Major version upgrades are described below. For a complete list of component versions, go to the [Harness Cloud image specifications](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#platforms-and-image-specifications). (CI-7537)
 
-:::caution
+:::warning
 
 If you have pipelines running on Harness Cloud that rely on specific component versions, you might need to [lock versions or install additional tools](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#lock-versions-or-install-additional-tools) to prevent your pipeline from failing due to image changes.
 

--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -155,7 +155,7 @@ Harness updated the Nginx ingress controller to version 1.3.0. With this upgrade
 
 The Harness Cloud Windows image has been upgraded to Windows Server 2022. This includes major and minor version upgrades for many components. For a complete list of component versions, go to the [Harness Cloud image specifications](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#platforms-and-image-specifications).
 
-:::caution
+:::warning
 
 If you have pipelines running on Harness Cloud that rely on specific component versions, you might need to [lock versions or install additional tools](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#lock-versions-or-install-additional-tools) to prevent your pipeline from failing due to image changes.
 
@@ -1544,7 +1544,7 @@ gsutil -m cp \
   .
 ```
 
-:::caution
+:::warning
 
 The Harness Self-Managed Edition Helm chart release 0.9.0 includes major changes. You must update your existing override files to include the new changes. If you do not update your Helm chart override files, Helm upgrades will fail. The patch release package includes a `migrate-values-0.9.x.sh` script to convert the old `override.yaml` file to the new format.
 
@@ -1782,7 +1782,7 @@ The Harness Self-Managed Edition Helm chart release 0.9.0 includes major changes
 
 ##### Custom Dashboards
 
-:::caution
+:::warning
 
 Argo CD deployments were failing. Looker now includes `models.persistent.storageClass` and `database.persistent.storageClass` fields to override any `storageClass` field used in PVC that has a higher precedence over `global.storageClass`. Looker also now includes `models.persistent.existingClaim` and `database.persistent.existingClaim` to use an existing PVC. These updates resolve the issue. (CDB-1149)
 
@@ -2449,7 +2449,7 @@ gsutil -m cp \
 
 The Harness Cloud Linux amd64 image has new major and minor versions for multiple components. Major version upgrades are described below. For a complete list of component versions, go to the [Harness Cloud image specifications](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#platforms-and-image-specifications). (CI-7537)
 
-:::caution
+:::warning
 If you have pipelines running on Harness Cloud that rely on specific component versions, you might need to [lock versions or install additional tools](https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#lock-versions-or-install-additional-tools) to prevent your pipeline from failing due to image changes.
 :::
 

--- a/tutorials/cd-pipelines/approvals.md
+++ b/tutorials/cd-pipelines/approvals.md
@@ -79,7 +79,7 @@ For this tutorial, we will use the visual view of the pipeline.
 
 7. Select **Save**, and then select **Run** to run the pipeline.
 
-:::caution
+:::warning
 
 Approval steps should not be added to run in parallel with other steps, including other Approval steps. The Harness Pipeline Studio will not allow you to add Approval steps in parallel with other steps, but the pipeline YAML editor does not prevent this setup. During execution, a successful parallel Approval step will not fail the deployment, but it is not a valid configuration because Approvals are checks on the release process and should always be used between steps.
 

--- a/tutorials/cd-pipelines/kubernetes/cosign-opa.md
+++ b/tutorials/cd-pipelines/kubernetes/cosign-opa.md
@@ -178,7 +178,7 @@ The first four variables on this list are used to ensure that the correct image 
 
 Let's add a [policy step](https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/advanced/cd-governance/add-a-governance-policy-step-to-a-pipeline/) after the **cosign_verify** step (you can call this **policy_enforcement** step). You can define and store policies directly in the OPA service in Harness.
 
-:::caution
+:::warning
 
 Policy Based Governance is a paid feature on the Harness platform.
 

--- a/tutorials/cd-pipelines/kubernetes/helm-chart.md
+++ b/tutorials/cd-pipelines/kubernetes/helm-chart.md
@@ -194,7 +194,7 @@ Once you have installed the Agent, Harness will start importing all the entities
 
    :::
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 
@@ -459,7 +459,7 @@ Verify the following:
 
    :::
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 
@@ -833,7 +833,7 @@ Make sure that you have met the following requirements:
 
 2. Select **Projects** on the top left corner of the UI, and then select **Default Project**.
 
-:::caution
+:::warning
 
 Follow the below mentioned steps as they are, including the naming conventions, for the pipeline to run successfully.
 

--- a/tutorials/cd-pipelines/kubernetes/kustomize.md
+++ b/tutorials/cd-pipelines/kubernetes/kustomize.md
@@ -324,7 +324,7 @@ Complete the following tasks:
    ```
    > Note: Replace `HARNESS_API_TOKEN` with the Harness API token that you obtained during the prerequisite section of this tutorial.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, perform all of the following steps as they are, including the naming conventions.
 
@@ -484,7 +484,7 @@ Verify the following:
 
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/kubernetes/manifest.md
+++ b/tutorials/cd-pipelines/kubernetes/manifest.md
@@ -422,7 +422,7 @@ export TV_VAR_account_id="123abcXXXXXXXX"
 export TV_VAR_harness_api_token="pat.abc123xxxxxxxxxx…"
 ```
 
-:::caution
+:::warning
 
 Never store your Harness API Key in a plain text configuration file or in version control. Use an environment variable or dedicated secrets manager.
 
@@ -648,7 +648,7 @@ Verify the following:
 
    :::
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 
@@ -855,7 +855,7 @@ Verify that you have the following:
 1. Log in to [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow the remaining steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/kubernetes/ownapp.md
+++ b/tutorials/cd-pipelines/kubernetes/ownapp.md
@@ -355,7 +355,7 @@ export TV_VAR_account_id="123abcXXXXXXXX"
 export TV_VAR_harness_api_token="pat.abc123xxxxxxxxxx…"
 ```
 
-:::caution
+:::warning
 
 Never store your Harness API Key in a plain text configuration file or in version control. Use an environment variable or dedicated secrets manager.
 
@@ -604,7 +604,7 @@ Verify the following:
   - Verify that the delegate is installed successfully and can connect to the Harness Manager.
   - You can also follow the [Install Harness delegate on Kubernetes or Docker](/tutorials/platform/install-delegate/) tutorial to install the delegate using the Terraform Helm Provider or Kubernetes manifest.
 
-:::caution
+:::warning
 
 If you plan to use your own Project, Organization, and custom names for Harness resources, please update the resource YAMLs accordingly with these details.
 
@@ -744,7 +744,7 @@ Verify that you have the following:
   - Verify that the delegate is installed successfully and can connect to the Harness Manager.
   - You can also follow the [Install Harness delegate on Kubernetes or Docker](/tutorials/platform/install-delegate/) tutorial to install the delegate using the Terraform Helm Provider or Kubernetes manifest.
 
-:::caution
+:::warning
 
 If you plan to use your own Project, Organization, and custom names for Harness resources, please update the resource YAMLs accordingly with these details.
 

--- a/tutorials/cd-pipelines/serverless/aws-lambda.md
+++ b/tutorials/cd-pipelines/serverless/aws-lambda.md
@@ -75,7 +75,7 @@ Verify the following:
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects** and choose **Default Project**.
 
-:::caution
+:::warning
 
 Going forward, follow all the steps as they are, including the naming conventions, for the pipeline to run successfully.
 
@@ -535,7 +535,7 @@ Verify the following:
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow the remaining steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/serverless/gcp-cloud-func.md
+++ b/tutorials/cd-pipelines/serverless/gcp-cloud-func.md
@@ -82,7 +82,7 @@ We suggest opting for Cloud Functions **2nd gen** whenever feasible for new func
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow the remaining steps as they are, including the naming conventions.
 
@@ -507,7 +507,7 @@ You've just learned how to use Harness CD to deploy a Google Cloud Function to G
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow the remaining steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/templates.md
+++ b/tutorials/cd-pipelines/templates.md
@@ -77,7 +77,7 @@ Make sure you have followed the [get started](/tutorials/cd-pipelines/kubernetes
 6. Select the `harness-deployment-template` you just created and select **Use Template**.
 7. Select **Save** and then select **Run** to run the pipeline.
 
-:::caution
+:::warning
 
 The `harness-deployment-template` will only work under the `default_project` which already has all the pipeline resources created during get started pipleine.
 

--- a/tutorials/cd-pipelines/trigger.md
+++ b/tutorials/cd-pipelines/trigger.md
@@ -38,7 +38,7 @@ Verify the following:
 1. Log in to your Harness instance.
 2. Select **Projects**, and then select **Default Project**.
 
-   :::caution
+   :::warning
 
    For the pipeline to run successfully, you must follow all of the following steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/vm/aws.md
+++ b/tutorials/cd-pipelines/vm/aws.md
@@ -40,7 +40,7 @@ Verify the following:
 
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
-   :::caution
+   :::warning
 
    For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 
@@ -255,7 +255,7 @@ Verify the following:
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
 
-   :::caution
+   :::warning
 
    For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/vm/azure.md
+++ b/tutorials/cd-pipelines/vm/azure.md
@@ -40,7 +40,7 @@ Verify the following:
 
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
-   :::caution
+   :::warning
 
    For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 
@@ -255,7 +255,7 @@ Verify the following:
 1. Log into [Harness](https://app.harness.io/).
 2. Select **Projects**, and then select **Default Project**.
 
-   :::caution
+   :::warning
 
    For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 

--- a/tutorials/cd-pipelines/vm/pdc.md
+++ b/tutorials/cd-pipelines/vm/pdc.md
@@ -47,7 +47,7 @@ Verify that you have the following:
 
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, follow all of the steps below as they are, including the naming conventions.
 
@@ -267,7 +267,7 @@ Verify that you have the following:
 
 2. Select **Projects**, and then select **Default Project**.
 
-:::caution
+:::warning
 
 For the pipeline to run successfully, please follow all of the following steps as they are, including the naming conventions.
 

--- a/tutorials/ci-pipelines/build/ci-ruby.md
+++ b/tutorials/ci-pipelines/build/ci-ruby.md
@@ -77,7 +77,7 @@ You can cache your Ruby dependencies with [Cache Intelligence](/docs/continuous-
     spec:
       caching:
         enabled: true
-        key: cache-{{ checksum "gemfile.lock" }}
+        key: cache-{{ checksum "Gemfile.lock" }}
         paths:
           - "vendor/bundle"
       sharedPaths:
@@ -104,7 +104,7 @@ Here's an example of a pipeline with **Save Cache to S3** and **Restore Cache fr
                     connectorRef: AWS_connector
                     region: us-east-1
                     bucket: some_s3_bucket
-                    key: cache-{{ checksum "gemfile.lock" }}
+                    key: cache-{{ checksum "Gemfile.lock" }}
                     archiveFormat: Tar
               - step:
                   type: Run
@@ -120,7 +120,7 @@ Here's an example of a pipeline with **Save Cache to S3** and **Restore Cache fr
                     connectorRef: AWS_connector
                     region: us-east-1
                     bucket: some_s3_bucket
-                    key: cache-{{ checksum "gemfile.lock" }}
+                    key: cache-{{ checksum "Gemfile.lock" }}
                     sourcePaths:
                       - vendor/bundle
                     archiveFormat: Tar
@@ -411,7 +411,7 @@ pipeline:
           cloneCodebase: true
           caching:
             enabled: true
-            key: cache-{{ checksum "gemfile.lock" }}
+            key: cache-{{ checksum "Gemfile.lock" }}
             paths:
               - vendor/bundle
           sharedPaths:
@@ -492,7 +492,7 @@ pipeline:
                     connectorRef: YOUR_AWS_CONNECTOR_ID
                     region: us-east-1 ## Set to your bucket's AWS region
                     bucket: YOUR_AWS_BUCKET_NAME
-                    key: cache-{{ checksum "gemfile.lock" }}
+                    key: cache-{{ checksum "Gemfile.lock" }}
                     archiveFormat: Tar
               - step:
                   type: Run
@@ -534,7 +534,7 @@ pipeline:
                     connectorRef: YOUR_AWS_CONNECTOR_ID
                     region: us-east-1 ## Set to your bucket's AWS region
                     bucket: YOUR_AWS_BUCKET_NAME
-                    key: cache-{{ checksum "gemfile.lock" }}
+                    key: cache-{{ checksum "Gemfile.lock" }}
                     sourcePaths:
                       - vendor/bundle
                     archiveFormat: Tar

--- a/tutorials/ci-pipelines/ci-kubernetes-build-farm.md
+++ b/tutorials/ci-pipelines/ci-kubernetes-build-farm.md
@@ -63,7 +63,7 @@ In addition to a Harness account, you need the following accounts and tools:
   - Namespace: During the tutorial, when you install the Harness Delegate, the `harness-delegate-ng` namespace is created. You'll use the same namespace for the build infrastructure.
 - A **Kubernetes service account** with permission to create entities in the target namespace. The set of permissions should include `list`, `get`, `create`, and `delete` permissions. Usually, the `cluster-admin` permission or `namespace admin` permission is sufficient. For more information, go to the Kubernetes documentation on [User-Facing Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 
-:::caution
+:::warning
 
 Google Kubernetes Engine (GKE) [Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) is not recommended. For more information, go to [Set up a Kubernetes cluster build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure).
 

--- a/tutorials/hdh/hdh-docusaurus-sandbox.md
+++ b/tutorials/hdh/hdh-docusaurus-sandbox.md
@@ -73,7 +73,7 @@ Tip text.
 
 :::
 
-:::caution
+:::warning
 
 Caution text.
 

--- a/tutorials/self-managed-enterprise-edition/use-an-external-postgres-database.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-postgres-database.md
@@ -74,7 +74,7 @@ You can update the DNS record dynamically using a script or use the service disc
 
 ## Set up PostgreSQL VMs
 
-:::caution
+:::warning
 If you installed PostgreSQL through a method other than the apt package manager maintained by Debian or Ubuntu archive, you may receive errors when following these instructions. Harness recommends that you uninstall existing PostgreSQL installations before you continue.
 :::
 

--- a/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
@@ -69,7 +69,7 @@ You can update the DNS record dynamically using a script or use the service disc
 
 ## Set up TimescaleDB VMs on Debian-based systems
 
-:::caution
+:::warning
 If you installed PostgreSQL through a method other than the apt package manager maintained by Debian or Ubuntu archive, you may receive errors when following these instructions. Harness recommends that you uninstall existing PostgreSQL installations before you continue.
 :::
 


### PR DESCRIPTION
Change `:::caution` to `:::warning` due to deprecation in Docusaurus 3.
Fix capitalization of `Gemfile.lock` in some code samples.