### PR TITLE
[PL-46234] Update SMP external cloud-based MongoDB tutorial for TLS support for 0.13.0

### DIFF
--- a/tutorials/self-managed-enterprise-edition/use-an-external-mongodb-database.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-mongodb-database.md
@@ -99,7 +99,7 @@ platform:
 
 ## TLS support
 
-TLS is supported with MongoDB Atlas using the `mongodb+srv` protocol. No additional change is required in the `override.yaml` file to enable TLS for MongoDB Atlas.
+TLS is supported for Harness Self-Managed Enterprise Edition 0.13.0 or later with MongoDB Atlas using the `mongodb+srv` protocol. No additional change is required in the `override.yaml` file to enable TLS for MongoDB Atlas.
 
 ## FAQs
 

--- a/tutorials/self-managed-enterprise-edition/use-an-external-mongodb-database.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-mongodb-database.md
@@ -97,6 +97,10 @@ platform:
       enabled: false
 ```
 
+## TLS support
+
+TLS is supported with MongoDB Atlas using the `mongodb+srv` protocol. No additional change is required in the `override.yaml` file to enable TLS for MongoDB Atlas.
+
 ## FAQs
 
 ### How do I resolve an out of sync issue?

--- a/tutorials/self-managed-enterprise-edition/use-an-external-self-managed-mongodb.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-self-managed-mongodb.md
@@ -268,6 +268,8 @@ To set up a MongoDB VM, do the following:
     helm install my-release harness/harness -n <namespace> -f override.yaml
     ```
 
+<!-- 
 ## TLS support
 
 TLS is supported with MongoDB Atlas using the `mongodb+srv` protocol. No additional change is required in the `override.yaml` file to enable TLS for MongoDB Atlas.
+-->

--- a/tutorials/self-managed-enterprise-edition/use-an-external-self-managed-mongodb.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-self-managed-mongodb.md
@@ -267,3 +267,7 @@ To set up a MongoDB VM, do the following:
     ```
     helm install my-release harness/harness -n <namespace> -f override.yaml
     ```
+
+## TLS support
+
+TLS is supported with MongoDB Atlas using the `mongodb+srv` protocol. No additional change is required in the `override.yaml` file to enable TLS for MongoDB Atlas.

--- a/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
@@ -59,7 +59,7 @@ In the event of controller node failure, a standby node can be promoted as the n
 
 For more information, go to [Streaming replication](https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION) and [Write-ahead logging](https://www.postgresql.org/docs/current/wal-intro.html) in the PostgreSQL documentation.
 
-### High availability
+## High availability
 
 To create a highly-available setup, there will be a DNS record that always points to the primary node of your TimescaleDB replication setup. You can use service discovery with a third-party tool (etcd/Consul/Zookeeper) to track your current primary node's IP address and health status.
 
@@ -532,6 +532,33 @@ To recover the former primary and add host replication, do the following.
    ```
 
    The former primary instance is now a new secondary instance.
+
+## TLS support
+
+You can enable TLS for TimescaleDB.
+
+To enable TLS, do the following:
+
+1. Save the ca certificate in the `server_ca.cer` file.
+
+2. Run the following command to create the secret in Kubernetes. 
+
+   ```
+   kubectl create secret generic timescale-client-tls --from-file ca.crt=server-ca.cer -n <YOUR_NAMESPACE>
+   ```
+
+3. Make the following changes to your `override.yaml` file.
+
+   ```yaml
+   global:
+     database:
+       timescaledb:
+         sslEnabled: true
+         certName: "timescale-client-tls"
+         certKey: "ca.crt"
+   ```
+
+4. Upgrade Harness with your updated `override.yaml` file.
 
 ## Upgrade TimescaleDB
 

--- a/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
+++ b/tutorials/self-managed-enterprise-edition/use-an-external-sm-timescaledb.md
@@ -533,6 +533,7 @@ To recover the former primary and add host replication, do the following.
 
    The former primary instance is now a new secondary instance.
 
+<!-- 
 ## TLS support
 
 You can enable TLS for TimescaleDB.
@@ -559,6 +560,7 @@ To enable TLS, do the following:
    ```
 
 4. Upgrade Harness with your updated `override.yaml` file.
+-->
 
 ## Upgrade TimescaleDB
 

--- a/tutorials/self-managed-enterprise-edition/use-self-managed-minio-object-storage.md
+++ b/tutorials/self-managed-enterprise-edition/use-self-managed-minio-object-storage.md
@@ -9,11 +9,11 @@ Harness Self-Managed Enterprise Edition enables you to configure self-managed ob
 
 You can install MinIO on your preferred VMs and provide the endpoint in your Harness Helm charts. This topic describes how to set up 4 MinIO servers.
 
-### MinIO prerequisites
+## MinIO prerequisites
 
 Make sure to meet the MinIO prerequisites before you set up self-managed object storage. For prerequisites, go to [Object Storage for Linux](https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#prerequisites) in the MinIO documentation.
 
-### MinIO hardware requirements
+## MinIO hardware requirements
 
 - 4 VMs
 - 4 cores per VM
@@ -22,7 +22,7 @@ Make sure to meet the MinIO prerequisites before you set up self-managed object 
 - 1GB/s minimum network bandwidth
 - Ubuntu 20.04 LTS operating system
 
-### Nginx hardware requirements
+## Nginx hardware requirements
 
 - 1 VM
 - 4 cores per VM
@@ -34,7 +34,17 @@ import Strongpass from '/tutorials/shared/strong-passwords.md'
 
 <Strongpass />
 
-### Create an Nginx LoadBalancer VM
+## TLS support
+
+### MinIO Google bucket
+
+TLS is supported for GCS buckets without any additional configuration changes over the `https` protocol.
+
+#### MinIO AWS S3 bucket
+
+TLS is supported for AWS S3 buckets without any additional configuration changes over the `https` protocol.
+
+## Create an Nginx LoadBalancer VM
 
 To set up MinIO, you must first create a VM for the Nginx LoadBalancer with the above hardware requirements.
 
@@ -48,7 +58,7 @@ To create a new VM instance for the Nginx load balancer, do the following:
 
 4. Reserve an external static IP address.
 
-### Create the MinIO server VMs
+## Create the MinIO server VMs
 
 Next, you must create 4 VMs with the MinIO hardware requirements.
 
@@ -64,7 +74,7 @@ To create the MinIO server VMs, do the following:
 
 5. Attach an additional disk to the VM.
 
-### Set up the Nginx load balancer
+## Set up the Nginx load balancer
 
 Next, set up the Nginx load balancer.
 
@@ -160,7 +170,7 @@ To set up the Nginx load balancer, do the following:
    nginx sudo nginx -s reload
    ```
 
-### Set up MinIO servers
+## Set up MinIO servers
 
 Now you are ready to set up your MinIO servers.
 
@@ -274,7 +284,7 @@ To configure your MinIO servers, do the following:
 
 12. Repeat the process for your other three VMs.
    
-### Test MinIO connectivity
+## Test MinIO connectivity
 
 To test your MinIO connectivity, do the following:
 
@@ -286,7 +296,7 @@ To test your MinIO connectivity, do the following:
 
 4. Check the contents in the `/mnt/disks/disk1/` disk.
 
-### Configure your Harness environment and Helm chart
+## Configure your Harness environment and Helm chart
 
 Now you're ready to configure your Harness Self-Managed Enterprise Edition environment and Helm chart.
 

--- a/tutorials/self-managed-enterprise-edition/use-self-managed-minio-object-storage.md
+++ b/tutorials/self-managed-enterprise-edition/use-self-managed-minio-object-storage.md
@@ -34,6 +34,7 @@ import Strongpass from '/tutorials/shared/strong-passwords.md'
 
 <Strongpass />
 
+<!-- 
 ## TLS support
 
 ### MinIO Google bucket
@@ -43,6 +44,7 @@ TLS is supported for GCS buckets without any additional configuration changes ov
 #### MinIO AWS S3 bucket
 
 TLS is supported for AWS S3 buckets without any additional configuration changes over the `https` protocol.
+-->
 
 ## Create an Nginx LoadBalancer VM
 


### PR DESCRIPTION
Update SMP external db tutorials for TLS support for 0.13.0

For reviewers, a preview is available:

[External cloud-based MongoDB](https://65b12f7da64cb61cbb6e29f8--harness-developer.netlify.app/tutorials/self-managed-enterprise-edition/use-an-external-mongodb-database)

## What Type of PR is This?

- [ ] Issue
- [x] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screen Shoot. 
