### PR TITLE
Remove duplication of the curl -LO part.

### DIFF
--- a/docs/platform/shared/cli/amd.md
+++ b/docs/platform/shared/cli/amd.md
@@ -1,5 +1,5 @@
 ```bash
-curl -LO curl -LO harness.gateway.scarf.sh/v0.0.20-Preview/harness-v0.0.20-Preview-linux-amd64.tar.gz
+curl -LO harness.gateway.scarf.sh/v0.0.20-Preview/harness-v0.0.20-Preview-linux-amd64.tar.gz
 tar -xvf harness-v0.0.20-Preview-linux-amd64.tar.gz
 ```
 


### PR DESCRIPTION
# Harness Developer Pull Request

This PR removes duplication of the `curl -LO` part for Linux/AMD-architecture installation of Harness CLI.