### PR TITLE
remove bundle install in run tests step examples

### DIFF
--- a/docs/continuous-integration/use-ci/run-tests/test-intelligence/ti-for-ruby.md
+++ b/docs/continuous-integration/use-ci/run-tests/test-intelligence/ti-for-ruby.md
@@ -23,7 +23,6 @@ Using [Test Intelligence (TI)](./set-up-test-intelligence.md) in your Harness CI
          language: Ruby
          buildTool: Rspec
          runOnlySelectedTests: true ## Must be 'true' to enable TI.
-         preCommand: bundle install
    ```
 
    For additional YAML examples, go to [Pipeline examples](#pipeline-examples)
@@ -131,7 +130,6 @@ This example shows a pipeline that:
                 testGlobs: "**/test/unit/**/*_test.rb" ## Optional
                 runOnlySelectedTests: true ## Must be 'true' to use TI.
                 enableTestSplitting: true ## Optional. Apply parallelism to further improve test times.
-                preCommand: bundle install
 ```
 
 </TabItem>
@@ -171,7 +169,6 @@ pipeline:
                     language: Ruby
                     buildTool: Rspec
                     runOnlySelectedTests: true ## Must be 'true' to use TI.
-                    preCommand: bundle install
           infrastructure:
             type: KubernetesDirect
             spec:
@@ -254,14 +251,7 @@ Used to [enable test splitting (parallelism) for TI](./ti-test-splitting.md).
 
 ### Pre-Command, Post-Command, and Shell
 
-- **Pre-Command:** Enter commands for setting up the environment before running the tests, such as `bundle install`
-
-:::info
-
-If you need to run `bundle install` before running tests, you must include `bundle install` in **Pre-Command**.
-
-:::
-
+- **Pre-Command:** Enter commands for setting up the environment before running the tests.
 - **Post-Command:** You can enter commands used for cleaning up the environment after running the tests.
 - **Shell:** If you supplied a script in **Pre-command** or **Post-command**, select the corresponding shell script type.
 

--- a/tutorials/ci-pipelines/build/ci-ruby.md
+++ b/tutorials/ci-pipelines/build/ci-ruby.md
@@ -235,7 +235,6 @@ You can use Run Tests steps to [run Ruby unit tests with Test Intelligence](/doc
       language: Ruby
       buildTool: Rspec
       runOnlySelectedTests: true
-      preCommand: bundle install
 ```
 
 </TabItem>
@@ -252,7 +251,6 @@ You can use Run Tests steps to [run Ruby unit tests with Test Intelligence](/doc
       language: Ruby
       buildTool: Rspec
       runOnlySelectedTests: true
-      preCommand: bundle install
 ```
 
 </TabItem>


### PR DESCRIPTION
No longer required to include bundle install in precommand.