### PR TITLE
[PL-47785] Add minikube windows install link, clarify variable info for UI vs CLI delegate installs

### DIFF
--- a/docs/platform/delegates/install-delegates/install-delegate.md
+++ b/docs/platform/delegates/install-delegates/install-delegate.md
@@ -45,6 +45,12 @@ https://app.harness.io/ng/#/account/6_vVHzo9Qeu9fXvj-AcQCb/settings/overview
 
 `6_vVHzo9Qeu9fXvj-AcQCb` is the `accountId`. 
 
+:::info note
+
+When you install a delegate via the Harness UI, several dependencies in this topic are prefilled for your convenience. This topic explains where to find the required information for CLI-based installation.
+
+:::
+
 For more information, go to [View account info and subscribe to downtime alerts](/docs/platform/get-started/view-account-info-and-subscribe-to-alerts).
 
 <Tabs>
@@ -58,19 +64,24 @@ Ensure that you have access to a Kubernetes cluster. For the purposes of this tu
 
 - On Windows
 
-```
-choco install minikube
-```
+   ```
+   choco install minikube
+   ```
+
+   For additional options to install minikube on Windows, go to [minikube start](https://minikube.sigs.k8s.io/docs/start/) in the minikube documentation.
 
 - On macOS:
 
-```
-brew install minikube
-```
+   ```
+   brew install minikube
+   ```
+
 Now start minikube with the following config.
-```
-minikube start --memory 4g --cpus 4
-```
+
+   ```
+   minikube start --memory 4g --cpus 4
+   ```
+
 Validate that you have kubectl access to your cluster.
 
 ```

--- a/docs/platform/delegates/install-delegates/install-delegate.md
+++ b/docs/platform/delegates/install-delegates/install-delegate.md
@@ -67,14 +67,22 @@ Ensure that you have access to a Kubernetes cluster. For the purposes of this tu
    ```
    choco install minikube
    ```
-
+   
+   :::info
+   For Chocolatey installation instructions, go to [Installing Chocolatey](https://chocolatey.org/install) in the Chocolatey documentation.
+   
    For additional options to install minikube on Windows, go to [minikube start](https://minikube.sigs.k8s.io/docs/start/) in the minikube documentation.
+   :::
 
 - On macOS:
 
    ```
    brew install minikube
    ```
+
+   :::info
+   For Homebrew installation instructions, go to [Installation](https://docs.brew.sh/Installation) in the Homebrew documentation.
+   :::
 
 Now start minikube with the following config.
 


### PR DESCRIPTION
Update based on GTM Slack feedback. 

Add minikube windows install link, clarify variable info for UI vs CLI delegate installs

For reviewers, a preview is available:

[Install Harness Delegate on Kubernetes or Docker](https://65de52a4bb7acd465144b013--harness-developer.netlify.app/docs/platform/delegates/install-delegates/install-delegate)

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screenshot. 
