### PR TITLE
chore: [CHAOS-4175]: Doc Tasks for CHAOS-4167 - Add bearer token Auth support to prometheus probe

### DIFF
--- a/docs/chaos-engineering/technical-reference/probes/prom-probe.md
+++ b/docs/chaos-engineering/technical-reference/probes/prom-probe.md
@@ -126,6 +126,7 @@ Listed below is the probe schema for the Prometheus probe, with properties share
     <td>The <code>value</code> contains value of the comparison, which should follow the given criteria as part of comparison operation.</td>
   </tr>
 </table>
+
 ### Authentication
 
 This establishes a fundamental authentication mechanism for the Prometheus server. The "username:password", encoded in base64, should be placed either within the `credentials` field or as a file path in the `credentialsFile` field.
@@ -143,18 +144,25 @@ The `credentials` and `credentialsFile` are two options that can't be used simul
    <td><strong>Notes</strong> </td>
   </tr>
   <tr>
-   <td>credentials </td>
-   <td>Flag to hold the basic auth credentials in base64 format </td>
+   <td>type </td>
+   <td>Flag to hold the authentication type </td>
    <td>Optional </td>
    <td><code>string</code> </td>
-   <td>The <code>credentials</code> comprises the Prometheus server's basic authentication credentials in the form of username:password, encoded using base64 format </td>
+   <td>The <code>type</code> encompasses the authentication method, which includes support for both Basic and Bearer authentication types </td>
+  </tr>
+  <tr>
+   <td>credentials </td>
+   <td>Flag to hold the basic auth credentials in base64 format or bearer token </td>
+   <td>Optional </td>
+   <td><code>string</code> </td>
+   <td>The <code>credentials</code> consists of the basic authentication credentials, either as username:password encoded in base64 format or as a bearer token, depending on the authentication type </td>
   </tr>
   <tr>
    <td> credentialsFile </td>
-   <td>Flag to hold the basic auth credentials file path </td>
+   <td>Flag to hold the basic auth credentials or bearer token file path </td>
    <td>Optional </td>
    <td><code>string</code> </td>
-   <td>The <code>credentials</code> encompasses the filepath for basic authentication credentials, which are mounted to the experiment pod as volume secrets. These secrets consist of username:password encoded in base64 format for the Prometheus server </td>
+   <td>The <code>credentials</code> consists of file path for basic authentication credentials or a bearer token, which are then attached to the experiment pod as volume secrets. These secret resources contain either the username:password encoded in base64 format or a bearer token, depending on the authentication type </td>
   </tr>
 </table>
 
@@ -378,7 +386,7 @@ spec:
 
 ### Authentication
 
-This establishes a fundamental authentication mechanism for the Prometheus server. The "username:password" encoded in base64, should be placed either within the `credentials` field or as a file path in the `credentialsFile` field.
+This establishes a fundamental authentication mechanism for the Prometheus server. The "username:password" encoded in base64 or bearer token, should be placed either within the `credentials` field or as a file path in the `credentialsFile` field.
 
 :::tip
 The `credentials` and `credentialsFile` are two options that can't be used simultaneously.
@@ -416,6 +424,7 @@ spec:
             # expected value, which should follow the specified criteria
             value: "0"
           auth:
+            type: Basic
             credentials: "base64(<username:password>)"
         mode: "Edge"
         runProperties:


### PR DESCRIPTION
[Prometheus probe](https://65c8ff0c0d7890420fd598f9--harness-developer.netlify.app/docs/chaos-engineering/technical-reference/probes/prom-probe)