### PR TITLE
Add pill for STO step not available on free plans.

### DIFF
--- a/tutorials/cd-pipelines/unified-cicd/e2e-pipeline.md
+++ b/tutorials/cd-pipelines/unified-cicd/e2e-pipeline.md
@@ -77,6 +77,12 @@ harness connector --file docker-connector.yaml apply
 
 ## Build the CI stage
 
+<DocsTag  backgroundColor= "#4279fd" text="Harness Paid Plan Feature"  textColor="#ffffff"/>
+
+:::info
+The 'Run Owasp Tests' step is a placeholder and does not actually run an OWASP scan. This is because this step is part of the Harness STO module, which is not available on free plans.
+:::
+
 Next, let's create the Continuous Integration (CI) pipeline that will do the following:
 
 - Clone the repository


### PR DESCRIPTION
# Harness Developer Pull Request

At the time of this PR, the STO steps are not available on CI free plans. This PR adds a pill and note to https://developer.harness.io/tutorials/cd-pipelines/unified-cicd/e2e-pipeline so that readers are aware.

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [x] *Optional* Screen Shoot. 
![Screenshot 2024-01-11 at 5 35 04 PM](https://github.com/harness/developer-hub/assets/30604461/b728a6a7-8a85-4dde-a23d-d97fb41dbb10)

