### PR TITLE
Fix FeatureFlags certifications page's bold markdown formating

### DIFF
--- a/src/components/Certifications/data/ff-certification-developer-review-guide.md
+++ b/src/components/Certifications/data/ff-certification-developer-review-guide.md
@@ -1,18 +1,18 @@
 | Topic                                                                            | Material                                                                                                                          |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **1. Introduction to Feature Flags **                                               |                                                                                                                                   |
+| **1. Introduction to Feature Flags**                                               |                                                                                                                                   |
 | Understand what a feature flag is and how it can be used in software development | [Overview of Feature Flags](/docs/feature-flags/get-started/overview)               |
 | Understand the benefits of using feature flags in a development process          | [Best practices for managing flags](/docs/feature-flags/get-started/feature-flag-best-practices)    |
 | Familiarize with the terminology used in Harness.io's feature flag capabilities  | [Overview of Feature Flags](/docs/feature-flags/get-started/overview)               |
-| **2. Harness.io's Feature Flag Fundamentals  **                                     |                                                                                                                                   |
+| **2. Harness.io's Feature Flag Fundamentals**                                     |                                                                                                                                   |
 | Learn about the basics of Harness.io's feature flag capabilities                 | [Get started with a flag](/docs/feature-flags/get-started/onboarding-guide)       |
 | Identify different types of feature flags within the Harness.io environment      | [Change the variations of your flags](/docs/feature-flags/ff-creating-flag/manage-variations)         |
 | Familiarize with the different statuses of feature flags                         | [Use the FF dashboard](/docs/feature-flags/ff-data/dashboard)                                         |
-| **3. Managing Feature Flags in Harness.io  **                                       |                                                                                                                                   |
+| **3. Managing Feature Flags in Harness.io**                                       |                                                                                                                                   |
 | Learn how to create a simple feature flag in Harness.io                          | [Create a Feature Flag](/docs/feature-flags/ff-creating-flag/create-a-feature-flag)                   |
 | Learn how to enable and disable a feature flag                                   | [Enable or disable your flags](/docs/feature-flags/ff-creating-flag/enable-or-disable-a-feature-flag) |
 | Learn how to use the Harness.io dashboard to manage feature flags                | [Use the FF dashboard](/docs/feature-flags/ff-data/dashboard)                                         |
-| **4. Advanced Feature Flag Techniques **                                            |                                                                                                                                   |
+| **4. Advanced Feature Flag Techniques**                                            |                                                                                                                                   |
 | Understand the concept of feature flag hierarchy                                 | [Policies overview for Feature Flags](/docs/feature-flags/harness-policy-engine)                      |
 | Learn about the concept of percentage rollouts with feature flags                | [Use Pipelines with Feature Flags](/docs/category/use-pipelines-with-flags)                           |
 | Understand the basics of targeting rules in feature flags                        | [Manage target users and groups](/docs/category/manage-target-users-and-groups)                       |
@@ -20,7 +20,7 @@
 | Understand the role of feature flags in continuous delivery                      | [Use the Harness Relay Proxy](/docs/category/use-the-harness-relay-proxy)                             |
 | Learn how to integrate feature flags into your existing development workflow     | [Use the Harness Relay Proxy](/docs/category/use-the-harness-relay-proxy)                             |
 | Understand the process of rolling back a feature flag                            | [Enable or disable your flags](/docs/feature-flags/ff-creating-flag/enable-or-disable-a-feature-flag) |
-| **6. Security and Analytics in Feature Flags **                                     |                                                                                                                                   |
+| **6. Security and Analytics in Feature Flags**                                     |                                                                                                                                   |
 | Learn how to read and interpret feature flag analytics                           | [Get Data on Your Feature Flags](/docs/category/get-data-on-your-flags)                               |
 | Familiarize with Harness.io's security measures related to feature flags         | [Feature Flag Security and Compliance](/docs/category/ff-security-and-compliance)                     |
 | Learn how to troubleshoot basic feature flag issues                              | [Feature Flag FAQs](https://developer.harness.io/kb/feature-flags/harness-feature-flag-faqs)                                      |


### PR DESCRIPTION
Some of the bullet points on this page were showing Markdown formatting errors on the website.

This commit removes spaces which make markdown renderer properly render the text as **Bold**.

Here's what the website currently looks like:

https://developer.harness.io/certifications/feature-flags/?lvl=developer

<img width="923" alt="image" src="https://github.com/harness/developer-hub/assets/25652765/86715342-57a2-46ca-b64c-4e2cc9bef247">

Note that the **5.** point is bold, as expected. The others were not, and showing random stars.

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* No issues in perticular. I just leave things in a better shape than I find them where I can 😸 

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [x] *Optional* Screen Shoot. 
