### PR TITLE
Add Secrets to Supported Categories and Supported Scanners STO-7048

### DIFF
--- a/docs/security-testing-orchestration/get-started/shared/_supported-versions-and-data-formats.md
+++ b/docs/security-testing-orchestration/get-started/shared/_supported-versions-and-data-formats.md
@@ -1,3 +1,0 @@
-The following list shows the supported versions and data formats of . 
-
-This topic was last updated on: document.lastModified 

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-categories.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-categories.md
@@ -2,5 +2,6 @@ The following list shows the scan types that STO supports:
 
 * **SAST (Static Application Security Testing)** scans a code repository and identifies known vulnerabilities in open-source and proprietary code.
 * **SCA (Software Composition Analysis)** scans a code repository and identifies known vulnerabilities in open-source libraries and packages used by the code. 
+* **Secret Scanning** scans a code repository and identifies all secrets such as access keys and passwords.
 * **DAST (Dynamic Application Security Testing)** scans a running application for vulnerabilties by simulating a malicious external actor exploiting known vulnerabilties. 
 * **Container Scanning** identifies vulnerabilities in container images.

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -61,7 +61,17 @@ If you use a scanner that isn't listed in the following table, you can still ing
         	</ul>
      </td>
    </tr>
-    <tr>
+   <tr>
+        <td valign="top">Secrets</td>
+        <td valign="top">
+         	<ul>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>
+        	</ul>
+        </td>
+        <td>
+        </td>
+   </tr>
+   <tr>
         <td valign="top">DAST</td>
         <td valign="top">
          	<ul>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_supported-infrastructures.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_supported-infrastructures.md
@@ -1,0 +1,44 @@
+STO uses [CI build infrastructures](/docs/continuous-integration/use-ci/set-up-build-infrastructure/which-build-infrastructure-is-right-for-me.md) to orchestrate scans and ingest issues. The following table shows STO support for each infrastructure type.
+
+<table>
+    <tr>
+        <th>Operating System</th>
+        <th>Architecture</th>
+        <th>Harness Cloud</th>
+        <th>Self-hosted local runner</th>
+        <th>Self-hosted Cloud provider VMs</th>
+        <th>Self-hosted Kubernetes cluster</th>
+    </tr>
+    <tr>
+        <td>Linux</td>
+        <td>amd64</td>
+        <td align="left">✅ Supported</td>
+        <td align="left">✅ Supported</td>
+        <td align="left">✅ Supported</td>
+        <td align="left">✅ Supported</td>
+    </tr>
+    <tr>
+        <td>Linux</td>
+        <td>arm64</td>
+        <td align="center">❌ Not supported</td>
+        <td align="center">❌ Not supported</td>
+        <td align="center">❌ Not supported</td>
+        <td align="center">❌ Not supported</td>
+    </tr>
+    <tr>
+        <td>Windows</td>
+        <td>amd64</td>
+        <td align="center">Roadmap</td>
+        <td align="center">❌ Not supported</td>
+        <td align="center">Roadmap</td>
+        <td align="center">❌ Not supported</td>
+    </tr>
+    <tr>
+        <td>MacOS</td>
+        <td>arm64</td>
+        <td align="center">Roadmap</td>
+        <td align="center">Roadmap</td>
+        <td align="center">Roadmap</td>
+        <td align="center">❌ Not supported</td>
+    </tr>
+</table>


### PR DESCRIPTION
Updated sections:
- [Scanner categories supported by STO](https://65b05ec65d5cce1ae0db92d1--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference/#scanner-categories-supported-by-sto)
- [Scanners supported by STO](https://65b05ec65d5cce1ae0db92d1--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference/#scanners-supported-by-sto)