### PR TITLE
Remove intro heading from faults

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/alb-az-down.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/alb-az-down.md
@@ -2,7 +2,6 @@
 id: alb-az-down
 title: ALB AZ down
 ---
-## Introduction
 ALB (Application Load Balancer) AZ (Availability Zones) down takes down the AZ on a target application load balancer for a specific duration thereby impacting the delivery. This fault restricts access to certain availability zones for a specific duration.
 
 ![ALB AZ Down](./static/images/alb-az-down.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/alb-az-down.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/alb-az-down.md
@@ -12,7 +12,7 @@ ALB AZ down:
 - Detaches the AZ from the application load balancer thereby disrupting the application's performance. 
 - Tests the application sanity, availability, and recovery workflows of the application pod attached to the load balancer.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Appropriate AWS access to attach or detach subnet from the target ALB.
 - There needs to be a minimum of two AZs attached to the target ALB after injecting chaos; otherwise, the fault will fail to detach the given AZ.
@@ -62,8 +62,9 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile) to use a different profile for AWS faults and [superset permission or policy](./security-configurations/policy-for-all-aws-faults) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -77,7 +78,7 @@ Below is an example AWS policy to execute the fault.
       <tr>
         <td> ZONES </td>
         <td> Target zones that should be detached from the ALB. </td>
-        <td> For example, <code>us-east-1a</code>. For more information, go to <a href="#zones"> zones.</a></td>
+        <td> For example, <code>us-east-1a</code>. For more information, go to <a href="#target-zones"> zones.</a></td>
       </tr>
       <tr>
         <td> REGION </td>
@@ -85,8 +86,10 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+    
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/clb-az-down.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/clb-az-down.md
@@ -2,7 +2,6 @@
 id: clb-az-down
 title: CLB AZ down
 ---
-## Introduction
 
 CLB (Classic Load Balancer) AZ (Availability Zones) down takes down the AZ on a target CLB for a specific duration. This fault restricts access to certain availability zones for a specific duration.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/clb-az-down.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/clb-az-down.md
@@ -14,7 +14,7 @@ CLB AZ down:
 - Detaches the AZ from the classic load balancer thereby disrupting the dependent application's performance. 
 - Tests the application sanity, availability, and recovery workflows of the application pod attached to the load balancer.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Appropriate AWS access to attach or detach an AZ from CLB.
 - A minimum of one AZ attached to the CLB after injecting chaos; otherwise, the fault fails to detach the given AZ.
@@ -64,8 +64,9 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile) to use a different profile for AWS faults and [superset permission or policy](./security-configurations/policy-for-all-aws-faults) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -87,8 +88,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-id.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-id.md
@@ -2,7 +2,6 @@
 id: ebs-loss-by-id
 title: EBS loss by ID
 ---
-## Introduction
 
 EBS (Elastic Block Store) loss by ID disrupts the state of EBS volume by detaching it from the node (or EC2) instance using volume ID for a certain duration. In case of EBS persistent volumes, the volumes can self-attach, and the re-attachment step can be skipped.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-id.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-id.md
@@ -10,7 +10,7 @@ EBS (Elastic Block Store) loss by ID disrupts the state of EBS volume by detachi
 ## Use cases
 EBS loss by ID tests the deployment sanity (replica availability and uninterrupted service) and recovery workflows of the application pod.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17 
 - Appropriate AWS access to attach or detach an EBS volume for the instance.
 - The EBS volume should be attached to the instance.
@@ -69,8 +69,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -87,8 +87,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+    
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-tag.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-tag.md
@@ -2,7 +2,6 @@
 id: ebs-loss-by-tag
 title: EBS loss by tag
 ---
-## Introduction
 
 EBS (Elastic Block Store) loss by tag disrupts the state of EBS volume by detaching it from the node (or EC2) instance using volume ID for a certain duration. In case of EBS persistent volumes, the volumes can self-attach, and the re-attachment step can be skipped.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-tag.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ebs-loss-by-tag.md
@@ -11,7 +11,7 @@ EBS (Elastic Block Store) loss by tag disrupts the state of EBS volume by detach
 ## Use cases
 EBS loss by tag tests the deployment sanity (replica availability and uninterrupted service) and recovery workflows of the application pod.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - EBS volume is attached to the instance.
 - Appropriate AWS access to attach or detach an EBS volume for the instance. 
@@ -70,8 +70,9 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -88,8 +89,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-cpu-hog.md
@@ -2,8 +2,6 @@
 id: ec2-cpu-hog
 title: EC2 CPU hog
 ---
-## Introduction
-
 EC2 CPU hog induces stress on the AWS EC2 instances using the Amazon SSM Run command. The SSM Run command is executed using SSM documentation that is built into the fault. This fault causes CPU chaos on the target EC2 instances using the `EC2_INSTANCE_ID` environment variable for a specific duration.
 
 ![EC2 CPU Hog](./static/images/ec2-cpu-hog.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-cpu-hog.md
@@ -13,7 +13,7 @@ EC2 CPU hog:
 - Simulates a lack of CPU for processes running on the application, which degrades their performance. 
 - Simulates slow application traffic or exhaustion of the resources, leading to degradation in the performance of processes on the instance.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance should be in a healthy state.
 - SSM agent should be installed and running on the target EC2 instance.
@@ -90,8 +90,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile) to use a different profile for AWS faults and [superset permission or policy](./security-configurations/policy-for-all-aws-faults) to execute all AWS faults.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -108,8 +108,9 @@ Below is an example AWS policy to execute the fault.
             <td> For example: <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-dns-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-dns-chaos.md
@@ -2,7 +2,6 @@
 id: ec2-dns-chaos
 title: EC2 DNS chaos
 ---
-## Introduction
 
 EC2 DNS chaos causes DNS errors such as unavailability or malfunctioning of DNS servers on the specified EC2 instance for a specific duration. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-dns-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-dns-chaos.md
@@ -14,7 +14,7 @@ EC2 DNS chaos:
 - Determines the impact of DNS chaos on the infrastructure and standalone tasks. 
 - Simulates unavailability of the DNS server (loss of access to any external domain from a given microservice, access to cloud provider dependencies, and access to specific third party services).
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running on the target EC2 instance.
 - The EC2 instance should be in a healthy state.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-latency.md
@@ -2,7 +2,6 @@
 id: ec2-http-latency
 title: EC2 HTTP latency
 ---
-## Introduction
 
 EC2 HTTP latency disrupts the state of infrastructure resources. This fault induces HTTP chaos on an AWS EC2 instance using the Amazon SSM Run command, carried out using SSM Docs that is in-built in the fault.
 - It injects HTTP response latency to the service whose port is specified using `TARGET_SERVICE_PORT` environment variable by starting the proxy server and redirecting the traffic through the proxy server.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-latency.md
@@ -16,8 +16,7 @@ EC2 HTTP latency:
 - Simulates latency to specific API services for (or from) a given microservice.
 - Simulates a slow response on specific third party (or dependent) components (or services). 
 
-
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running on the target EC2 instance.
 - You can pass the VM credentials as secrets or as a `ChaosEngine` environment variable.
@@ -96,8 +95,8 @@ Below is an example AWS policy to execute the fault.
 :::
 
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -124,8 +123,9 @@ Below is an example AWS policy to execute the fault.
             <td> Default: port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-body.md
@@ -2,7 +2,6 @@
 id: ec2-http-modify-body
 title: EC2 HTTP modify body
 ---
-## Introduction
 
 EC2 HTTP modify body injects HTTP chaos which affects the request or response by modifying the status code or the body or the headers by starting proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-body.md
@@ -11,7 +11,7 @@ EC2 HTTP modify body injects HTTP chaos which affects the request or response by
 ## Use cases
 EC2 HTTP modify body tests the application's resilience to erroneous (or incorrect) HTTP response body.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running in the target EC2 instance.
 - The EC2 instance should be in a healthy state.
@@ -89,8 +89,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) to tune the common tunables for all the faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -117,8 +117,9 @@ Below is an example AWS policy to execute the fault.
             <td> If no value is provided, the response will be an empty body (defaults to empty body). For more information, go to <a href="#modifying-the-response-body"> response body.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-header.md
@@ -2,7 +2,6 @@
 id: ec2-http-modify-header
 title: EC2 HTTP modify header
 ---
-## Introduction
 
 EC2 HTTP modify header injects HTTP chaos which affects the request (or response) by modifying the status code (or the body or the headers) by starting the proxy server and redirecting the traffic through the proxy server. This fault modifies the headers of requests and responses of the service. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-modify-header.md
@@ -11,7 +11,7 @@ EC2 HTTP modify header injects HTTP chaos which affects the request (or response
 
 EC2 HTTP modify header tests the resilience of the application to incorrect or incomplete headers.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - You can pass the VM credentials as secrets or as a `ChaosEngine` environment variable.
 - The EC2 instance should be in a healthy state.
@@ -89,8 +89,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common attributes](../common-tunables-for-all-faults) to tune the common tunables for all the faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -122,8 +122,9 @@ Below is an example AWS policy to execute the fault.
             <td> Default: response. For more information, go to <a href="#modifying-the-response-headers"> header mode.</a></td>
         </tr>
     </table>
-    <h2>Optional tunables</h2>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-reset-peer.md
@@ -2,7 +2,6 @@
 id: ec2-http-reset-peer
 title: EC2 HTTP reset peer
 ---
-## Introduction
 
 EC2 HTTP reset peer injects HTTP reset on the service whose port is specified using the `TARGET_SERVICE_PORT` environment variable. This fault stops the outgoing HTTP requests by resetting the TCP connection for the requests.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-reset-peer.md
@@ -13,7 +13,7 @@ EC2 HTTP reset peer:
 - Simulates connection resets due to resource limitations on the server side like out of memory server (or process killed or overload on the server due to a high amount of traffic). 
 - Determines the application's resilience to a lossy (or flaky) HTTP connection.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance should be in a healthy state.
 - SSM agent is installed and running in the target EC2 instance.
@@ -91,8 +91,8 @@ Below is an example AWS policy to execute the fault.
 :::
 
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -119,8 +119,10 @@ Below is an example AWS policy to execute the fault.
             <td> Default: port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional tunable</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-status-code.md
@@ -2,7 +2,6 @@
 id: ec2-http-status-code
 title: EC2 HTTP status code
 ---
-## Introduction
 EC2 HTTP status code injects HTTP chaos that affects the request (or response) by modifying the status code (or the body or the headers) by starting a proxy server and redirecting the traffic through the proxy server.
 
 ![EC2 HTTP Modify Response](./static/images/ec2-http-status-code.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-http-status-code.md
@@ -13,7 +13,7 @@ EC2 HTTP status code:
 - Simulates unavailability of specific APIs for (or from) a given microservice (TBD or Path Filter) (404).
 - Simulates unauthorized requests for 3rd party services (401 or 403), and API malfunction (internal server error) (50x).
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running in the target EC2 instance.
 - The EC2 instance should be in a healthy state.
@@ -92,8 +92,8 @@ Below is an example AWS policy to execute the fault.
 :::
 
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -128,8 +128,9 @@ Below is an example AWS policy to execute the fault.
             <td> If true, then the body is replaced by a default template for the status code. Default: True.</td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-io-stress.md
@@ -2,7 +2,6 @@
 id: ec2-io-stress
 title: EC2 IO stress
 ---
-## Introduction
 
 EC2 IO stress disrupts the state of infrastructure resources. This fault:
 - Induces stress on AWS EC2 instance using Amazon SSM Run command. The SSM Run command is executed using SSM documentation that is built into the fault.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-io-stress.md
@@ -17,7 +17,7 @@ EC2 IO stress:
 - Verifies the disk performance on increasing IO threads and varying IO block sizes.
 - Checks how the application functions under high disk latency conditions, when IO traffic is high and includes large I/O blocks, and when other services monopolize the IO disks. 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance should be in a healthy state.
 - SSM agent should be installed and running on the target EC2 instance.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-memory-hog.md
@@ -2,7 +2,6 @@
 id: ec2-memory-hog
 title: EC2 memory hog
 ---
-## Introduction
 
 EC2 memory hog disrupts the state of infrastructure resources. This fault:
 - Induces stress on AWS EC2 instance using Amazon SSM Run command. The SSM Run command is executed using SSM documentation that is built into the fault.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-memory-hog.md
@@ -17,7 +17,7 @@ EC2 memory hog:
 - Simulates the situation of memory leaks in the deployment of microservices.
 - Simulates application slowness due to memory starvation, and noisy neighbour problems due to hogging.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance should be in a healthy state.
 - SSM agent should be installed and running on the target EC2 instance.
@@ -93,8 +93,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile) to use a different profile for AWS faults, and the [superset permission/policy](./security-configurations/policy-for-all-aws-faults) to execute all AWS faults.
 :::
 
+### Mandatory tunables
 
-<h3>Mandatory tunables</h3>
 <table>
     <tr>
         <th> Tunable </th>
@@ -112,7 +112,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
     </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
+
 <table>
     <tr>
         <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-latency.md
@@ -2,7 +2,6 @@
 id: ec2-network-latency
 title: EC2 network latency
 ---
-## Introduction
 
 EC2 network latency causes flaky access to the application (or services) by injecting network packet latency to EC2 instance(s). This fault:
 - Degrades the network without marking the EC2 instance as unhealthy (or unworthy) of traffic, which is resolved using a middleware that switches traffic based on SLOs (performance parameters).

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-latency.md
@@ -17,7 +17,7 @@ EC2 network latency:
 - Simulates jittery connection with transient latency spikes between microservices.
 - Simulates a slow response on specific third party (or dependent) components (or services), and degraded data-plane of service-mesh infrastructure.  
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running on the target EC2 instance.
 - The EC2 instance should be in healthy state.
@@ -94,8 +94,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) to tune the common tunables for all the faults.
 :::
 
-<h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -112,8 +112,10 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-loss.md
@@ -2,7 +2,6 @@
 id: ec2-network-loss
 title: EC2 network loss
 ---
-## Introduction
 
 EC2 network loss causes flaky access to the application (or services) by injecting network packet loss to EC2 instance(s). This fault:
 - Degrades the network without marking the EC2 instance as unhealthy (or unworthy) of traffic, which is resolved using a middleware that switches traffic based on SLOs (performance parameters).

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-network-loss.md
@@ -18,7 +18,7 @@ EC2 network loss:
 - Simulates a slow response on specific third party (or dependent) components (or services), and degraded data-plane of service-mesh infrastructure.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - SSM agent is installed and running on the target EC2 instance.
 - The EC2 instance should be in a healthy state.
@@ -95,8 +95,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) to tune the common tunables for all the faults.
 :::
 
- <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -113,8 +113,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-process-kill.md
@@ -2,7 +2,6 @@
 id: ec2-process-kill
 title: EC2 process kill
 ---
-## Introduction
 
 EC2 process kill fault kills the target processes running on an EC2 instance. This fault disrupts the application critical processes such as databases or message queues running on the EC2 instance by killing their underlying processes or threads.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-process-kill.md
@@ -11,7 +11,7 @@ EC2 process kill fault kills the target processes running on an EC2 instance. Th
 EC2 process kill determines the resilience of applications when processes on EC2 instances are unexpectedly killed (or disrupted).
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance should be in healthy state
 - The target processes should exist in the VM.
@@ -89,8 +89,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile) to use a different profile for AWS faults and the [superset permission/policy](./security-configurations/policy-for-all-aws-faults) to execute all AWS faults.
 :::
 
- <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -112,8 +112,10 @@ Below is an example AWS policy to execute the fault.
         <td> For example, 183,253,857. For more information, go to <a href="#process-ids"> process IDs.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-id.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-id.md
@@ -2,8 +2,6 @@
 id: ec2-stop-by-id
 title: EC2 stop by ID
 ---
-## Introduction
-
 EC2 stop by ID stops an EC2 instance using the provided instance ID or list of instance IDs and brings back the instance after a specific duration. When the `MANAGED_NODEGROUP` environment variable is enabled, the fault will not try to start the instance after chaos. Instead, it checks for the addition of a new node instance to the cluster.
 
 ![EC2 Stop By ID](./static/images/ec2-stop-by-id.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-id.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-id.md
@@ -12,7 +12,7 @@ EC2 stop by ID:
 - Determines the resilience of an application to unexpected halts in the EC2 instance by validating its failover capabilities.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Access to start and stop an EC2 instance in AWS.
 - The EC2 instance should be in a healthy state.
@@ -67,8 +67,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
- <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -85,8 +85,9 @@ Below is an example AWS policy to execute the fault.
         <td> </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-tag.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-tag.md
@@ -2,7 +2,6 @@
 id: ec2-stop-by-tag
 title: EC2 stop by tag
 ---
-## Introduction
 
 EC2 stop by tag stops an EC2 instance using the provided tag and brings back the instance after a specific duration. When the `MANAGED_NODEGROUP` environment variable is enabled, the fault will not try to start the instance after chaos. Instead, it checks for the addition of a new node instance to the cluster.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-tag.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ec2-stop-by-tag.md
@@ -12,7 +12,7 @@ EC2 stop by tag:
 - Determines the performance of the application (or process) running on the EC2 instance.
 - Determines the resilience of an application to unexpected halts in the EC2 instance by validating its failover capabilities.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Appropriate AWS access to stop and start an EC2 instance. 
 - The EC2 instances should be in a healthy state.
@@ -67,8 +67,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
- <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -85,8 +85,10 @@ Below is an example AWS policy to execute the fault.
         <td> For more information, go to <a href="#target-single-instance"> region.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
@@ -2,7 +2,6 @@
 id: ecs-agent-stop
 title: ECS agent stop
 ---
-## Introduction
 
 ECS agent stop disrupts the state of infrastructure resources. This fault:
 - Induces an agent stop chaos on AWS ECS using Amazon SSM Run command, that is carried out by using SSM documentation which is in-built in the fault for the give chaos scenario.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-agent-stop.md
@@ -13,7 +13,7 @@ ECS agent stop disrupts the state of infrastructure resources. This fault:
 ECS agent stop halts the agent that manages the task container on the ECS cluster, thereby impacting its delivery. 
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The ECS container instance should be in healthy state.
 - ECS container metadata should be enabled (this feature is disabled by default). To enable it please follow the aws docs to [Enabling container metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If you have your task running prior this activity you may need to restart it to get the metadata directory as mentioned in the docs.
@@ -107,8 +107,8 @@ Below is an example AWS policy to execute the fault.
 :::
 
 
-<h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -125,8 +125,10 @@ Below is an example AWS policy to execute the fault.
           <td> For example, <code>us-east-2</code></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
@@ -2,8 +2,6 @@
 id: ecs-container-cpu-hog
 title: ECS container CPU hog
 ---
-## Introduction
-
 ECS container CPU hog disrupts the state of infrastructure resources. It induces stress on the AWS ECS container using Amazon SSM Run command, which is carried out using SSM documentation that is in-built into the fault. This fault:
 - Causes CPU chaos on the containers of the ECS task using the given `CLUSTER_NAME` environment variable for a specific duration.
 - To select the Task Under Chaos (TUC), use the service name associated with the task. If you provide the service name along with the cluster name, all the tasks associated with the given service will be selected as chaos targets.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-cpu-hog.md
@@ -21,7 +21,7 @@ ECS Container CPU hog:
 - Tests the ECS task sanity (service availability) and recovery of the task containers subject to CPU stress.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container instance should be in a healthy state.
 - ECS container metadata is enabled (disabled by default). To enable it, go to [container metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is running from before, you may need to restart it to get the metadata directory.
@@ -113,8 +113,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
- <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -131,8 +131,10 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-latency.md
@@ -19,7 +19,7 @@ ECS container HTTP latency:
   - Evaluating the impact of HTTP latency on the performance and availability of your application.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, go to [container metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is currently running, restart it to get the metadata directory.
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
@@ -103,8 +103,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to [AWS named rrofile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -126,8 +126,10 @@ Below is an example AWS policy to execute the fault.
             <td> Defaults to port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-modify-body.md
@@ -15,7 +15,7 @@ ECS container HTTP modify body:
 - Tests the resilience of the ECS application container to erroneous or incorrect HTTP response body.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, go to [container metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is currently running, you may need to restart it to get the metadata directory.
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
@@ -99,8 +99,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to [AWS named profile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -122,8 +122,9 @@ Below is an example AWS policy to execute the fault.
             <td> If no value is provided, the response will be an empty body (defaults to empty body). For more information, go to <a href="#modifying-the-response-body"> response body.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+    
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-reset-peer.md
@@ -15,7 +15,7 @@ ECS container HTTP reset peer:
 - Simulates premature connection loss (firewall issues or other issues) between microservices (verify connection timeout).
 - Simulates connection resets due to resource limitations on the server side like out of memory server (or process killed or overload on the server due to a high amount of traffic). 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, go to [container metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is currently running, you may need to restart it to get the metadata directory.
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
@@ -99,8 +99,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to [AWS named profile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -122,8 +122,9 @@ Below is an example AWS policy to execute the fault.
             <td> Default: port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-http-status-code.md
@@ -14,7 +14,7 @@ ECS container HTTP status code:
 - Simulates unauthorized requests for 3rd party services (401 or 403), and API malfunction (internal server error) (50x) on ECS task container.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, refer to this [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is running from before, you may need to restart it to get the metadata directory.
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
@@ -98,8 +98,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to [AWS named profile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -129,9 +129,10 @@ Below is an example AWS policy to execute the fault.
             <td> If true, then the body is replaced by a default template for the status code. Defaults to true. </td>
         </tr>
     </table>
-    <h3>Optional tunable</h3>
-    <table>
-        <tr>
+
+### Optional tunables
+  <table>        
+    <tr>
             <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-io-stress.md
@@ -16,7 +16,7 @@ ECS container IO stress determines how a container recovers from a memory exhaus
 File system read and write evicts the application (task container) and impacts its delivery. These issues are also known as noisy-neighbour problems.
 Injecting a rogue process into a target container starves the main microservice process (typically pid 1) of the resources allocated to it (where the limits are defined). This slows down the application traffic or exhausts the resources leading to eviction of all task containers.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, refer to this [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is running from before, you may need to restart it to get the metadata directory.
 - You and the ECS cluster instances have a role with the required AWS access to perform the SSM and ECS operations. Refer to [systems manager docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-launch-managed-instance.html).
@@ -111,8 +111,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
         <th> Variables </th>
         <th> Description </th>
@@ -129,8 +129,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-<table>
+    
+### Optional tunables
+  <table>
     <tr>
       <th> Variables </th>
       <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-memory-hog.md
@@ -20,7 +20,7 @@ When there are no limits on the memory consumption of containers, containers on 
 This fault launches a stress process within the target container, that causes the primary process in the container to have constraints based on resources or eat up the available system memory on the instance when limits on resources are not specified. 
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS container metadata is enabled (disabled by default). To enable it, refer to this [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html). If your task is running from before, you may need to restart it to get the metadata directory.
 - You and the ECS cluster instances have a role with the required AWS access to perform the SSM and ECS operations. Refer to [systems manager docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-launch-managed-instance.html).
@@ -114,8 +114,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-    <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
         <th> Variables </th>
         <th> Description </th>
@@ -132,8 +132,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Variables </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-latency.md
@@ -21,7 +21,7 @@ It also determines the impact of the fault on the microservice.
 The task may stall or get corrupted while waiting endlessly for a packet. The fault limits the impact (blast radius) to only the traffic you wish to test by specifying the service to find TUC (Task Under Chaos). This fault helps improve the resilience of the services over time.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Adequate AWS access to stop and start an EC2 instance.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -114,8 +114,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
         <th> Variables </th>
         <th> Description </th>
@@ -132,8 +132,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Variables </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-network-loss.md
@@ -23,7 +23,7 @@ The task may stall or get corrupted while waiting endlessly for a packet. The fa
 - It simulates degraded network with varied percentages of dropped packets between microservices, loss of access to specific third party (or dependent) services (or components), blackhole against traffic to a given AZ (failure simulation of availability zones), and network partitions (split-brain) between peer replicas for a stateful application. 
 - This fault helps improve the resilience of the services over time.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The ECS container instance should be in a healthy state.
 - Adequate AWS access to stop and start an EC2 instance.
@@ -116,8 +116,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-    <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
         <th> Variables </th>
         <th> Description </th>
@@ -134,8 +134,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, us-east-1 </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Variables </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-volume-detach.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-container-volume-detach.md
@@ -14,7 +14,7 @@ ECS container volume detach:
 - By detaching volumes, you can safely remove the volume associations from the containers without deleting the volumes themselves. 
 - By detaching unnecessary volumes, you can optimize the resource utilization within your ECS tasks. This helps to free up storage space and minimize any potential performance impact associated with unused volumes.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -74,8 +74,8 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -97,8 +97,9 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+ 
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-cpu-hog.md
@@ -15,7 +15,7 @@ ECS Fargate CPU hog:
 - Validates the behavior of your application and infrastructure during a heavy CPU load, such as:
   - Testing the resilience of your system during stress, including verifying if the latency of the main container is increased and if the container fail to survive.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -75,8 +75,8 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -98,8 +98,9 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-fargate-memory-hog.md
@@ -15,7 +15,7 @@ ECS Fargate memory hog:
 - Validates the behavior of your application and infrastructure during a heavy memory load, such as:
   - Testing the resilience of your system during stress, including verifying if the latency of the main container is increased and if the container fail to survive.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -74,8 +74,8 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -97,8 +97,9 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-instance-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-instance-stop.md
@@ -14,7 +14,7 @@ ECS instance stop induces stress on an AWS ECS cluster. It derives the instance 
 EC2 instance stop breaks the agent that manages the task container on ECS cluster, thereby impacting its delivery. Killing the EC2 instance disrupts the performance of the task container.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The ECS container instance should be in a healthy state.
 - Adequate AWS access to stop and start an EC2 instance.
@@ -81,10 +81,10 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
         </tr>
@@ -99,10 +99,11 @@ Below is an example AWS policy to execute the fault.
         <td> For example, us-east-1 </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-invalid-container-image.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-invalid-container-image.md
@@ -17,7 +17,7 @@ ECS invalid container image:
   - Testing the resilience of your system during image updates, including verifying if the updated image is pulled successfully and if the container starts with the new image.
   - Validating the performance and availability of your application after the container image updates, that includes checking if the updated image performs as expected and if there are issues with the new image.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -76,8 +76,8 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -99,8 +99,9 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-network-restrict.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-network-restrict.md
@@ -19,7 +19,7 @@ ECS network restrict:
   - Validating the performance and availability of your application in a restricted networking environment, including checking if the application can continue to function properly with limited network access.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -76,8 +76,8 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -99,8 +99,9 @@ Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-spe
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-scale.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-scale.md
@@ -11,7 +11,7 @@ ECS task scale:
 - Affects the availability of a task in a cluster. 
 - Determines the resilience of an application when ECS tasks are unexpectedly scaled up (or down).
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - [Sufficient AWS permissions to scale the ECS tasks](#permissions-required).
 - The target ECS tasks should be in a healthy state.
@@ -61,10 +61,10 @@ Below is an example AWS permission to help execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
         </tr>
@@ -89,10 +89,11 @@ Below is an example AWS permission to help execute the fault.
         <td> Default: 5. For more information, go to <a href="#ecs-task-replicas"> task replicas.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-task-stop.md
@@ -12,7 +12,7 @@ ECS task stop is an AWS fault that injects chaos to stop the ECS tasks based on 
 
 This fault determines the resilience of an application when ECS tasks unexpectedly stop due to task being unavailable.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Sufficient AWS access to stop the ECS tasks.
 - The target ECS tasks should be in a healthy state.
@@ -65,10 +65,10 @@ Below is an example AWS policy to help execute the fault.
 - Refer to the [common attributes](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and aws specific tunables.
 :::
 
-    <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
         </tr>
@@ -93,10 +93,12 @@ Below is an example AWS policy to help execute the fault.
         <td> `SERVICE_NAME` and `TASK_REPLICA_ID` are mutually exclusive. If both the values are provided, `SERVICE_NAME` takes precedence. For more information, go to <a href="#ecs-task-replica-ids"> ECS task replica ID.</a></td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+
+### Optional tunables
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-resource-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-resource-limit.md
@@ -23,7 +23,7 @@ ECS update container resource limit:
 Modifying the container resource limits using the ECS update container resource limit is an intentional disruption and should be used carefully in controlled environments, such as during testing or staging, to avoid any negative impact on the production workloads.
 :::
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -83,8 +83,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -106,8 +106,9 @@ Below is an example AWS policy to execute the fault.
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-timeout.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-container-timeout.md
@@ -18,7 +18,7 @@ ECS update container timeout:
 - Evaluates the impact of above-mentioned scenarios on the overall application availability and performance.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -78,8 +78,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -101,8 +101,9 @@ Below is an example AWS policy to execute the fault.
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-task-role.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/ecs-update-task-role.md
@@ -24,7 +24,7 @@ ECS update task role:
 Modifying the IAM task role using the ECS update task role is an intentional disruption and should be used carefully in controlled environments.
 :::
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -84,8 +84,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -107,8 +107,9 @@ Below is an example AWS policy to execute the fault.
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunable</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-event-source-mapping.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-event-source-mapping.md
@@ -2,8 +2,6 @@
 id: lambda-delete-event-source-mapping
 title: Lambda delete event source mapping
 ---
-## Introduction
-
 Lambda delete event source mapping removes the event source mapping from an AWS Lambda function for a specific duration. Deleting an event source mapping from a Lambda function is critical. It can lead to failure in updating the database on an event trigger, which can break the service. 
 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-event-source-mapping.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-event-source-mapping.md
@@ -14,7 +14,7 @@ Lambda delete event source mapping:
 - Determines whether proper error handling or auto-recovery options have been configured for the application.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - AWS Lambda event source mapping must be healthy and attached to the Lambda function.
 - Kubernetes secret should have the AWS access configuration(key) in the `CHAOS_NAMESPACE`. A secret file looks like this:
@@ -67,8 +67,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -90,8 +90,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-2</code></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-function-concurrency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-function-concurrency.md
@@ -2,8 +2,6 @@
 id: lambda-delete-function-concurrency
 title: Lambda delete function concurrency
 ---
-## Introduction
-
 Lambda delete function concurrency is an AWS fault that deletes the Lambda function's reserved concurrency, thereby ensuring that the function has adequate unreserved concurrency to run.
 
 ![Lambda Delete Function Concurrency](./static/images/lambda-delete-function-concurrency.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-function-concurrency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-delete-function-concurrency.md
@@ -10,7 +10,7 @@ Lambda delete function concurrency is an AWS fault that deletes the Lambda funct
 ## Use cases
 Lambda delete function concurrency examines the performance of the running Lambda application, if the Lambda function lacks sufficient concurrency.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Reserved concurrency must be set on the target Lambda function.
 - Lambda function must be up and running.
@@ -60,8 +60,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -83,8 +83,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-2</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-toggle-event-mapping-state.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-toggle-event-mapping-state.md
@@ -2,7 +2,6 @@
 id: lambda-toggle-event-mapping-state
 title: Lambda toggle event mapping state
 ---
-## Introduction
 
 Lambda toggle event mapping state toggles (or sets) the event source mapping state to `disable` for a Lambda function during a specific duration. Toggling between different states of event source mapping from a Lambda function may lead to failures when updating the database on an event trigger. This can break the service and impact its delivery. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-toggle-event-mapping-state.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-toggle-event-mapping-state.md
@@ -14,7 +14,7 @@ Lambda toggle event mapping:
 - Determines if the application has proper error handling or auto recovery actions configured.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - AWS Lambda event source mapping must be healthy and attached to the Lambda function.
 - Kubernetes secret must have the AWS access configuration(key) in the `CHAOS_NAMESPACE`. A secret file looks like this:
@@ -67,8 +67,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -90,8 +90,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-2</code></td>
       </tr>
     </table>
-    <h2>Optional tunables</h2>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-memory.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-memory.md
@@ -2,8 +2,6 @@
 id: lambda-update-function-memory
 title: Lambda update function memory
 ---
-## Introduction
-
 Lambda update function memory causes the memory of a Lambda function to update to a specific value for a certain duration. This fault:
 - Determines a safe overall memory limit value for the function. Smaller the memory limit, higher will be the time taken by the Lambda function under load.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-memory.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-memory.md
@@ -13,7 +13,7 @@ Lambda update function memory:
 - Helps build resilience to unexpected scenarios such as hitting a memory limit with the Lambda function, that slows down the service and impacts its delivery. Running out of memory due to smaller limits interrupts the flow of the given function.
 - Checks the performance of the application (or service) running with a new memory limit.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Access to operate AWS Lambda functions.
 - Lambda function must be up and running.
@@ -63,8 +63,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -86,8 +86,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-2</code> </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-timeout.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-timeout.md
@@ -2,8 +2,6 @@
 id: lambda-update-function-timeout
 title: Lambda update function timeout
 ---
-## Introduction
-
 Lambda update function timeout causes a timeout of a Lambda function, thereby updating the timeout to a specific value for a certain duration. Timeout errors interrupt the flow of the given function.
 Hitting a timeout is a frequent scenario with Lambda functions. This can break the service and impact the delivery. Such scenarios can occur despite the availability aids provided by AWS. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-timeout.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-function-timeout.md
@@ -14,7 +14,7 @@ Lambda update function timeout:
 - Checks the performance of the application (or service) running with a new timeout.
 - Determines a safe overall timeout value for the function.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - Access to operate AWS Lambda service.
 - Lambda function must be up and running.
@@ -64,8 +64,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -87,8 +87,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-2</code> </td>
       </tr>
     </table>
-    <h2>Optional tunables</h2>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-role-permission.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-role-permission.md
@@ -2,7 +2,6 @@
 id: lambda-update-role-permission
 title: Lambda update role permission
 ---
-## Introduction
 Lambda update role permission is an AWS fault that modifies the role policies associated with a Lambda function. Sometimes, Lambda functions depend on services like RDS, DynamoDB, and S3. In such cases, certain permissions are required to access these services. This fault helps understand how your application would behave when a Lambda function does not have enough permissions to access the services.
 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-role-permission.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/lambda-update-role-permission.md
@@ -13,7 +13,7 @@ Lambda updated role permission:
 - Updates the role attached to a Lambda function.
 - Determines the performance of the running Lambda application when it does not have enough permissions.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The Lambda function must be up and running.
 - Kubernetes secret must have the AWS access configuration (key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -56,7 +56,6 @@ Below is an example AWS policy to execute the fault when `ROLE_ARN` environment 
 }
 ```
 
-
 Below is an example AWS policy to execute the fault when `POLICY_ARN` environment variable is set.
 
 ```json
@@ -85,8 +84,8 @@ Below is an example AWS policy to execute the fault when `POLICY_ARN` environmen
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -113,8 +112,9 @@ Below is an example AWS policy to execute the fault when `POLICY_ARN` environmen
         <td> For example, <code>us-east-2</code> </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/nlb-az-down.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/nlb-az-down.md
@@ -12,7 +12,7 @@ The NLB (Network Load Balancer) AZ (Availability Zone) down fault triggers the u
 - With this experiment, you can evaluate the application's behavior and assess its ability to handle and recover from a scenario where traffic from a particular AZ is blocked.
 - It conducts an application test by deliberately blocking traffic originating from a specific AZ on the network load balancer. This experiment involves intentionally preventing incoming and outgoing traffic from the designated AZ from reaching the application through the load balancer.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -58,8 +58,8 @@ Below is an example AWS policy to execute the fault.
 }
 ```
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -81,8 +81,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-delete.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-delete.md
@@ -2,7 +2,6 @@
 id: rds-instance-delete
 title: RDS instance delete
 ---
-## Introduction
 
 RDS instance delete removes an instances from AWS RDS cluster. This makes the cluster unavailable for a specific duration.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-delete.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-delete.md
@@ -10,7 +10,7 @@ RDS instance delete removes an instances from AWS RDS cluster. This makes the cl
 ## Use cases
 RDS instance delete determines how quickly an application can recover from an unexpected RDS cluster deletion. 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - AWS access to delete RDS instances.
 - The RDS instance must be in a healthy state.
@@ -60,8 +60,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [AWS named profile for chaos](./security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -83,8 +83,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, us-east-1 </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-reboot.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-reboot.md
@@ -2,7 +2,6 @@
 id: rds-instance-reboot
 title: RDS instance reboot
 ---
-## Introduction
 
 RDS instance reboot derives the instance under chaos from an RDS cluster.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-reboot.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/rds-instance-reboot.md
@@ -12,7 +12,7 @@ RDS instance reboot derives the instance under chaos from an RDS cluster.
 RDS instance reboot determines the resilience of an application when an instance under chaos is derived from an RDS cluster.
 
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - AWS access to reboot RDS instances.
 - The RDS instance must be in a healthy state.
@@ -62,8 +62,8 @@ Below is an example AWS policy to execute the fault.
 - Go to the [common tunables](../common-tunables-for-all-faults) and [AWS-specific tunables](./aws-fault-tunables) to tune the common tunables for all faults and AWS-specific tunables.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -85,8 +85,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, us-east-1 </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/resource-access-restrict.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/resource-access-restrict.md
@@ -12,7 +12,7 @@ The AWS Resource Access Restrict chaos experiment allows you to create network a
 - This experiment enables you to simulate scenarios where network connectivity is restricted for an AWS service, providing valuable insights into the behavior and resilience of your system in such conditions.
 - By imposing these access restrictions, you can evaluate how your application and resources handle limited network access and ensure that they continue to operate effectively and securely.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - ECS cluster running with the desired tasks and containers and familiarity with ECS service update and deployment concepts.
 - Create a Kubernetes secret that has the AWS access configuration(key) in the `CHAOS_NAMESPACE`. Below is a sample secret file:
@@ -66,8 +66,8 @@ Below is an example AWS policy to execute the fault.
 - Refer to the [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
           <th> Tunable </th>
           <th> Description </th>
@@ -84,8 +84,9 @@ Below is an example AWS policy to execute the fault.
           <td> For example, <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunable</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-blackhole-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-blackhole-chaos.md
@@ -2,8 +2,6 @@
 id: windows-ec2-blackhole-chaos
 title: Windows EC2 blackhole chaos
 ---
-## Introduction
-
 Windows EC2 blackhole chaos results in loss of access to the given target hosts or IPs by injecting firewall rules. This fault:
 - Degrades the network without marking the EC2 instance as unhealthy (or unworthy) of traffic. This can be resolved by using a middleware that switches the traffic based on certain SLOs (performance parameters). 
 - Limits the impact, that is, blast radius to only the traffic that you wish to test, by specifying the destination hosts or IP addresses. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-blackhole-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-blackhole-chaos.md
@@ -12,7 +12,7 @@ Windows EC2 blackhole chaos results in loss of access to the given target hosts 
 
 Windows EC2 blackhole chaos determines the performance of the application (or process) running on the EC2 instances.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 instance.
@@ -89,8 +89,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -112,8 +112,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-cpu-hog.md
@@ -2,8 +2,6 @@
 id: windows-ec2-cpu-hog
 title: Windows EC2 CPU hog
 ---
-## Introduction
-
 EC2 windows CPU hog induces CPU stress on the AWS Windows EC2 instances using Amazon SSM Run command. The SSM Run command is executed using SSM documentation that is built into the fault.
 
 ![Windows EC2 CPU hog](./static/images/windows-ec2-cpu-hog.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-cpu-hog.md
@@ -12,7 +12,7 @@ EC2 windows CPU hog:
 - Simulates the situation of a lack of CPU for processes running on the instance, which degrades their performance. 
 - Simulates slow application traffic or exhaustion of the resources, leading to degradation in the performance of processes on the instance.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 instance.
@@ -90,8 +90,8 @@ Below is an example AWS policy to execute the fault.
 - Go to [superset permission/policy](./security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
 :::
 
-<h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+ <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -108,8 +108,9 @@ Below is an example AWS policy to execute the fault.
             <td> For example: <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-memory-hog.md
@@ -2,7 +2,6 @@
 id: windows-ec2-memory-hog
 title: Windows EC2 memory hog
 ---
-## Introduction
 
 Windows EC2 memory hog induces memory stress on the target AWS Windows EC2 instance using Amazon SSM Run command. The SSM Run command is executed using SSM documentation that is built into the fault. This fault causes memory exhaustion on the target Windows EC2 instance for a specific duration.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/aws/windows-ec2-memory-hog.md
@@ -15,7 +15,7 @@ Windows EC2 memory hog:
 - Simulates the situation of memory leaks in the deployment of microservices.
 - Simulates application slowness due to memory starvation, and noisy neighbour problems due to hogging.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes >= 1.17
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 Windows instance in the admin mode.
@@ -93,7 +93,7 @@ Below is an example AWS policy to execute the fault.
 :::
 
 
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
     <tr>
         <th> Tunable </th>
@@ -111,8 +111,9 @@ Below is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
     </tr>
 </table>
-<h3>Optional tunables</h3>
-<table>
+
+### Optional tunables
+  <table>
     <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-disk-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-disk-loss.md
@@ -13,7 +13,7 @@ Azure disk loss:
 - Determines the resilience of an application to unexpected disk detachment. 
 - Determines how quickly the Azure instance recovers from such failures. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate Azure access to detach and attach a disk.
 - Azure disk should be connected to an instance.
@@ -40,15 +40,15 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -63,10 +63,11 @@ stringData:
             <td> For example, <code>TeamDevops</code>. For more information, go to <a href="#detach-virtual-disks-by-name"> resource group field in the YAML file. </a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-cpu-hog.md
@@ -21,7 +21,7 @@ Azure instance CPU hog:
 - Verifies the autopilot functionality of cloud managed clusters. 
 - Verifies multi-tenant load issues. When the load on one container increases, the fault checks for any downtime in other containers. 
 
-:::note
+###Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Azure Run Command agent should be installed and running in the target Azure instance.
 - Azure disk should be in a healthy state.
@@ -49,15 +49,15 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -72,10 +72,11 @@ stringData:
             <td> All the instances must be from the same resource group. For more information, go to <a href="#cpu-core"> resource group field in the YAML file. </a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-io-stress.md
@@ -20,7 +20,7 @@ Azure instance I/O stress:
 - Checks whether or not the application functions under high I/O traffic, and large I/O blocks.
 - Checks if other services monopolize the I/O disks during stress. 
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Azure Run Command agent is installed and running in the target Azure instance.
 - Azure instance should be in a healthy state.
@@ -48,16 +48,16 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
+### Mandatory tunables
 
-<h3>Mandatory fields</h3>
 <table>
     <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
     </tr>
@@ -73,10 +73,10 @@ stringData:
     </tr>
 </table>
 
-<h3>Optional fields</h3>
+### Optional tunables
 <table>
     <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
     </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-memory-hog.md
@@ -19,7 +19,7 @@ Azure instance memory hog:
 - Verifies pod priority and QoS setting for eviction purposes. 
 - Verifies application restarts on OOM (out of memory) kills.
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Azure Run Command agent is installed and running in the target Azure instance.
 - Azure instance should be in a healthy state.
@@ -47,15 +47,15 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
-
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
     <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
     </tr>
@@ -70,10 +70,11 @@ stringData:
         <td> All the instances must be from the same resource group. For more information, go to <a href="#multiple-workers"> resource group field in the YAML file. </a></td>
     </tr>
 </table>
-<h3>Optional fields</h3>
+
+### Optional tunables
 <table>
     <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
     </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-instance-stop.md
@@ -11,7 +11,7 @@ Azure instance stop:
 - Determines the resilience of an application to unexpected power off of the Azure instances. 
 - Determines how the application handles the requests and how quickly it recovers from such failures.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate Azure access to start and stop an instance.
 - Azure instance should be in a healthy state.
@@ -39,15 +39,15 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -62,10 +62,11 @@ stringData:
         <td> For example, <code>TeamDevops</code>. For more information, go to <a href="#stop-instances-by-name"> resource group field in the YAML file. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-web-app-access-restrict.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-web-app-access-restrict.md
@@ -12,7 +12,7 @@ Azure web app access restrict causes a split brain condition by restricting the 
 
 Azure web app access restrict determines the resilience of an application when access to a specific application service instance is restricted.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate Azure access to the web applications.
 - The target Azure web application should be in the running state.
@@ -40,15 +40,15 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -63,10 +63,11 @@ stringData:
             <td> For example, <code>TeamDevops</code>. For more information, go to <a href="#web-app-access-restrict-by-name"> resource group field in the YAML file.</a></td>
         </tr> 
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-web-app-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/azure/azure-web-app-stop.md
@@ -12,7 +12,7 @@ Azure web app stop
 - Determines the resilience of a web application to unplanned halts (or stops). 
 - Determines the resilience based on how quickly and efficiently the application recovers from the failure by re-routing the traffic to a different instance on the same application service. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate Azure access to start and stop the web applications.
 - The target Azure web application should be in the running state. 
@@ -40,15 +40,16 @@ stringData:
       "managementEndpointUrl": "XXXXXXXXX"
     }
 ```
-- If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the secret key name from `azure.auth` to a new name, ensure that you update the `AZURE_AUTH_LOCATION` environment variable in the chaos experiment with the new name.
 :::
 
-## Fault tunables
+### Mandatory tunables
 
-<h3>Mandatory fields</h3>
-    <table>
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -63,10 +64,11 @@ stringData:
             <td> All the web applications must belong to the same resource group. For more information, go to <a href="#stop-web-app-by-name"> resource group field in the YAML file. </a></td>
         </tr> 
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/cloud-foundry/cf-app-route-unmap.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/cloud-foundry/cf-app-route-unmap.md
@@ -15,8 +15,7 @@ CF app route unmap:
 - Checks resilience against abrupt un-mapping of an app route.
 - Validates the effectiveness of disaster recovery and high availability of the app.
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -50,7 +49,7 @@ CF app route unmap:
   </tr>
 </table>
 
-<h3>Optional fields</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/cloud-foundry/cf-app-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/cloud-foundry/cf-app-stop.md
@@ -15,8 +15,7 @@ CF app stop:
 - Checks resilience against abrupt stopping of the application components/microservices.
 - Validates the effectiveness of disaster recovery and high availability of the app.
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -45,7 +44,7 @@ CF app stop:
   </tr>
 </table>
 
-<h3>Optional fields</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss-by-label.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss-by-label.md
@@ -10,7 +10,7 @@ GCP VM disk loss by label disrupts the state of GCP persistent disk volume filte
 
 - GCP VM disk loss by label fault can be used to determine the resilience of the GKE infrastructure. It helps determine how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Service account should have editor access (or owner access) to the GCP project.
 - Target disk volume should not be a boot disk of any VM instance.
@@ -34,13 +34,11 @@ stringData:
   auth_provider_x509_cert_url:
   client_x509_cert_url:
 ```
-:::
 
-## Fault tunables
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -60,10 +58,11 @@ stringData:
         <td> Only one zone is provided, which indicates that all target disks reside in the same zone. For more information, go to <a href="#detach-volumes-by-label">zones.</a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss.md
@@ -10,7 +10,7 @@ GCP VM disk loss disrupts the state of GCP persistent disk volume using the disk
 
 - GCP VM disk loss fault determines the resilience of the GKE infrastructure. It helps determine how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Service account should have editor access (or owner access) to the GCP project.
 - Target disk volume should not be a boot disk of any VM instance.
@@ -35,7 +35,6 @@ stringData:
   auth_provider_x509_cert_url:
   client_x509_cert_url:
 ```
-:::
 
 ## Fault tunables
   <h3>Mandatory fields</h3>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop-by-label.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop-by-label.md
@@ -10,7 +10,7 @@ GCP VM instance stop by label powers off from the GCP VM instances (filtered by 
 
 - GCP VM instance stop by label fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Adequate GCP permissions to stop and start the GCP VM instances.
 - The VM instances with the target label should be in a healthy state.
@@ -34,13 +34,11 @@ stringData:
   auth_provider_x509_cert_url:
   client_x509_cert_url:
 ```
-:::
 
-## Fault tunables
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -60,10 +58,11 @@ stringData:
         <td> Only one zone is provided, that is, all the target instances should reside in the same zone. For more information, go to <a href="#target-gcp-instances">zones. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop.md
@@ -12,7 +12,7 @@ GCP VM instance stop powers off from a GCP VM instance using the instance name (
 
 - GCP VM instance stop fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Adequate GCP permissions to stop and start the GCP VM instances.
 - The VM instances should be in a healthy state.
@@ -36,13 +36,11 @@ stringData:
   auth_provider_x509_cert_url:
   client_x509_cert_url:
 ```
-:::
 
-## Fault tunables
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -62,10 +60,11 @@ stringData:
         <td> Zone for every instance name is provided as zone1,zone2,... and so on, in the same order as <code>VM_INSTANCE_NAMES</code>. For more information, go to <a href="#target-gcp-instances">zones. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kube-resilience/kubelet-density.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kube-resilience/kubelet-density.md
@@ -19,17 +19,16 @@ Kubelet density determines the resilience of the kubelet by creating pods on a s
 - It also verifies pod creation and scheduling SLIs on the cluster nodes.
 - It also helps determine the performance of the kubelet for a specific node.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - The target nodes should be in the healthy state before and after injecting chaos.
 :::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -39,10 +38,11 @@ Kubelet density determines the resilience of the kubelet by creating pods on a s
         <td> If this environment variable isn't set, a random target node is selected. For more information, go to <a href = "/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-single-node">target node</a>.</td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+    
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/common-tunables-for-node-faults.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/common-tunables-for-node-faults.md
@@ -1,7 +1,6 @@
 ---
 title: Common node fault tunables
 ---
-## Introduction
 Fault tunables which are common to all the node faults are described here. These tunables can be provided at `.spec.experiment[*].spec.components.env` in the chaosengine.
 
 ### Target single node

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/docker-service-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/docker-service-kill.md
@@ -2,7 +2,6 @@
 id: docker-service-kill
 title: Docker service kill
 ---
-## Introduction
 Docker service kill makes the application unreachable on the account of the node turning unschedulable (in **NotReady** status).
 - Docker service is stopped (or killed) on a node to make it unschedulable for a specific duration.
 - The application node goes back to normal state and services are resumed after a specific duration. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/docker-service-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/docker-service-kill.md
@@ -11,18 +11,15 @@ Docker service kill makes the application unreachable on the account of the node
 ## Use cases
 Docker service kill fault determines the resilience of an application when a node becomes unschedulable, that is, NotReady state.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Node specified in the <code>TARGET_NODE</code> environment variable (the node for which Docker service would be killed) should be cordoned before executing the chaos fault. This ensures that the fault resources are not scheduled on it or subject to eviction. This is achieved using the following steps:
   - Get node names against the applications pods using command <code>kubectl get pods -o wide</code>.
   - Cordon the node using command <code>kubectl cordon &lt;nodename&gt;</code>.
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
-
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -39,8 +36,9 @@ Docker service kill fault determines the resilience of an application when a nod
         <td> It is mutually exclusive with the <code>TARGET_NODE</code> environment variable. If both are provided, the fault uses <code>TARGET_NODE</code>. For more information, go to <a href="/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/common-tunables-for-node-faults/#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/kubelet-service-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/kubelet-service-kill.md
@@ -2,7 +2,6 @@
 id: kubelet-service-kill
 title: Kubelet service kill
 ---
-## Introduction
 
 Kubelet service kill makes the application unreachable on the account of the node turning unschedulable (in **NotReady** state).
 - Kubelet service is stopped (or killed) on a node to make it unschedulable for a specific duration. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/kubelet-service-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/kubelet-service-kill.md
@@ -13,17 +13,15 @@ Kubelet service kill makes the application unreachable on the account of the nod
 ## Use cases
 Kubelet service kill fault determines the resilience of an application when a node becomes unschedulable, that is, **NotReady** state.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Node specified in the <code>TARGET_NODE</code> environment variable (the node for which Docker service would be killed) should be cordoned before executing the chaos fault. This ensures that the fault resources are not scheduled on it or subject to eviction. This is achieved using the following steps:
   - Get node names against the applications pods using command <code>kubectl get pods -o wide</code>.
   - Cordon the node using command <code>kubectl cordon &lt;nodename&gt;</code>.
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -40,8 +38,10 @@ Kubelet service kill fault determines the resilience of an application when a no
         <td> It is mutually exclusive with the <code>TARGET_NODE</code> environment variable. If both are provided, the fault uses <code>TARGET_NODE</code>. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-cpu-hog.md
@@ -2,7 +2,6 @@
 id: node-cpu-hog
 title: Node CPU hog
 ---
-## Introduction
 
 Node CPU hog exhausts the CPU resources on a Kubernetes node. 
 - The CPU chaos is injected using a helper pod running the Linux stress tool (a workload generator). 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-cpu-hog.md
@@ -19,15 +19,13 @@ Node CPU hog exhausts the CPU resources on a Kubernetes node.
 - It verifies the autopilot functionality of cloud managed clusters. 
 - It also verifies multi-tenant load issues; that is, when the load increases on one container, it does not cause downtime in other containers. 
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -44,8 +42,10 @@ Node CPU hog exhausts the CPU resources on a Kubernetes node.
         <td>It is mutually exclusive with the <code>TARGET_NODES</code> environment variable. If both are provided, <code>TARGET_NODES</code> takes precedence. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-drain.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-drain.md
@@ -2,7 +2,6 @@
 id: node-drain
 title: Node drain
 ---
-## Introduction
 
 Node drain drains the node of all its resources running on it. Due to this, services running on the target node should be rescheduled to run on other nodes. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-drain.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-drain.md
@@ -16,18 +16,16 @@ Node drain drains the node of all its resources running on it. Due to this, serv
 - It verifies resource budgeting on cluster nodes (whether request (or limit) settings are honored on available nodes).
 - It verifies whether topology constraints are adhered to (node selectors, tolerations, zone distribution, affinity(or anti-affinity) policies) or not. 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - Node specified in the <code>TARGET_NODE</code> environment variable should be cordoned before executing the chaos fault. This ensures that the fault resources are not scheduled on it (or subject to eviction). This is achieved by the following steps:
   - Get node names against the applications pods using command <code>kubectl get pods -o wide</code>.
   - Cordon the node using command <code>kubectl cordon &lt;nodename&gt;</code>.
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -44,8 +42,10 @@ Node drain drains the node of all its resources running on it. Due to this, serv
         <td>It is mutually exclusive with the <code>TARGET_NODES</code> environment variable. If both are provided, <code>TARGET_NODES</code> takes precedence. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-io-stress.md
@@ -4,7 +4,6 @@ id: node-io-stress
 redirect_from:
   - /docs/chaos-engineering/chaos-faults/kubernetes/node/node-io-stress
 ---
-## Introduction
 
 Node IO stress causes I/O stress on the Kubernetes node. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-io-stress.md
@@ -17,15 +17,13 @@ Node IO stress causes I/O stress on the Kubernetes node.
 - It also verifies the disk performance on increasing I/O threads and varying I/O block sizes. 
 - It checks if the application functions under high disk latency conditions. when I/O traffic is very high and includes large I/O blocks, and when other services monopolize the I/O disks. 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -42,8 +40,11 @@ Node IO stress causes I/O stress on the Kubernetes node.
         <td>If both the environment variables are provided, <code>TARGET_NODES</code> takes precedence. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-memory-hog.md
@@ -2,7 +2,6 @@
 id: node-memory-hog
 title: Node memory hog
 ---
-## Introduction
 Node memory hog causes memory resource exhaustion on the Kubernetes node. 
 - It is injected using a helper pod running the Linux stress-ng tool (a workload generator).
 - The chaos affects the application for a specific duration.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-memory-hog.md
@@ -19,14 +19,13 @@ Node memory hog causes memory resource exhaustion on the Kubernetes node.
 - It verifies pod priority and QoS setting for eviction purposes. 
 - It also verifies application restarts on OOM kills. 
 
-:::info note
+### Prerequisites
+- Kubernetes > 1.16 
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -43,8 +42,10 @@ Node memory hog causes memory resource exhaustion on the Kubernetes node.
         <td>It is mutually exclusive with the <code>TARGET_NODES</code> environment variable. If both are provided, <code>TARGET_NODES</code> takes precedence. For more information, go to <a href = "https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">target nodes with labels.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-latency.md
@@ -3,8 +3,6 @@ id: node-network-latency
 title: Node network latency
 ---
 
-## Introduction
-
 Node network latency is a Kubernetes node-level chaos fault that induces packet latency across the entire node. Similar to pod network latency, this fault uses traffic control (tc) along with netem rules to inject network latency.
 
 ![Node Network Latency](./static/images/node-network-latency.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-latency.md
@@ -13,11 +13,11 @@ Node network latency:
 - Tests the node and inter-node communication resilience against packet latency.
 - Simulates scenarios where specific nodes might experience network problems due to issues like faulty NICs or network misconfigurations.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes > 1.16
 - Nodes should be in a healthy state before and after injecting chaos.
 
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
     <thead>
         <tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-loss.md
@@ -3,8 +3,6 @@ id: node-network-loss
 title: Node network loss
 ---
 
-## Introduction
-
 Node network loss is a Kubernetes node-level chaos fault that induces packet loss across the entire node. Similar to pod network loss, this fault uses traffic control (tc) along with netem rules to inject network loss.
 
 ![Node Network Loss](./static/images/node-network-loss.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-network-loss.md
@@ -13,11 +13,11 @@ Node network loss:
 - Tests the node and inter-node communication resilience against packet loss.
 - Simulates scenarios where specific nodes might experience network problems due to issues like faulty NICs or network misconfigurations.
 
-## Prerequisites
+### Prerequisites
 - Kubernetes > 1.16
 - Nodes should be in a healthy state before and after injecting chaos.
 
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
     <thead>
         <tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-restart.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-restart.md
@@ -2,8 +2,6 @@
 id: node-restart
 title: Node restart
 ---
-## Introduction
-
 Node restart disrupts the state of the node by restarting it.
 
 ![Node Restart](./static/images/node-restart.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-restart.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-restart.md
@@ -13,8 +13,8 @@ Node restart disrupts the state of the node by restarting it.
 - It verifies resource budgeting on cluster nodes (whether request(or limit) settings honored on available nodes).
 - It verifies whether topology constraints are adhered to (node selectors, tolerations, zone distribution, affinity or anti-affinity policies) or not.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - Create a Kubernetes secret named `id-rsa` where the fault will be executed. The contents of the secret will be the private SSH key for `SSH_USER` that will be used to connect to the node that hosts the target pod in the secret field `ssh-privatekey`. 
   - Below is a sample secret file:
 
@@ -44,12 +44,10 @@ Node restart disrupts the state of the node by restarting it.
 
 - The target nodes should be in the ready state before and after injecting chaos.
 
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -66,8 +64,11 @@ Node restart disrupts the state of the node by restarting it.
         <td>It is mutually exclusive with the <code>TARGET_NODES</code> environment variable. If both are provided, <code>TARGET_NODES</code> takes precedence. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/node/common-tunables-for-node-faults#target-nodes-with-labels">tagret node with labels.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-taint.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-taint.md
@@ -2,7 +2,6 @@
 id: node-taint
 title: Node taint
 ---
-## Introduction
 
 Node taint taints the node by applying the desired effect. Only the resources that contain the corresponding tolerations can bypass the taints.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-taint.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/node/node-taint.md
@@ -13,18 +13,18 @@ Node taint taints the node by applying the desired effect. Only the resources th
 - It verifies resource budgeting on cluster nodes (whether request(or limit) settings are honored on the available nodes).
 - It verifies whether topology constraints are adhered to (node selectors, tolerations, zone distribution, affinity(or anti-affinity) policies) or not.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+
+- Kubernetes > 1.16
 - Node specified in the `TARGET_NODE` environment variable should be cordoned before executing the chaos fault. This ensures that the fault resources are not scheduled on it (or subject to eviction). This is achieved by the following steps:
   - Get node names against the applications pods using command `kubectl get pods -o wide`.
   - Cordon the node using command `kubectl cordon NODENAME`.
 - The target nodes should be in the ready state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-   <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -46,8 +46,11 @@ Node taint taints the node by applying the desired effect. Only the resources th
         <td> For more information, go to <a href="#taint-label"> taint label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/container-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/container-kill.md
@@ -2,7 +2,6 @@
 id: container-kill
 title: Container kill
 ---
-## Introduction
 
 Container kill is a Kubernetes pod-level chaos fault that causes container failure on specific or random replicas of an application resource.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/container-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/container-kill.md
@@ -13,15 +13,13 @@ Container kill:
 - Tests an application's deployment sanity (replica availability and uninterrupted service) and recovery workflow when certain replicas are not available.
 - Tests the recovery of pods that possess sidecar containers.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description  </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/disk-fill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/disk-fill.md
@@ -2,7 +2,6 @@
 id: disk-fill
 title: Disk fill
 ---
-## Introduction
 
 Disk fill is a Kubernetes pod-level chaos fault that applies disk stress by filling the pod's ephemeral storage on a node. This fault evicts the application pod if its capacity exceeds the pod's ephemeral storage limit.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/disk-fill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/disk-fill.md
@@ -16,8 +16,8 @@ Disk fill:
 - Verifies file system performance, and thin-provisioning support.
 - Verifies space reclamation (UNMAP) capabilities on storage. 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running before and after injecting chaos.
 - Appropriate Ephemeral storage requests and limits should be set for the application before running the fault. An example specification is shown below:
 ```yaml
@@ -45,12 +45,10 @@ Disk fill:
           limits:
             ephemeral-storage: "4Gi"
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -82,8 +80,9 @@ Disk fill:
         <td> Default: <code>/run/containerd/containerd.sock</code>. For more information, go to <a href="#container-runtime-and-socket-path">socket path </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-block.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-block.md
@@ -2,7 +2,6 @@
 id: pod-api-block
 title: Pod API block
 ---
-## Introduction
 
 Pod API block is a Kubernetes pod-level chaos fault that blocks the api requests through path filtering. This is achieved by starting the proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-block.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-block.md
@@ -15,15 +15,14 @@ Pod API block:
 - Evaluate if your system can gracefully degrade performance when a specific component (in this case, a pod) is experiencing issues.
 
 
-:::info note
-- Kubernetes> 1.17 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.17
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -45,8 +44,9 @@ Pod API block:
         <td> For more information, go to <a href="#path-filter">path filter </a>.</td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -158,9 +158,9 @@ spec:
               value: '/status'   
 ```
 
-### Path Filter
+### Path filter
 
-API sub path/route to filter the api calls. Tune it by using the `PATH_FILTER` environment variable.
+API sub path (or route) to filter the API calls. Tune it by using the `PATH_FILTER` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -198,9 +198,7 @@ spec:
 A comma-separated list of the destination service or host ports for which `egress` traffic should be affected as a result of chaos testing on the target application. Tune it by using the `DESTINATION_PORTS` environment variable.
 
 :::note
-
 It is applicable only for the egress `SERVICE_DIRECTION`.
-
 :::
 
 The following YAML snippet illustrates the use of this environment variable:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-latency.md
@@ -2,7 +2,6 @@
 id: pod-api-latency
 title: Pod API latency
 ---
-## Introduction
 
 Pod API latency is a Kubernetes pod-level chaos fault that injects api request and response latency by starting proxy server and redirecting the traffic through it.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-latency.md
@@ -14,16 +14,14 @@ Pod API latency:
 - Simulate situations where an API request takes longer than expected to respond. By introducing latency, you can test how well your application handles timeouts and implements appropriate error handling mechanisms.
 - It can be used to test, how well the application handles network delays and failures, and if it recovers gracefully when network connectivity is restored.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
 
-## Fault tunables
+## Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
     <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -55,8 +53,9 @@ Pod API latency:
         <td> For more information, go to <a href="#path-filter">path filter </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -205,9 +204,9 @@ spec:
               value: '/status'
 ```
 
-### Path Filter
+### Path filter
 
-API sub path/route to filter the api calls. Tune it by using the `PATH_FILTER` environment variable.
+API sub path (or route) to filter the API calls. Tune it by using the `PATH_FILTER` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -245,9 +244,7 @@ spec:
 A comma-separated list of the destination service or host ports for which `egress` traffic should be affected as a result of chaos testing on the target application. Tune it by using the `DESTINATION_PORTS` environment variable.
 
 :::note
-
 It is applicable only for the egress `SERVICE_DIRECTION`.
-
 :::
 
 The following YAML snippet illustrates the use of this environment variable:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-body.md
@@ -4,7 +4,6 @@ title: Pod API modify body
 redirect_from:
   - /docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-api-modify-body
 ---
-## Introduction
 
 Pod API modify body is a Kubernetes pod-level chaos fault that modifies the api request and response body by replacing any portions that match a specified regular expression with a provided value. This is achieved by starting the proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-body.md
@@ -15,15 +15,13 @@ Pod API modify body:
 - Simulate error conditions and test the error handling capabilities of API by replacing specific patterns in the response body with error messages or custom error codes to test error handling and reporting mechanisms are in place.
 - It can be useful for obscuring or redacting personally identifiable information (PII), such as email addresses or phone numbers, before logging or transmitting the data for security and privacy compliance.
 
-:::info note
-- Kubernetes> 1.17 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.17
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -55,8 +53,9 @@ Pod API modify body:
         <td> For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-body#path-filter">path filter </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -136,7 +135,7 @@ Pod API modify body:
 
 ### Target service port
 
-Port of the targeted service. Tune it by using the `TARGET_SERVICE_PORT` environment variable.
+Port of the target service. Tune it by using the `TARGET_SERVICE_PORT` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -210,7 +209,7 @@ spec:
 
 ### Path Filter
 
-API sub path/route to filter the api calls. Tune it by using the `PATH_FILTER` environment variable.
+API sub path (or route) to filter the API calls. Tune it by using the `PATH_FILTER` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -250,9 +249,7 @@ spec:
 A comma-separated list of the destination service or host ports for which `egress` traffic should be affected as a result of chaos testing on the target application. Tune it by using the `DESTINATION_PORTS` environment variable.
 
 :::note
-
 It is applicable only for the egress `SERVICE_DIRECTION`.
-
 :::
 
 The following YAML snippet illustrates the use of this environment variable:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-header.md
@@ -2,7 +2,6 @@
 id: pod-api-modify-header
 title: Pod API modify header
 ---
-## Introduction
 
 Pod API modify header is a Kubernetes pod-level chaos fault that overrides the header values of API requests and responses with the user-provided values for the given keys. This is achieved by starting the proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-modify-header.md
@@ -13,15 +13,13 @@ Pod API modify header:
 - This fault can be utilized to validate the caching behavior of your API or client applications. By overriding cache-related headers, such as the "Cache-Control" or "ETag" headers, you can simulate cache validation scenarios.
 - It can be used to test content negotiation capabilities. By modifying the "Accept" header in the API request, you can simulate different content types or formats that the client application can accept.
 
-:::info note
-- Kubernetes> 1.17 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.17
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -53,8 +51,9 @@ Pod API modify header:
         <td> For more information, go to <a href="#path-filter">path filter </a>.</td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -206,9 +205,9 @@ spec:
               value: '/status'  
 ```
 
-### Path Filter
+### Path filter
 
-API sub path/route to filter the api calls. Tune it by using the `PATH_FILTER` environment variable.
+API sub path (or route) to filter the API calls. Tune it by using the `PATH_FILTER` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -248,9 +247,7 @@ spec:
 A comma-separated list of the destination service or host ports for which `egress` traffic should be affected as a result of chaos testing on the target application. Tune it by using the `DESTINATION_PORTS` environment variable.
 
 :::note
-
 It is applicable only for the egress `SERVICE_DIRECTION`.
-
 :::
 
 The following YAML snippet illustrates the use of this environment variable:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-status-code.md
@@ -2,7 +2,6 @@
 id: pod-api-status-code
 title: Pod API status code
 ---
-## Introduction
 
 Pod API status code is a Kubernetes pod-level chaos fault that change the API response status code and optionally api response body through path filtering. This is achieved by starting the proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-api-status-code.md
@@ -13,15 +13,13 @@ Pod API status code:
 - Simulates situations where the API may be temporarily unavailable or rate-limited by returning temporary error codes like 503 (Service Unavailable) or 429 (Too Many Requests).
 - It can be used for content filtering, by selectively filter or block certain responses. For example, you can change the status code to 404 (Not Found) for specific paths or patterns, indicating that the requested resource does not exist.
 
-:::info note
-- Kubernetes> 1.17 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.17
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -53,8 +51,9 @@ Pod API status code:
         <td> For more information, go to <a href="#path-filter">path filter </a>.</td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -211,9 +210,9 @@ spec:
               value: '/status'   
 ```
 
-### Path Filter
+### Path filter
 
-API sub path/route to filter the api calls. Tune it by using the `PATH_FILTER` environment variable.
+API sub path (or route) to filter the API calls. Tune it by using the `PATH_FILTER` environment variable.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -254,9 +253,7 @@ spec:
 A comma-separated list of the destination service or host ports for which `egress` traffic should be affected as a result of chaos testing on the target application. Tune it by using the `DESTINATION_PORTS` environment variable.
 
 :::note
-
 It is applicable only for the egress `SERVICE_DIRECTION`.
-
 :::
 
 The following YAML snippet illustrates the use of this environment variable:

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-autoscaler.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-autoscaler.md
@@ -2,7 +2,6 @@
 id: pod-autoscaler
 title: Pod autoscaler
 ---
-## Introduction
 
 Pod autoscaler is a Kubernetes pod-level chaos fault that determines whether nodes can accomodate multiple replicas of a given application pod. This fault examines the node auto-scaling feature by determining whether the pods were successfully rescheduled within a specified time frame if the existing nodes are running at the specified limits.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-autoscaler.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-autoscaler.md
@@ -12,15 +12,13 @@ Pod autoscaler is a Kubernetes pod-level chaos fault that determines whether nod
 
 Pod autoscaler determines how an application accomodates multiple replicas of a given application pod at unexpected times.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -37,8 +35,9 @@ Pod autoscaler determines how an application accomodates multiple replicas of a 
         <td> It is mutually exclusive with the <code>TARGET_NODE</code> environment variable. If both are provided, the fault uses <code>TARGET_NODE</code>. For more information, go to <a href="../node/common-tunables-for-node-faults#target-nodes-with-labels">node label.</a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog-exec.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog-exec.md
@@ -2,7 +2,6 @@
 id: pod-cpu-hog-exec
 title: Pod CPU hog exec
 ---
-## Introduction
 
 Pod CPU hog exec is a Kubernetes pod-level chaos fault that consumes excess CPU resources of the application container. This fault applies stress on the target pods by simulating a lack of CPU for processes running on the Kubernetes application. This degrades the performance of the application. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog-exec.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog-exec.md
@@ -17,15 +17,13 @@ CPU hog exec:
 - Verifies multi-tenant load issues, that is, when the load increases on one container, this does not cause downtime in other containers. 
 
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog.md
@@ -2,7 +2,6 @@
 id: pod-cpu-hog
 title: Pod CPU hog
 ---
-## Introduction
 
 Pod CPU hog is a Kubernetes pod-level chaos fault that excessively consumes CPU resources, resulting in a significant increase in the CPU resource usage of a pod. This fault applies stress on the target pods by smimulating lack of CPU for processes running on the Kubernetes application. This degrades the performance of the application. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-cpu-hog.md
@@ -16,15 +16,14 @@ CPU hog:
 - Verifies the autopilot functionality of cloud managed clusters. 
 - Verifies multi-tenant load issues, that is, when the load increases on one container, this does not cause downtime in other containers. 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-delete.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-delete.md
@@ -2,7 +2,6 @@
 id: pod-delete
 title: Pod delete
 ---
-## Introduction
 
 Pod delete is a Kubernetes pod-level chaos fault that causes specific (or random) replicas of an application resource to fail forcibly (or gracefully). 
 - To ensure smooth usage, applications must have a minimum number of available replicas. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-delete.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-delete.md
@@ -25,14 +25,12 @@ Pod delete:
   - Forced deletion of pods as a result of eviction.
   - Leader-election in complex applications.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods are in the running state before and after chaos injection.
-:::
 
-## Fault tunables
-<h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-error.md
@@ -2,7 +2,6 @@
 id: pod-dns-error
 title: Pod DNS error
 ---
-## Introduction
 
 Pod DNS error is a Kubernetes pod-level chaos fault that injects chaos to disrupt DNS resolution in pods. It removes access to services by blocking the DNS resolution of host names or domains.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-error.md
@@ -17,15 +17,13 @@ Pod DNS error:
 - Simulates malfunctioning of DNS server (loss of access to specific domains from a given microservice.
 - Simulates access to the cloud provider dependencies, and access to specific third party services.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
 
-## Fault tunables
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description  </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-spoof.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-spoof.md
@@ -2,7 +2,6 @@
 id: pod-dns-spoof
 title: Pod DNS Spoof
 ---
-## Introduction
 
 Pod DNS spoof is a Kubernetes pod-level chaos fault that injects chaos into pods to mimic DNS resolution. This fault resolves DNS target host names or domains to other IPs as specified in the `SPOOF_MAP` environment variable in the chaos engine configuration.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-spoof.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-dns-spoof.md
@@ -15,15 +15,12 @@ Pod DNS spoof:
 - Determines how quickly an application can resolve the host names and recover from the failure. 
 - Simulates custom responses from a spoofed upstream service.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
-
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description  </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-latency.md
@@ -2,7 +2,6 @@
 id: pod-http-latency
 title: Pod HTTP latency
 ---
-## Introduction
 
 Pod HTTP latency is a Kubernetes pod-level chaos fault that injects HTTP response latency by starting the proxy server and redirecting the traffic through it. This fault:
 - Injects the latency into the service whose port is specified using the `TARGET_SERVICE_PORT` environment variable.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-latency.md
@@ -16,13 +16,12 @@ Pod HTTP latency:
 - Simulates a slow response on specific third-party or dependent components or services. 
 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
 
-## Fault tunables
+### Mandatory tunables
 
   <h3>Mandatory tunables</h3>
     <table>
@@ -47,8 +46,9 @@ Pod HTTP latency:
         <td> Default: 2000. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-latency#latency">latency </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-body.md
@@ -2,7 +2,6 @@
 id: pod-http-modify-body
 title: Pod HTTP modify body
 ---
-## Introduction
 
 Pod HTTP modify body is a Kubernetes pod-level chaos fault that injects chaos on the service whose port is provided using the `TARGET_SERVICE_PORT` environment variable. This is achieved by starting the proxy server and redirecting the traffic through the proxy server. This fault can be used to overwrite the HTTP response body by providing the new body value as `RESPONSE_BODY`.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-body.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-body.md
@@ -11,15 +11,13 @@ Pod HTTP modify body is a Kubernetes pod-level chaos fault that injects chaos on
 
 Pod HTTP modify body tests the application's resilience to erroneous or incorrect HTTP response body.
 
-:::info note
-- Kubernetes> 1.17 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.17
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -41,8 +39,9 @@ Pod HTTP modify body tests the application's resilience to erroneous or incorrec
         <td> If no value is provided, response will be an empty body. Defaults to empty body. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-body#response-body">response body </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-header.md
@@ -2,7 +2,6 @@
 id: pod-http-modify-header
 title: Pod HTTP modify header
 ---
-## Introduction
 
 Pod HTTP modify header is a Kubernetes pod-level chaos fault that injects chaos on the service whose port is provided using the `TARGET_SERVICE_PORT` environment variable. This is done by starting the proxy server and redirecting the traffic through the proxy server. This fault modifies headers of the requests and responses of the service. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-header.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-modify-header.md
@@ -12,15 +12,13 @@ Pod HTTP modify header is a Kubernetes pod-level chaos fault that injects chaos 
 
 Pod HTTP modify header can be used to test resilience towards incorrect or incomplete headers in application services.
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -47,8 +45,9 @@ Pod HTTP modify header can be used to test resilience towards incorrect or incom
         <td> Default: response. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-modify-header#header-mode">header mode </a> </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
@@ -2,7 +2,6 @@
 id: pod-http-reset-peer
 title: Pod HTTP reset peer
 ---
-## Introduction
 
 Pod HTTP reset peer is a Kubernetes pod-level chaos fault that injects chaos on the service whose port is specified using the `TARGET_SERVICE_PORT` environment variable. This fault:
 - Stops the outgoing HTTP requests by resetting the TCP connection. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-reset-peer.md
@@ -18,15 +18,13 @@ Pod HTTP reset peer:
 - Simulates connection resets due to resource limitations on the server side such as out of memory error, process kills, overload on the server due to high amounts of traffic. 
 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -48,8 +46,9 @@ Pod HTTP reset peer:
         <td> Default: 0. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-reset-peer#reset-timeout">reset timeout </a></td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-status-code.md
@@ -2,7 +2,6 @@
 id: pod-http-status-code
 title: Pod HTTP status code
 ---
-## Introduction
 
 Pod HTTP status code is a Kubernetes pod-level fault that injects chaos inside the pod by modifying the status code of the response from the application server to the desired status code provided by the user. This is achieved by starting the proxy server and redirecting the traffic through the proxy server.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-status-code.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-http-status-code.md
@@ -14,15 +14,13 @@ Pod HTTP status code:
 - Simulates unavailability of specific APIs for (or from) a given microservice.
 - Simulates unauthorized requests for third party services (401 or 403), and API malfunction, that is internal server error (50x). 
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -50,8 +48,9 @@ Pod HTTP status code:
         <td> If true, the body is replaced by a default template for the status code. Defaults to true. For more information, go to <a href="https://developer.harness.io/docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-http-status-code#modify-response-body">modify response body </a> </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-attribute-override.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-attribute-override.md
@@ -5,7 +5,7 @@ title: Pod IO attribute override
 
 import IOFaultsCaution from './shared/io-faults-caution.md'
 
-Pod IO Attribute Override, modify the properties of files located within the mounted volume of the pod. 
+Pod IO attribute override modifies the properties of files located within the mounted volume of the pod. 
 This fault should be used as a sanity test for validating your application's failover capability against unexpected changes in file attributes, such as permissions, ownership, or timestamps.
 
 ![Pod IO Attribute Override](./static/images/pod-io-attribute-override.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-attribute-override.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-attribute-override.md
@@ -20,15 +20,12 @@ Pod IO attribute override:
 
 <IOFaultsCaution />
 
-:::info note
-- Kubernetes 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
-
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -46,8 +43,8 @@ Pod IO attribute override:
       </tr>
     </table>
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -155,7 +152,7 @@ spec:
           value: '60'
 ```
 
-### Mount Path
+### Mount path
 
 Mount path of the volume mounted to the target application. Tune it by using the `MOUNT_PATH` environment variable.
 
@@ -190,7 +187,7 @@ spec:
           value: '60'
 ```
 
-### Advanced Fault Tunables
+### Advanced fault tunables
 
 - `FILE_PATH`: The path for injecting faults can be specified as either a single file or a wildcard. By default it targets all the files present inside the mount path.
 - `PERCENTAGE`: The likelihood of failure per operation, expressed as a percentage. Default is 100%.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
@@ -5,7 +5,7 @@ title: Pod IO error
 
 import IOFaultsCaution from './shared/io-faults-caution.md'
 
-The pod-io-error chaos fault simulates an error that can occur during system calls of the files located within the mounted volume of the pod.
+The pod IO error simulates an error that can occur during system calls of the files located within the mounted volume of the pod.
 When triggered, it causes the call to fail and return an error, potentially disrupting critical processes that rely on accurate file operations.
 
 ![Pod IO Error](./static/images/pod-io-error.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-error.md
@@ -19,15 +19,13 @@ Pod IO error:
 
 <IOFaultsCaution />
 
-:::info note
-- Kubernetes 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -45,8 +43,8 @@ Pod IO error:
       </tr>
     </table>
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -119,7 +117,7 @@ Pod IO error:
       </tr>
     </table>
 
-### Error Code
+### Error code
 
 Error code to be injected in system calls of the files located within the mounted volume of the pod. Tune it by using the `ERROR_CODE` environment variable. 
 
@@ -154,7 +152,7 @@ spec:
           value: '60'
 ```
 
-### Mount Path
+### Mount path
 
 Mount path of the volume mounted to the target application. Tune it by using the `MOUNT_PATH` environment variable.
 
@@ -189,7 +187,7 @@ spec:
           value: '60'
 ```
 
-### Advanced Fault Tunables
+### Advanced fault tunables
 
 - `FILE_PATH`: The path for injecting faults can be specified as either a single file or a wildcard. By default it targets all the files present inside the mount path.
 - `PERCENTAGE`: The likelihood of failure per operation, expressed as a percentage. Default is 100%.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-latency.md
@@ -19,15 +19,13 @@ Pod IO latency:
 
 <IOFaultsCaution />
 
-:::info note
-- Kubernetes 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -45,8 +43,8 @@ Pod IO latency:
       </tr>
     </table>
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -154,7 +152,7 @@ spec:
           value: '60'
 ```
 
-### Mount Path
+### Mount path
 
 Mount path of the volume mounted to the target application. Tune it by using the `MOUNT_PATH` environment variable.
 
@@ -189,7 +187,7 @@ spec:
           value: '60'
 ```
 
-### Advanced Fault Tunables
+### Advanced fault tunables
 
 - `FILE_PATH`: The path for injecting faults can be specified as either a single file or a wildcard. By default it targets all the files present inside the mount path.
 - `PERCENTAGE`: The likelihood of failure per operation, expressed as a percentage. Default is 100%.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-stress.md
@@ -2,8 +2,6 @@
 id: pod-io-stress
 title: Pod IO stress
 ---
-## Introduction
-
 Pod I/O stress is a Kubernetes pod-level chaos fault that causes I/O stress on the application pod by increasing the number of input and output requests. Applying stress on the disk with continuous and heavy I/O degrades the reads and writes with respect to the microservices. Scratch space consumed on a node may lead to lack of memory for new containers to be scheduled. All these aspects increase resilience to stress. 
 
 ![Pod IO Stress](./static/images/pod-io-stress.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-io-stress.md
@@ -16,15 +16,13 @@ Pod IO stress:
 - Checks how the application functions under high disk latency conditions and when I/O traffic is very high.
 - Checks how the application functions under large I/O blocks, and when other services monopolize the I/O disks. 
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog-exec.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog-exec.md
@@ -2,7 +2,6 @@
 id: pod-memory-hog-exec
 title: Pod memory hog exec
 ---
-## Introduction
 
 Pod memory hog exec is a Kubernetes pod-level chaos fault that consumes excessive memory resources on the application container. Since this fault stresses the target container, the primary process within the container may consume the available system memory on the node. 
 - Memory usage within containers is subject to various constraints in Kubernetes. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog-exec.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog-exec.md
@@ -20,15 +20,13 @@ Pod memory hog exec:
 - Verifies application restarts on OOM (out of memory) kills. 
 - Tests how the overall application stack behaves when such a situation occurs.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog.md
@@ -2,7 +2,6 @@
 id: pod-memory-hog
 title: Pod memory hog
 ---
-## Introduction
 
 Pod memory hog is a Kubernetes pod-level chaos fault that consumes excessive memory resources on the application container. Since this fault stresses the target container, the primary process within the container may consume the available system memory on the node. 
 - Memory usage within containers is subject to various constraints in Kubernetes. 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-memory-hog.md
@@ -19,16 +19,13 @@ Pod memory hog exec:
 - Verifies application restarts on OOM (out of memory) kills. 
 - Tests how the overall application stack behaves when such a situation occurs.
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.16 
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
+### Optional tunables
 
-## Fault tunables
-
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-corruption.md
@@ -2,7 +2,6 @@
 id: pod-network-corruption
 title: Pod network corruption
 ---
-## Introduction
 
 Pod network corruption is a Kubernetes pod-level chaos fault that injects corrupted packets of data into the specified container. This is achieved by starting a traffic control (tc) process with netem rules to add egress packet corruption.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-corruption.md
@@ -13,15 +13,13 @@ Pod network corruption:
 - Simulates degraded network with varied percentages of dropped packets between microservices (dropped at the destination).
 - Tests the application's resilience to lossy or flaky network.
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -183,7 +181,7 @@ spec:
           value: '60'
 ```
 
-### Source And Destination Ports
+### Source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The interruption of specific port(s) can be tuned via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 
@@ -222,7 +220,7 @@ spec:
           value: '60'
 ```
 
-### Ignore Source and Destination Ports
+### Ignore source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The specific ports can be ignored via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-duplication.md
@@ -2,7 +2,6 @@
 id: pod-network-duplication
 title: Pod network duplication
 ---
-## Introduction
 
 Pod network duplication is a Kubernetes pod-level chaos fault that injects chaos to disrupt the network connectivity to Kubernetes pods. This fault injects chaos on the specific container by starting a traffic control (tc) process with netem rules to add egress delays. 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-duplication.md
@@ -13,15 +13,13 @@ Pod network duplication:
 - Determines the application's resilience to duplicate network.
 - Simulates a degraded network with varied percentages of dropped packets between microservices (dropped at the destination).
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.16 
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -185,7 +183,7 @@ spec:
               value: "60"
 ```
 
-### Source And Destination Ports
+### Source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The interruption of specific port(s) can be tuned via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 
@@ -224,7 +222,7 @@ spec:
           value: '60'
 ```
 
-### Ignore Source and Destination Ports
+### Ignore source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The specific ports can be ignored via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-latency.md
@@ -2,7 +2,6 @@
 id: pod-network-latency
 title: Pod network latency
 ---
-## Introduction
 
 Pod network latency is a Kubernetes pod-level chaos fault that introduces latency (delay) to a specific container. This fault:
 - Initiates a traffic control (tc) process with netem rules to add egress delays.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-latency.md
@@ -10,9 +10,7 @@ Pod network latency is a Kubernetes pod-level chaos fault that introduces latenc
   - Such issues can also be resolved by setting up alerts and notifications to highlight a degradation, so that they can be addressed, and rectified. A
   - Issues can also be resolved by understanding the impact of the failure and determining the last point before degradation in the application stack. 
 
-
 ![Pod Network Latency](./static/images/pod-network-latency.png)
-
 
 ## Use cases
 Pod network latency:
@@ -25,15 +23,12 @@ Pod network latency:
 - Simulates a degraded data-plane of service-mesh infrastructure.  
 
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes> 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
-
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -202,7 +197,7 @@ spec:
               value: "60"
 ```
 
-### Source And Destination Ports
+### Source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The interruption of specific port(s) can be tuned via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 
@@ -241,7 +236,7 @@ spec:
           value: '60'
 ```
 
-### Ignore Source and Destination Ports
+### Ignore source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The specific ports can be ignore via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-loss.md
@@ -2,7 +2,6 @@
 id: pod-network-loss
 title: Pod network loss
 ---
-## Introduction
 
 Pod network loss is a Kubernetes pod-level chaos fault that causes packet loss in a specific container by starting a traffic control (tc) process with netem rules to add egress (or ingress) loss.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-loss.md
@@ -16,15 +16,13 @@ Pod network loss:
 - Simulates network partitions (split-brain) between peer replicas for a stateful application.
 - Tests the application's resilience to lossy (or flaky) network.
 
-:::info note
-- Kubernetes> 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -185,7 +183,7 @@ spec:
           value: '60'
 ```
 
-### Source And Destination Ports
+### Source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The interruption of specific port(s) can be tuned via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 
@@ -224,7 +222,7 @@ spec:
           value: '60'
 ```
 
-### Ignore Source and Destination Ports
+### Ignore source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The specific ports can be ignored via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-partition.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-partition.md
@@ -2,7 +2,6 @@
 id: pod-network-partition
 title: Pod network partition
 ---
-## Introduction
 
 Pod network partition is a Kubernetes pod-level fault that blocks 100 percent ingress and egress traffic of the target application by creating a network policy.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-partition.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-partition.md
@@ -11,15 +11,13 @@ Pod network partition is a Kubernetes pod-level fault that blocks 100 percent in
 
 Pod network partition tests the application's resilience to lossy or flaky network.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16 
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
+### Optional tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-rate-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-rate-limit.md
@@ -5,8 +5,6 @@ redirect_from:
   - /docs/chaos-engineering/chaos-faults/kubernetes/pod/pod-network-rate-limit
 ---
 
-## Introduction
-
 Pod network rate limit is a Kubernetes pod-level chaos fault that generates Traffic Control (tc) rules with Token Bucket Filter (TBF) to assess Kubernetes pod resilience under limited network bandwidth condition.
 
 ![Pod Network Rate Limit](./static/images/pod-network-rate-limit.png)

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-rate-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/pod-network-rate-limit.md
@@ -16,15 +16,14 @@ Pod network rate limit:
 - Evaluate the impact of network rate limits on security-related functions such as DDoS mitigation or intrusion detection, and assessing whether the system can withstand such scenarios.
 - Determine the optimal network bandwidth allocation for different pods and applications to effectively plan resource usage and accommodate growth without degradation in performance.
 
-:::info note
-- Kubernetes > 1.16 is required to execute this fault.
+### Prerequisites
+- Kubernetes > 1.16 
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -47,8 +46,8 @@ Pod network rate limit:
       </tr>
     </table>
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -179,7 +178,7 @@ spec:
           value: '60'
 ```
 
-### Advance Tunables
+### Advance tunables
 
 - `MIN_BURST`: It contains the size of the peakrate bucket
 - `PEAK_RATE`: It contains the maximum depletion rate of the bucket
@@ -267,7 +266,7 @@ spec:
           value: '60'
 ```
 
-### Source And Destination Ports
+### Source and destination ports
 
 By default, the network experiments disrupt traffic for all the source and destination ports. The interruption of specific port(s) can be tuned via `SOURCE_PORTS` and `DESTINATION_PORTS` ENV.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/time-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/time-chaos.md
@@ -2,9 +2,8 @@
 id: time-chaos
 title: Time Chaos
 ---
-## Introduction
 
-Time Chaos is a Kubernetes pod-level fault that introduces controlled time offsets to disrupt the system time of the target pod.
+Time chaos is a Kubernetes pod-level fault that introduces controlled time offsets to disrupt the system time of the target pod.
 
 ![Time Chaos](./static/images/time-chaos.png)
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/time-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/pod/time-chaos.md
@@ -13,15 +13,13 @@ Time Chaos:
 - It is used to identify potential weaknesses in the system's ability to recover and handle time-related faults, leading to improvements in fault-tolerant designs and system resilience.
 -  It can be used in various simulations to mimic real-world scenarios where time synchronization or manipulation is critical.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - The application pods should be in the running state before and after injecting chaos.
-:::
 
-## Fault tunables
 
-  <h3>Optional tunables</h3>
-    <table>
+### Mandatory tunables
+  <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -34,8 +32,8 @@ Time Chaos:
       </tr>
     </table>
 
-  <h3>Optional tunables</h3>
-    <table>
+### Optional tunables
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/security-considerations/container-permissions.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/kubernetes/security-considerations/container-permissions.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 This topic lists the various categories of Kubernetes faults and the container permissions required to execute them.
 
 
-### Supported Kubernetes faults and required container permissions
+### Supported Kubernetes faults and container permissions
 
 The following table shows the supported Kubernetes faults and the required fault container permissions to execute them.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-cpu-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-cpu-stress.md
@@ -20,11 +20,11 @@ Linux CPU stress fault applies stress on the CPU of the target Linux machines fo
 
 <FaultPermissions />
 
-## External packages
+### External packages
 This fault uses [`stress-ng`](https://github.com/ColinIanKing/stress-ng), which is installed as part of the infrastructure installation.
 
-## Fault tunables
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-disk-fill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-disk-fill.md
@@ -21,8 +21,7 @@ Linux disk fill:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-disk-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-disk-io-stress.md
@@ -21,11 +21,10 @@ Linux disk IO stress applies stress on the disk of the target Linux machines ove
 
 <FaultPermissions />
 
-## External packages
+### External packages
 This fault uses [`stress-ng`](https://github.com/ColinIanKing/stress-ng), which is installed as part of the infrastructure installation.
 
-## Fault tunables
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-error.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-error.md
@@ -19,8 +19,7 @@ Linux DNS error injects chaos to disrupt the DNS resolution on a Linux machine.
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-spoof.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-dns-spoof.md
@@ -20,8 +20,7 @@ Linux DNS spoof injects chaos to mimic DNS resolution on a Linux machine.
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -34,7 +33,8 @@ Linux DNS spoof injects chaos to mimic DNS resolution on a Linux machine.
     <td> For example, '&#123;"abc.com":"spoofabc.com"&#125;' where key is the host name to be spoofed and value is the host name to which the key is spoofed. </td>
   </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-memory-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-memory-stress.md
@@ -24,7 +24,7 @@ The mapped memory space is unmapped only after the chaos duration; the same memo
 
 <FaultPermissions />
 
-## External packages
+### External packages
 This fault uses [`stress-ng`](https://github.com/ColinIanKing/stress-ng), which is installed as part of the infrastructure installation.
 
 ## Fault tunables

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-corruption.md
@@ -20,8 +20,7 @@ Linux network corruption:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -34,7 +33,8 @@ Linux network corruption:
     <td> For example, <code>eth0,ens192</code> </td>
   </tr>
 </table>
-<h3>Optional fields</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-duplication.md
@@ -20,8 +20,7 @@ Linux network duplication:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -34,7 +33,8 @@ Linux network duplication:
     <td> For example, <code>eth0,ens192</code> </td>
   </tr>
 </table>
-<h3>Optional fields</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-latency.md
@@ -19,8 +19,7 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -33,7 +32,8 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
     <td> For example: <code>eth0,ens192</code> </td>
   </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-loss.md
@@ -20,8 +20,7 @@ Linux network loss:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -34,7 +33,8 @@ Linux network loss:
     <td> For example, <code>eth0,ens192</code>. </td>
   </tr>
 </table>
-<h3>Optional fields</h3>
+
+### Optional fields
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-rate-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-network-rate-limit.md
@@ -20,8 +20,7 @@ Linux network rate limit:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory fields</h3>
+## Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -35,7 +34,7 @@ Linux network rate limit:
   </tr>
 </table>
 
-<h3>Optional fields</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-process-kill.md
@@ -21,8 +21,7 @@ Linux process kill:
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -45,7 +44,8 @@ Linux process kill:
     <td> For example, <code>nginx,redis</code> </td>
   </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -58,7 +58,7 @@ Linux process kill:
     <td> Default: <code>false</code>. </td>
   </tr>
   <tr>
-    <td> duration </td>
+    <td> Duration </td>
     <td> Duration through which chaos is injected into the target resource. Should be provided in <code>[numeric-hours]h[numeric-minutes]m[numeric-seconds]s</code> format. </td>
     <td> Default: <code>30s</code>. Examples: <code>1m25s</code>, <code>1h3m2s</code>, <code>1h3s</code> </td>
   </tr>
@@ -90,7 +90,7 @@ spec:
     duration: 30s
 ```
 
-### Process Names
+### Process names
 
 The `processNames` input variable targets process names to kill.
 
@@ -111,7 +111,7 @@ spec:
     duration: 30s
 ```
 
-### Process Command
+### Process command
 
 The `processCommand` input variable targets the processes, based on the command used to start processes, if available. A substring match is made on the given command to determine the target processes.
 
@@ -132,7 +132,7 @@ spec:
     duration: 30s
 ```
 
-### Force Kill
+### Force kill
 
 The `forceKill` input variable specifies whether to force kill the target processes using the `SIGKILL` signal or gracefully kill the target processes with the `SIGTERM` signal.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-service-restart.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-service-restart.md
@@ -20,8 +20,7 @@ Linux service restart stops the target system services running in a Linux machin
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
   <tr>
     <th> Tunable </th>
@@ -34,7 +33,8 @@ Linux service restart stops the target system services running in a Linux machin
     <td> For example <code>nginx,apache2,sshd</code> </td>
   </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-time-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/linux-time-chaos.md
@@ -19,8 +19,7 @@ Linux time chaos injects chaos to change the time of the Linux machine.
 
 <FaultPermissions />
 
-## Fault tunables
-<h3>Optional tunables</h3>
+### Optional tunables
 <table>
   <tr>
     <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/linux/shared/fault-permissions.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/linux/shared/fault-permissions.md
@@ -1,2 +1,2 @@
-## Fault permissions
+### Fault permissions
 The fault uses the `root` Linux user and `root` user group.

--- a/docs/chaos-engineering/technical-reference/chaos-faults/load/locust-loadgen.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/load/locust-loadgen.md
@@ -12,7 +12,7 @@ Locust loadgen fault simulates load generation on the target hosts for a specifi
 - Locust loadgen fault determines the resilience of an application under heavy load. 
 - It determines how quickly the target application recovers from such a failure. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.17 is required to execute this fault.
 - The target host should be accessible.
 - Kubernetes configmap that contains the `config.py` file is required. This file is used as a locustfile to generate load in the `CHAOS_NAMESPACE`. Below is a sample configmap:
@@ -33,16 +33,17 @@ data:
         def hello_world(self):
             self.client.get("")
 ```
-- If you change the `config.py` file, ensure that you update the `CONFIG_MAP_FILE` environment variable in the chaos experiment with the new name.
+
+:::tip
+If you change the `config.py` file, ensure that you update the `CONFIG_MAP_FILE` environment variable in the chaos experiment with the new name.
 :::
 
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -52,17 +53,18 @@ data:
             <td> Provide the name of target host ex: <code>https://google.com</code>. For more information, go to <a href="#target-host"> target host.</a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
         <tr>
             <td> TOTAL_CHAOS_DURATION </td>
             <td> Time taken to inject chaos into the target resource (in seconds). </td>
-            <td> Defaults to 60s. For more information, go to <a href="/docs/chaos-engineering/technical-reference/chaos-faults/common-tunables-for-all-faults#duration-of-the-chaos">duration of the chaos</a>.</td>
+            <td> Default: 60s. For more information, go to <a href="/docs/chaos-engineering/technical-reference/chaos-faults/common-tunables-for-all-faults#duration-of-the-chaos">duration of the chaos</a>.</td>
         </tr>
         <tr>
             <td> CHAOS_INTERVAL </td>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/security-chaos/kube-security-cis.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/security-chaos/kube-security-cis.md
@@ -2,7 +2,6 @@
 id: kube-security-cis
 title: Kube security CIS
 ---
-## Introduction
 
 Kube security CIS runs the CIS benchmark on the Kubernetes cluster and checks for the compliance of the cluster with the CIS benchmark. CIS benchmark is a set of security best practices to improve the resilience of the Kubernetes cluster.
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/security-chaos/kube-security-cis.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/security-chaos/kube-security-cis.md
@@ -12,12 +12,11 @@ Kube security CIS:
 - Determines the compliance of the Kubernetes cluster with the CIS benchmark.
 - Finds and fixes the security issues in the Kubernetes cluster.
 
-:::info note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate permissions to execute this fault.
-:::
 
-<h3>Mandatory tunables</h3>
+### Mandatory tunables
 <table>
     <tr>
         <th> Tunable </th>
@@ -30,7 +29,8 @@ Kube security CIS:
         <td> Default: <code>/run/containerd/containerd.sock</code>. </td>
     </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
     <tr>
         <th> Tunable </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/ssh/ssh-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/ssh/ssh-chaos.md
@@ -23,10 +23,8 @@ Before executing the SSH chaos experiment, ensure that you follow the steps in t
 If you use the default names for ConfigMap and secrets, you won't need to modify the experiment. If you use different names, update the respective environment variables with their names. For example, if your script file is `test.sh` instead of `script.sh`, update the `CHAOS SCRIPT PATH` environment variable with the correct value.
 :::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
             <th> Variables </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-cpu-hog.md
@@ -15,7 +15,7 @@ VMware CPU hog applies stress on the CPU resources on Linux OS based VMware VM. 
 - It verifies the autopilot functionality of cloud managed clusters. 
 - It verifies multi-tenant load issues, that is, when the load on one container increases, it should not cause downtime in other containers.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -36,14 +36,13 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +62,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-disk-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-disk-loss.md
@@ -11,7 +11,7 @@ VMware disk loss detaches the disks that are attached to a Linux OS based VMware
 
 - VMware disk loss determines the resilience of an application to the unplanned scaling of K8s pods.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - The VM should be in a healthy state before and after injecting chaos.
 - The target disks should be attached to the VM.
@@ -32,14 +32,11 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -54,10 +51,12 @@ stringData:
         <td> For example, <code>disk-1.vmdk,disk-2.vmdk</code>. For more information, go to <a href="#virtual-disk-names"> virtual disk names. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-dns-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-dns-chaos.md
@@ -16,7 +16,7 @@ VMware DNS chaos causes DNS errors in the VMware VMs which results in the DNS se
 - It simulates malfunctioning of DNS server, that is, loss of access to specific domains from a given microservice, loss of access to cloud provider dependencies, and loss of access to specific third party services.
 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ``` 
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +61,12 @@ stringData:
         <td> Defaults to 54. For more information, go to <a href="#run-dns-chaos-with-port"> DNS chaos with port.</a> </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -106,10 +106,11 @@ stringData:
         <td> Defaults to the server mentioned in <code>resolv.conf</code> file. For more information, go to <a href="#run-dns-chaos-with-upstream-server"> DNS chaos with upstream server. </a></td>
       </tr>
     </table>
-    <h3>Secret fields</h3>
-     <table>
+
+### Secret tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-host-reboot.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-host-reboot.md
@@ -14,7 +14,7 @@ VMware host reboot reboots a VMware host that is attached to the Vcenter.
 - It measures the impact of the host reboot on the VMs and its underlying applications. 
 - It also measures the effectiveness of a HA cluster.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - The VM should be in a healthy state before and after injecting chaos.
@@ -34,14 +34,11 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables 
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -61,10 +58,11 @@ stringData:
         <td> Defaults to disable. Supports enable as well. For more information, go to <a href="#ha-cluster"> high availablity cluster. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables 
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-latency.md
@@ -14,7 +14,7 @@ VMware HTTP latency injects HTTP response latency into the service of a specific
 - It determines how the system recovers or fetches the responses when there is a delay in accessing the service. - It simulates latency to specific API services for (or from) a given microservice. 
 - It also simulates a slow response on specific third party (or dependent) components (or services). 
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -32,14 +32,11 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables 
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -69,10 +66,11 @@ stringData:
             <td> Defaults to port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-modify-response.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-modify-response.md
@@ -15,7 +15,7 @@ VMware HTTP modify response injects HTTP chaos by modifying the status code, bod
 - VMware HTTP modify response determines the resilience of an application to modifications in the status code or body or header of the request (or response). 
 - It measures how accurately the application spots incorrect HTTP response body.
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -33,14 +33,11 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
-
-  <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -70,8 +67,9 @@ stringData:
             <td> Defaults to 'status_code'. It accepts 'body', and 'header' as well. For more information, go to <a href="#modifying-the-response-status-code"> modifying status code of the response.</a></td>
         </tr>
     </table>
-    <h3> Status code modification fields </h3>
-    <table>
+
+### Status code modification tunables
+  <table>
     <tr>
         <td> STATUS_CODE </td>
         <td> Modified the status code for the HTTP response. </td>
@@ -85,16 +83,18 @@ stringData:
         <td> Defaults to true, wherein the body is replaced by a default template for the status code. For more information, go to <a href="#modifying-the-response-status-code"> modify response body field. </a></td>
     </tr>
     </table>
-    <h3> Body modification fields </h3>
-    <table>
+
+### Body modification tunables
+   <table>
         <tr>
             <td> RESPONSE_BODY </td>
             <td> Body string used to overwrite the HTTP response body. </td>
             <td> If no value has been provided, the response will be an empty body. Defaults to empty body. For more information, go to <a href="#modifying-the-response-body"> response body field. </a></td>
         </tr>
     </table>
-    <h3> Header modification fields</h3>
-    <table>
+
+### Header modification tunables
+  <table>
         <tr>
             <td> HEADERS_MAP </td>
             <td> Map of the headers to modify (or add). </td>
@@ -106,8 +106,9 @@ stringData:
             <td> Defaults to response. Supports request as well.  For more information, go to <a href="#modifying-the-request-headers"> header mode field. </a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+  <table>
         <tr>
             <th> Variables </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-reset-peer.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-http-reset-peer.md
@@ -17,7 +17,7 @@ VMware HTTP reset peer injects HTTP reset chaos that stops the outgoing HTTP req
 - It simulates premature connection loss, such as firewall issues, between microservices by verifying connection timeouts.
 - It simulates connection resets due to resource limitations on the server side, such as running out of memory, killing processes, or overloading the server due to high amounts of traffic.
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -35,14 +35,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>
@@ -72,10 +70,12 @@ stringData:
             <td> Defaults to port 80. For more information, go to <a href="#target-service-port"> target service port.</a></td>
         </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
         <tr>
-            <th> Variables </th>
+            <th> Tunable </th>
             <th> Description </th>
             <th> Notes </th>
         </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-io-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-io-stress.md
@@ -19,7 +19,7 @@ VMware IO stress causes disk stress on the target VMware VMs. It aims to verify 
 - It checks whether the application functions well under high disk latency conditions.
 - It checks for high I/O traffic that includes large I/O blocks, and in what cases other services monopolize the I/O disks. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -39,14 +39,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -66,10 +64,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-memory-hog.md
@@ -16,11 +16,11 @@ VMware memory hog fault consumes excessive memory resources on Linux OS based VM
 - It verifies pod priority and QoS setting for eviction purposes. 
 - It also verifies application restarts on OOM (out of memory) kills. 
 
-:::note
+:::tip
 The mapped memory space is unmapped only after the chaos duration; the same memory space is used to write data into memory in an iterative manner. This way, constant memory is consumed throughout the fault duration.
 :::
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -40,14 +40,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -67,10 +65,13 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-latency.md
@@ -19,7 +19,7 @@ VMware network latency:
 - Simulates slow response on specific third party (or dependent) components (or services).
 - Simulates degraded data-plane of service-mesh infrastructure.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +61,12 @@ stringData:
         <td> It is used to run the govc command. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -121,10 +121,11 @@ stringData:
         <td> For example, 30s. For more information, go to <a href="../common-tunables-for-all-faults#ramp-time"> ramp time. </a></td>
       </tr>
     </table>
-    <h3>Secret fields</h3>
-     <table>
+
+### Secret tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-loss.md
@@ -19,7 +19,7 @@ VMware network loss:
 - Simulates blackhole against traffic to a given availability zone, that is, failure simulation of availability zones. 
 - Simulates network partitions (split-brain) between peer replicas for a stateful application. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +61,12 @@ stringData:
         <td> It is used to run the govc command. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -116,10 +116,11 @@ stringData:
         <td> For example, 30s. For more information, go to <a href="../common-tunables-for-all-faults#ramp-time"> ramp time. </a></td>
       </tr>
     </table>
-    <h3>Secret fields</h3>
-     <table>
+
+### Secret tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-rate-limit.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-network-rate-limit.md
@@ -18,7 +18,7 @@ VMware network rate limit:
 - Helps assess how the system performs when network resources are constrained, mimicking real-world scenarios where network connectivity may be compromised during a disaster or outage.
 - Determines how the system prioritizes and handles different types of traffic when network rate limits are in place, ensuring that critical services receive preferential treatment.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -35,14 +35,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -67,10 +65,12 @@ stringData:
         <td> For example, <code>ens160</code>. For more information, go to <a href="#network-interface"> network interface. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -130,10 +130,11 @@ stringData:
         <td> For example, 30s. For more information, go to <a href="../common-tunables-for-all-faults#ramp-time"> ramp time. </a></td>
       </tr>
     </table>
-    <h3>Secret fields</h3>
-     <table>
+
+### Secret tunables 
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-process-kill.md
@@ -12,7 +12,7 @@ VMware process kill kills the target processes that are running as a part of a L
 - VMware process kill disrupts critical processes running within the application, such as databases or message queues. 
 - The services that are disrupted might be running in the VMware VM, and this fault kills their underlying processes or threads. Such faults help determine how efficiently and quickly the VMware instance recovers from the unexpected disruption.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -33,14 +33,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
         <td> For example, <code>183,253,857</code>. For more information, go to <a href="#process-ids"> process Ids. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-service-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-service-stop.md
@@ -11,7 +11,7 @@ VMware service stop stops the target system services running on a Linux OS based
 - VMware service stop determines the resilience of an application to random halts. 
 - It determines how efficiently an application recovers and restarts the services.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443.
 - The VM should be in a healthy state before and after injecting chaos. 
@@ -32,14 +32,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +62,12 @@ stringData:
         <td> For example, <code>nginx</code>. For more information, go to <a href="#service-name"> service name.</a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-vm-poweroff.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-vm-poweroff.md
@@ -14,7 +14,7 @@ VMware VM poweroff stops (or powers off) the VMware VMs for a specific duration.
 - VMware VM poweroff determines the resilience of an application to random power failures. 
 - It determines how efficiently an application recovers and restarts the services.
 
-:::note
+### Prerequisites
 - Kubernetes >= 1.17 is required to execute this fault.
 - Appropriate vCenter permissions should be provided to start and stop the VMs.
 - The VM should be in a healthy state before and after injecting chaos.
@@ -34,12 +34,11 @@ stringData:
 ```
 :::
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -49,10 +48,12 @@ stringData:
         <td> For example, <code>vm-5365</code>. For more information, go to <a href="#stoppoweroff-the-vm-by-moid"> stop VM based on MOID. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-blackhole-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-blackhole-chaos.md
@@ -14,7 +14,7 @@ VMware Windows Blackhole Chaos simulates a network blackhole scenario on Windows
 - VMware Windows Blackhole Chaos simulates the situation of network isolation for processes running on the application, which degrades their performance.
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -37,14 +37,11 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
+### Mandatory tunables
 
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +61,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-cpu-hog.md
@@ -15,7 +15,7 @@ VMware Windows CPU hog applies stress on the CPU resources on Windows OS based V
 - It also helps verify metrics-based horizontal pod autoscaling as well as vertical autoscale, that is, demand based CPU addition. 
 - It verifies the autopilot functionality of cloud managed clusters.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - Adequate vCenter permissions should be provided to access the hosts and the VMs.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +61,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-disk-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-disk-stress.md
@@ -14,7 +14,7 @@ VMware Windows Disk Stress applies stress on the disk resources on Windows OS ba
 - VMware Windows Disk Stress simulates the situation of high disk usage for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle disk failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,11 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
+### Mandatory tunables
 
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +62,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-memory-hog.md
@@ -14,7 +14,7 @@ VMware Windows Memory hog applies stress on the Memory resources on Windows OS b
 - VMware Windows Memory hog simulates the situation of lack of Memory for processes running on the application, which degrades their performance. 
 - It verifies the autopilot functionality of services or application on the VM.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,10 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
-
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +61,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-corruption.md
@@ -14,7 +14,7 @@ VMware Windows Network Corruption simulates a network corruption scenario on Win
 - VMware Windows Network Corruption simulates the situation of network corruption on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-duplication.md
@@ -14,7 +14,7 @@ VMware Windows Network Duplication simulates a network duplication scenario on W
 - VMware Windows Network Duplication simulates the situation of network duplication on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-latency.md
@@ -14,7 +14,7 @@ VMware Windows Network Latency simulates a network latency scenario on Windows O
 - VMware Windows Network Latency simulates the situation of network latency for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,13 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-network-loss.md
@@ -14,7 +14,7 @@ VMware Windows Network Loss simulates a network loss scenario on Windows OS base
 - VMware Windows Network Loss simulates the situation of network loss for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-process-kill.md
@@ -14,7 +14,7 @@ VMware Windows Process Kill simulates a process kill scenario on Windows OS base
 - VMware Windows Process Kill simulates the situation of process kill for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle process failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -37,14 +37,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +62,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-service-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-service-stop.md
@@ -14,7 +14,7 @@ VMware Windows Service Stop simulates a service stop scenario on Windows OS base
 - VMware Windows Service Stop simulates the situation of service stop for services running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle service failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -68,10 +66,12 @@ stringData:
         <td> For example, <code>service1,service2</code>. For more information, go to <a href="#service-names"> service names. </a> </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-time-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/vmware/vmware-windows-time-chaos.md
@@ -14,7 +14,7 @@ VMware Windows Time Chaos simulates a time skew scenario on Windows OS based VMw
 - VMware Windows Time Chaos simulates the situation of time skew for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle time failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -37,14 +37,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +62,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-blackhole-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-blackhole-chaos.md
@@ -14,7 +14,7 @@ VMware Windows Blackhole Chaos simulates a network blackhole scenario on Windows
 - VMware Windows Blackhole Chaos simulates the situation of network isolation for processes running on the application, which degrades their performance.
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -22,7 +22,7 @@ VMware Windows Blackhole Chaos simulates a network blackhole scenario on Windows
 - Ensure the firewall is active and permissions to modify its rules are granted. Consider using the built-in Administrator user. [Learn how to enable it in Windows](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/enable-and-disable-the-built-in-administrator-account?view=windows-11).
 - The VM should be in a healthy state before and after injecting chaos.
 - Kubernetes secret has to be created that has the Vcenter credentials in the `CHAOS_NAMESPACE`. 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -37,14 +37,10 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
-
-## Fault tunables
-
-   <h3>Mandatory fields</h3>
-    <table>
+### Mandatory tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +60,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-cpu-hog.md
@@ -15,7 +15,7 @@ VMware Windows CPU hog applies stress on the CPU resources on Windows OS based V
 - It also helps verify metrics-based horizontal pod autoscaling as well as vertical autoscale, that is, demand based CPU addition. 
 - It verifies the autopilot functionality of cloud managed clusters.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - Adequate vCenter permissions should be provided to access the hosts and the VMs.
@@ -23,7 +23,7 @@ VMware Windows CPU hog applies stress on the CPU resources on Windows OS based V
 - The VM should be in a healthy state before and after injecting chaos.
 - Kubernetes secret has to be created that has the Vcenter credentials in the `CHAOS_NAMESPACE`.
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable. 
+- VM credentials can be passed as secrets or as a chaos engine environment variable. 
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -63,10 +61,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-disk-stress.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-disk-stress.md
@@ -14,7 +14,7 @@ VMware Windows Disk Stress applies stress on the disk resources on Windows OS ba
 - VMware Windows Disk Stress simulates the situation of high disk usage for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle disk failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -23,7 +23,7 @@ VMware Windows Disk Stress applies stress on the disk resources on Windows OS ba
 - Kubernetes secret has to be created that has the Vcenter credentials in the `CHAOS_NAMESPACE`. 
 - Ensure the installation of [Diskspd](https://learn.microsoft.com/en-us/azure-stack/hci/manage/diskspd-overview#quick-start-install-and-run-diskspd), a critical dependency for this experiment. Refer to the linked documentation for installation guidance.
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -38,14 +38,12 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-memory-hog.md
@@ -14,7 +14,7 @@ VMware Windows Memory hog applies stress on the Memory resources on Windows OS b
 - VMware Windows Memory hog simulates the situation of lack of Memory for processes running on the application, which degrades their performance. 
 - It verifies the autopilot functionality of services or application on the VM.
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -23,7 +23,7 @@ VMware Windows Memory hog applies stress on the Memory resources on Windows OS b
 - Kubernetes secret has to be created that has the Vcenter credentials in the `CHAOS_NAMESPACE`. 
 - Ensure installation of [Testlimit](https://learn.microsoft.com/en-us/sysinternals/downloads/testlimit) on the target VM, a prerequisite for this experiment. Execute the fault using the built-in Administrator user to ensure permissions for memory stress testing. [Instructions to enable the built-in Administrator in Windows](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/enable-and-disable-the-built-in-administrator-account?view=windows-11).
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -38,14 +38,12 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-corruption.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-corruption.md
@@ -14,7 +14,7 @@ VMware Windows Network Corruption simulates a network corruption scenario on Win
 - VMware Windows Network Corruption simulates the situation of network corruption on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -24,7 +24,7 @@ VMware Windows Network Corruption simulates a network corruption scenario on Win
 - Verify [clumsy](https://jagt.github.io/clumsy/download.html) is installed on the VM, as it's essential for this experiment.
 - Run the fault with a user possessing admin rights, preferably the built-in Administrator, to guarantee permissions for memory stress testing. [See how to enable the built-in Administrator in Windows](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/enable-and-disable-the-built-in-administrator-account?view=windows-11).
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+  <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-duplication.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-duplication.md
@@ -14,7 +14,7 @@ VMware Windows Network Duplication simulates a network duplication scenario on W
 - VMware Windows Network Duplication simulates the situation of network duplication on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -24,7 +24,7 @@ VMware Windows Network Duplication simulates a network duplication scenario on W
 - Verify [clumsy](https://jagt.github.io/clumsy/download.html) is installed on the VM, as it's essential for this experiment.
 - Run the fault with a user possessing admin rights, preferably the built-in Administrator, to guarantee permissions for memory stress testing. [See how to enable the built-in Administrator in Windows](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/enable-and-disable-the-built-in-administrator-account?view=windows-11).
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-latency.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-latency.md
@@ -14,7 +14,7 @@ VMware Windows Network Latency simulates a network latency scenario on Windows O
 - VMware Windows Network Latency simulates the situation of network latency for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -24,7 +24,7 @@ VMware Windows Network Latency simulates a network latency scenario on Windows O
 - Verify [clumsy](https://jagt.github.io/clumsy/download.html) is installed on the VM, as it's essential for this experiment.
 - Run the fault with a user possessing admin rights, preferably the built-in Administrator, to guarantee permissions for memory stress testing. [See how to enable the built-in Administrator in Windows](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/enable-and-disable-the-built-in-administrator-account?view=windows-11).
 
-- VM credentials can be passed as secrets or as a chaos enginer environment variable.
+- VM credentials can be passed as secrets or as a chaos engine environment variable.
 
 ```yaml
 apiVersion: v1
@@ -38,14 +38,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -65,10 +63,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-network-loss.md
@@ -14,7 +14,7 @@ VMware Windows Network Loss simulates a network loss scenario on Windows OS base
 - VMware Windows Network Loss simulates the situation of network loss for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle network failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -39,14 +39,12 @@ stringData:
     VCENTERPASS: XXXXXXXXXXXXX
 ```
 
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -66,10 +64,12 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-process-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-process-kill.md
@@ -14,7 +14,7 @@ VMware Windows Process Kill simulates a process kill scenario on Windows OS base
 - VMware Windows Process Kill simulates the situation of process kill for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle process failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -37,14 +37,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +62,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-service-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-service-stop.md
@@ -14,7 +14,7 @@ VMware Windows Service Stop simulates a service stop scenario on Windows OS base
 - VMware Windows Service Stop simulates the situation of service stop for services running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle service failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -36,14 +36,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -68,10 +66,12 @@ stringData:
         <td> For example, <code>service1,service2</code>. For more information, go to <a href="#service-names"> service names.</a> </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-time-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/vmware-windows-time-chaos.md
@@ -14,7 +14,7 @@ VMware Windows Time Chaos simulates a time skew scenario on Windows OS based VMw
 - VMware Windows Time Chaos simulates the situation of time skew for processes running on the application, which degrades their performance. 
 - It also helps verify the application's ability to handle time failures and its failover mechanisms. 
 
-:::note
+### Prerequisites
 - Kubernetes > 1.16 is required to execute this fault.
 - Execution plane should be connected to vCenter and host vCenter on port 443. 
 - VMware tool should be installed on the target VM with remote execution enabled.
@@ -37,14 +37,12 @@ stringData:
     VCENTERUSER: XXXXXXXXXXXXX
     VCENTERPASS: XXXXXXXXXXXXX
 ```
-:::
 
-## Fault tunables
+### Mandatory tunables
 
-   <h3>Mandatory fields</h3>
-    <table>
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -64,10 +62,11 @@ stringData:
           <td> For example, <code>1234</code>. Note: You can take the password from secret as well. </td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
-    <table>
+
+### Optional tunables
+   <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-blackhole-chaos.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-blackhole-chaos.md
@@ -2,7 +2,6 @@
 id: windows-ec2-blackhole-chaos
 title: Windows EC2 blackhole chaos
 ---
-## Introduction
 
 Windows EC2 blackhole chaos results in loss of access to the given target hosts or IPs by injecting firewall rules. This fault:
 - Degrades the network without marking the EC2 instance as unhealthy (or unworthy) of traffic. This can be resolved by using a middleware that switches the traffic based on certain SLOs (performance parameters). 
@@ -14,7 +13,7 @@ Windows EC2 blackhole chaos results in loss of access to the given target hosts 
 
 Windows EC2 blackhole chaos determines the performance of the application (or process) running on the EC2 instances.
 
-:::info note
+### Prerequisites
 - Kubernetes version 1.17 or later is required to execute this fault.
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 instance.
@@ -86,10 +85,9 @@ Here is an example AWS policy to execute the fault.
 }
 ```
 
-## Fault tunables
+### Mandatory tunables
 
-  <h3>Mandatory tunables</h3>
-    <table>
+   <table>
       <tr>
         <th> Tunable </th>
         <th> Description </th>
@@ -111,8 +109,9 @@ Here is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
       </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+### Optional tunables
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-cpu-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-cpu-hog.md
@@ -14,7 +14,7 @@ EC2 windows CPU hog:
 - Simulates the situation of a lack of CPU for processes running on the instance, which degrades their performance. 
 - Simulates slow application traffic or exhaustion of the resources, leading to degradation in the performance of processes on the instance.
 
-:::info note
+### Prerequisites
 - Kubernetes version 1.17 or later is required to execute this fault.
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 instance.
@@ -33,6 +33,8 @@ EC2 windows CPU hog:
         aws_access_key_id = XXXXXXXXXXXXXXXXXXX
         aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
+
+:::info note
 - Harness recommends using the same secret name, that is, `cloud-secret`. Otherwise, you must update the `AWS_SHARED_CREDENTIALS_FILE` environment variable in the fault template and you won't be able to use the default health check probes.
 - Go to [AWS named profile for chaos](../aws/security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 - Go to [superset permission/policy](../aws/security-configurations/policy-for-all-aws-faults.md) to execute all AWS faults.
@@ -88,10 +90,9 @@ Here is an example AWS policy to execute the fault.
 ```
 
 
-## Fault tunables
+### Mandatory tunables
 
-<h3>Mandatory tunables</h3>
-    <table>
+   <table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>
@@ -108,8 +109,10 @@ Here is an example AWS policy to execute the fault.
             <td> For example: <code>us-east-1</code>. </td>
         </tr>
     </table>
-    <h3>Optional tunables</h3>
-    <table>
+
+
+### Optional tunables
+<table>
         <tr>
             <th> Tunable </th>
             <th> Description </th>

--- a/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-memory-hog.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/windows/windows-ec2-memory-hog.md
@@ -16,7 +16,7 @@ Windows EC2 memory hog:
 - Simulates the situation of memory leaks in the deployment of microservices.
 - Simulates application slowness due to memory starvation, and noisy neighbour problems due to hogging.
 
-:::info note
+### Prerequisites
 - Kubernetes version 1.17 or later is required to execute this fault.
 - The EC2 instance must be in a healthy state.
 - SSM agent must be installed and running on the target EC2 Windows instance in the admin mode.
@@ -35,6 +35,8 @@ Windows EC2 memory hog:
         aws_access_key_id = XXXXXXXXXXXXXXXXXXX
         aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
+
+:::info note
 - Harness recommends using the same secret name, that is, `cloud-secret`. Otherwise, you will must update the `AWS_SHARED_CREDENTIALS_FILE` environment variable in the fault template and you won't be able to use the default health check probes.
 - Go to [AWS named profile for chaos](../aws/security-configurations/aws-switch-profile.md) to use a different profile for AWS faults.
 :::
@@ -89,9 +91,8 @@ Here is an example AWS policy to execute the fault.
 ```
 
 
-## Fault tunables
+### Mandatory tunables
 
-<h3>Mandatory tunables</h3>
 <table>
     <tr>
         <th> Tunable </th>
@@ -109,7 +110,8 @@ Here is an example AWS policy to execute the fault.
         <td> For example, <code>us-east-1</code>. </td>
     </tr>
 </table>
-<h3>Optional tunables</h3>
+
+### Optional tunables
 <table>
     <tr>
         <th> Tunable </th>


### PR DESCRIPTION
Remove 'introduction' heading from chaos faults
[Preview](https://65a7a4a750cedd9554b6d49e--harness-developer.netlify.app/docs/chaos-engineering/technical-reference/chaos-faults/)