### PR TITLE
Update ingest_tool_severity support info for Snyk STO-7109

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference.md
@@ -170,18 +170,19 @@ import StoSettingFailOnSeverity from '../shared/step_palette/all/_fail-on-severi
 
 ### Settings+-
 
-
 You can use this field to run the Snyk scan with additional options. 
+
+
 
 ### Show original CVSS scores overridden by Snyk security policies 
 
-You can configure a Snyk step to show the original score when a Snyk Enterprise security policy overrode the CVSS score for an issue. You can see this information in **Issue Details**:   
+You can now configure a Snyk step to show the original score when a [Snyk Enterprise security policy](https://docs.snyk.io/enterprise-configuration/policies/security-policies) overrode the severity for an issue coming from the `snyk` CLI. You can see this information in **Issue Details**.   
 
-  ![Security override in Security Tests](../static/sto-7041-override-in-security-tests.png)
+![Security override in Security Tests](../static/sto-7041-override-in-security-tests.png)
 
-  This feature is supported for `snyk container` and `snyk test` scans only.
+This feature is supported for `snyk container` and `snyk test` JSON output that properly reflects an override.
   
-  To enable this behavior, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. With this setting enabled, the Snyk step processes the relevant data for issues with overridden severities. 
+To enable this behavior, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. With this setting enabled, the Snyk step processes the relevant data for issues with overridden severities. 
 
   <Tabs>
      <TabItem value="Visual" label="Visual" default>

--- a/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference.md
@@ -168,17 +168,20 @@ import StoSettingFailOnSeverity from '../shared/step_palette/all/_fail-on-severi
 <StoSettingFailOnSeverity />
 
 
-### Settings
+### Settings+-
+
 
 You can use this field to run the Snyk scan with additional options. 
 
 ### Show original CVSS scores overridden by Snyk security policies 
 
-You can configure the Snyk step to show the original score when a Snyk security policy overrode the CVSS score for an issue.
+You can configure a Snyk step to show the original score when a Snyk Enterprise security policy overrode the CVSS score for an issue. You can see this information in **Issue Details**:   
 
   ![Security override in Security Tests](../static/sto-7041-override-in-security-tests.png)
 
-  To enable this behavior, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. This behavior occurs only for Snyk scans that ran with this setting enabled, and only for issues where the score was overridden due to a Snyk policy.  
+  This feature is supported for `snyk container` and `snyk test` scans only.
+  
+  To enable this behavior, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. With this setting enabled, the Snyk step processes the relevant data for issues with overridden severities. 
 
   <Tabs>
      <TabItem value="Visual" label="Visual" default>

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -31,11 +31,13 @@ These release notes describe recent changes to Harness Security Testing Orchestr
 
 #### Enhancements
 
-- **Security Tests** now shows the original score when a Snyk security policy overrode the CVSS score for an issue. (STO-7041)
+- You can now configure a Snyk step to show the original score when a Snyk Enterprise security policy overrode the CVSS score for an issue. You can see this information in **Issue Details**.  (STO-7041)
 
   ![Security override in Security Tests](../docs/security-testing-orchestration/sto-techref-category/static/sto-7041-override-in-security-tests.png)
 
-  To enable this behavior, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. This behavior occurs only for Snyk scans that ran with this setting enabled, and only for issues where the score was overridden due to a Snyk policy.  
+  This feature is supported for `snyk container` and `snyk test` scans only. 
+  
+  To enable this feature, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. With this setting enabled, the Snyk step ingests and processes the relevant data for issues with overridden severities.   
 
   <Tabs>
      <TabItem value="Visual" label="Visual" default>

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -31,11 +31,11 @@ These release notes describe recent changes to Harness Security Testing Orchestr
 
 #### Enhancements
 
-- You can now configure a Snyk step to show the original score when a Snyk Enterprise security policy overrode the CVSS score for an issue. You can see this information in **Issue Details**.  (STO-7041)
+- You can now configure a Snyk step to show the original score when a [Snyk Enterprise security policy](https://docs.snyk.io/enterprise-configuration/policies/security-policies) overrode the severity for an issue coming from the `snyk` CLI. You can see this information in **Issue Details**.  (STO-7041)
 
   ![Security override in Security Tests](../docs/security-testing-orchestration/sto-techref-category/static/sto-7041-override-in-security-tests.png)
 
-  This feature is supported for `snyk container` and `snyk test` scans only. 
+  This feature is supported for `snyk container` and `snyk test` JSON output that properly reflects an override. 
   
   To enable this feature, add the setting `ingest_tool_severity` and set it to `true` in the Snyk ingestion step. With this setting enabled, the Snyk step ingests and processes the relevant data for issues with overridden severities.   
 


### PR DESCRIPTION
Essentially the same content in both places:
- Release Notes: [Version 1.83.1](https://65cbabfba7908600ad4908f7--harness-developer.netlify.app/release-notes/security-testing-orchestration#version-1831)
- [Show original CVSS scores overridden by Snyk security policies](https://65cbabfba7908600ad4908f7--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference#show-original-cvss-scores-overridden-by-snyk-security-policies)