### PR TITLE
GCP faults audit

### DIFF
--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss-by-label.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss-by-label.md
@@ -8,10 +8,12 @@ GCP VM disk loss by label disrupts the state of GCP persistent disk volume filte
 
 ## Use cases
 
-- GCP VM disk loss by label fault can be used to determine the resilience of the GKE infrastructure. It helps determine how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
+GCP VM disk loss by label fault:
+- Determines the resilience of the GKE infrastructure. 
+- Determines how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
 
 ### Prerequisites
-- Kubernetes > 1.16 is required to execute this fault.
+- Kubernetes > 1.16
 - Service account should have editor access (or owner access) to the GCP project.
 - Target disk volume should not be a boot disk of any VM instance.
 - Disk volumes with the target label should be attached to their respective instances.
@@ -90,6 +92,11 @@ stringData:
         <td> RAMP_TIME </td>
         <td> Period to wait before and after injecting chaos (in seconds).</td>
         <td> For example, 30s. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#ramp-time">ramp time. </a></td>
+      </tr>
+      <tr>
+      <td>DEFAULT_HEALTH_CHECK</td>
+      <td>Determines if you wish to run the default health check which is present inside the fault. </td>
+      <td> Default: 'true'. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#default-health-check"> default health check.</a></td>
       </tr>
     </table>
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-disk-loss.md
@@ -8,10 +8,12 @@ GCP VM disk loss disrupts the state of GCP persistent disk volume using the disk
 
 ## Use cases
 
-- GCP VM disk loss fault determines the resilience of the GKE infrastructure. It helps determine how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
+GCP VM disk loss fault :
+- Determines the resilience of the GKE infrastructure. 
+- Determines how quickly a node can recover when a persistent disk volume is detached from the VM instance associated with it.
 
 ### Prerequisites
-- Kubernetes > 1.16 is required to execute this fault.
+- Kubernetes > 1.16
 - Service account should have editor access (or owner access) to the GCP project.
 - Target disk volume should not be a boot disk of any VM instance.
 - Disk volumes with the target label should be attached to their respective instances.
@@ -37,10 +39,10 @@ stringData:
 ```
 
 ## Fault tunables
-  <h3>Mandatory fields</h3>
+  <h3>Mandatory tunables</h3>
     <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -60,10 +62,10 @@ stringData:
         <td> Only one zone is provided, which indicates that all target disks should reside in the same zone. For more information, go to <a href="#detach-volumes-by-names">zones. </a></td>
       </tr>
     </table>
-    <h3>Optional fields</h3>
+    <h3>Optional tunables</h3>
     <table>
       <tr>
-        <th> Variables </th>
+        <th> Tunable </th>
         <th> Description </th>
         <th> Notes </th>
       </tr>
@@ -86,6 +88,11 @@ stringData:
         <td> RAMP_TIME </td>
         <td> Period to wait before and after injecting chaos (in seconds).</td>
         <td> For example, 30s. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#ramp-time">ramp time.</a></td>
+      </tr>
+      <tr>
+      <td>DEFAULT_HEALTH_CHECK</td>
+      <td>Determines if you wish to run the default health check which is present inside the fault. </td>
+      <td> Default: 'true'. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#default-health-check"> default health check.</a></td>
       </tr>
     </table>
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop-by-label.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop-by-label.md
@@ -8,10 +8,10 @@ GCP VM instance stop by label powers off from the GCP VM instances (filtered by 
 
 ## Use cases
 
-- GCP VM instance stop by label fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
+GCP VM instance stop by label fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
 
 ### Prerequisites
-- Kubernetes > 1.16 is required to execute this fault.
+- Kubernetes > 1.16
 - Adequate GCP permissions to stop and start the GCP VM instances.
 - The VM instances with the target label should be in a healthy state.
 - Kubernetes secret should have the GCP service account credentials in the default namespace. Refer [generate the necessary credentials in order to authenticate your identity with the Google Cloud Platform (GCP)](/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp) docs for more information.
@@ -95,6 +95,11 @@ stringData:
         <td> RAMP_TIME </td>
         <td> Period to wait before and after injecting chaos (in seconds). </td>
         <td> For example, 30s. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#ramp-time">ramp time.</a></td>
+      </tr>
+      <tr>
+      <td>DEFAULT_HEALTH_CHECK</td>
+      <td>Determines if you wish to run the default health check which is present inside the fault. </td>
+      <td> Default: 'true'. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#default-health-check"> default health check.</a></td>
       </tr>
     </table> 
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-instance-stop.md
@@ -10,10 +10,10 @@ GCP VM instance stop powers off from a GCP VM instance using the instance name (
 
 ## Use cases
 
-- GCP VM instance stop fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
+GCP VM instance stop fault determines the resilience of an application that runs on a VM instance when a VM instance unexpectedly stops (or fails).
 
 ### Prerequisites
-- Kubernetes > 1.16 is required to execute this fault.
+- Kubernetes > 1.16
 - Adequate GCP permissions to stop and start the GCP VM instances.
 - The VM instances should be in a healthy state.
 - Kubernetes secret should have the GCP service account credentials in the default namespace. Refer [generate the necessary credentials in order to authenticate your identity with the Google Cloud Platform (GCP)](/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp) docs for more information.
@@ -92,6 +92,10 @@ stringData:
         <td> RAMP_TIME </td>
         <td> Period to wait before and after injecting chaos (in seconds). </td>
         <td> For example, 30s. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#ramp-time">ramp time.</a></td>
+      </tr><tr>
+      <td>DEFAULT_HEALTH_CHECK</td>
+      <td>Determines if you wish to run the default health check which is present inside the fault. </td>
+      <td> Default: 'true'. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#default-health-check"> default health check.</a></td>
       </tr>
     </table>
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-service-kill.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/gcp-vm-service-kill.md
@@ -9,7 +9,7 @@ GCP VM service kill fault stops a given service for specified duration. As a con
 ![GCP VM service service kill](./static/images/gcp-vm-service-kill.png)
 
 ## Use cases
-The GCP VM service kill fault assesses a GKE node's resilience by evaluating the service operating on it.
+GCP VM service kill fault assesses a GKE node's resilience by evaluating the service operating on it.
 
 ### Prerequisites
 - Kubernetes > 1.23
@@ -94,6 +94,11 @@ stringData:
         <td> RAMP_TIME </td>
         <td> Period to wait before injecting chaos (in seconds). </td>
         <td> For example, 30 s. For more information, go to <a href = "/docs/chaos-engineering/technical-reference/chaos-faults/common-tunables-for-all-faults/#ramp-time">ramp time.</a></td>
+      </tr>
+      <tr>
+      <td>DEFAULT_HEALTH_CHECK</td>
+      <td>Determines if you wish to run the default health check which is present inside the fault. </td>
+      <td> Default: 'true'. For more information, go to <a href="../../chaos-faults/common-tunables-for-all-faults#default-health-check"> default health check.</a></td>
       </tr>
     </table>
 

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/_category_.json
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/_category_.json
@@ -1,0 +1,13 @@
+{
+  "position": 1,
+  "label": "Security configuration",
+  "collapsible": true,
+  "collapsed": true,
+  "link":{
+      "type":"generated-index",
+      "title":"Security configuration"
+   },
+  "customProps": {
+    "description": "Security configurations required to execute GCP chaos experiments"  
+}
+}

--- a/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp.md
+++ b/docs/chaos-engineering/technical-reference/chaos-faults/gcp/security-configurations/prepare-secret-for-gcp.md
@@ -1,8 +1,13 @@
-# Create a secret for GCP experiments
+---
+title: Creating secrets for GCP experiments
+---
 
-You must create a service account to derive the authentication secret to run experiments on GCP.
+This section describes the steps you can follow to create a secret to execute GCP chaos experiments. 
 
-To create the service account and secret:
+
+### Step 1: Create a service account
+
+Create a service account to derive the authentication secret to run experiments on GCP. To create the service account and secret:
 
 1. Set your current project. Replace &lt;project-id&gt; with your project ID:
 
@@ -15,17 +20,18 @@ To create the service account and secret:
   ```bash
   gcloud iam service-accounts create <service-account-name>
   ```
+### Step 2: Generate new JSON key file
 
-3. After the service account is created, you can generate a new JSON key file. Replace &lt;service-account-name&gt; with the name of your service account and &lt;key-file&gt; with the path where you want to save the key file:
+3. After you create a new service account, generate a new JSON key file. Replace &lt;service-account-name&gt; with the name of your service account and &lt;key-file&gt; with the path where you want to save the key file:
 
   ```bash
   gcloud iam service-accounts keys create <key-file> \
   --iam-account <service-account-name>@<project-id>.iam.gserviceaccount.com
   ```
 
-  The generated JSON key file will contain the fields you mentioned, and it looks something like this:
+The generated JSON key file will contain the fields you mentioned, and it looks something like this:
 
-  ```json
+```json
   {
       "type": "service_account",
       "project_id": "<project-id>",
@@ -38,10 +44,12 @@ To create the service account and secret:
       "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<service-account-name>%40<project-id>.iam.gserviceaccount.com"
   }
-  ```
-4. Prepare the secret YAML based on this JSON:
+```
 
-  ```yaml
+### Step 3: Prepare the secret YAML
+4. Based on the JSON key file you created earlier, prepare the secret YAML:
+
+```yaml
   apiVersion: v1
   kind: Secret
   metadata:
@@ -58,13 +66,14 @@ To create the service account and secret:
     token_uri: "<token-uri>"
     auth_provider_x509_cert_url: "<auth-provider-x509-cert-url>"
     client_x509_cert_url: "<client-x509-cert-url>"
-  ```
+```
 
-  :::warning
-  Newline (\n) characters within the private key are crucial. Avoid using double quotes to prevent their loss.
-  :::
+:::warning
+Newline (\n) characters within the private key are crucial. Avoid using double quotes to prevent their loss.
+:::
 
-5. Create the secret YAML file in the chaos infra namespace using the command:
+### Step 4: Apply the secret YAML in desired namespace
+5. Apply the secret YAML file you created earlier in the chaos infrastructure namespace using the command:
 
   ```bash
   kubectl apply -f secret.yaml -n <CHAOS-NAMESPACE>


### PR DESCRIPTION
`default_health_check` env variable added
Doc review of security consideration
Variables-> Tunables
[Preview](https://65ae5fbf7f607731c6dc0880--harness-developer.netlify.app/docs/chaos-engineering/technical-reference/chaos-faults/gcp/)