### PR TITLE
fix: [CDS-88861]: Remove delegate selector overrides info

### DIFF
--- a/docs/platform/delegates/manage-delegates/select-delegates-with-selectors.md
+++ b/docs/platform/delegates/manage-delegates/select-delegates-with-selectors.md
@@ -107,9 +107,6 @@ Delegates can be selected for the connector used in a stage's **Infrastructure**
 
 ![](./static/select-delegates-with-selectors-25.png)
 
-import Selector from '/docs/platform/shared/selector-infrastructure.md'
-
-<Selector />
 
 ### Selecting a delegate for a step using tags
 


### PR DESCRIPTION
# Harness Developer Pull Request

We need to remove this section ``Delegate selectors do not override service infrastructure connectors. Delegate selectors only determine the delegate that executes the operations of your pipeline``

Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screen Shoot. 
