### PR TITLE
certs management ff

### DIFF
--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -431,7 +431,7 @@ To help identify pods that aren't cleaned up after a build, pod deletion logs in
 
 ### Can I mount internal CA certs on the CI build pod?
 
-Yes. With a Kubernetes cluster build infrastructure, you can make the certs available to the delegate pod, and then set `DESTINATION_CA_PATH`. For `DESTINATION_CA_PATH`, provide a list of paths in the build pod where you want the certs to be mounted, and mount your certificate files to `opt/harness-delegate/ca-bundle`. For more information, go to [Configure a Kubernetes build farm to use self-signed certificates](https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates).
+Yes. To do this with a Kubernetes cluster build infrastructure, go to [Configure a Kubernetes build farm to use self-signed certificates](https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates).
 
 ### Can I use self-signed certs with local runner build infrastructure?
 


### PR DESCRIPTION
https://65de2ab9e5606722554d9ada--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates

[Enable self-signed certificates - Default flow](https://65de2ab9e5606722554d9ada--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates#:~:text=default%20certificates%20beta%20feature.%20This%20feature%20automatically%20mounts%20certificates%20for%20out%2Dof%2Dthe%2Dbox%20step%20containers%2C%20and%20you%20no%20longer%20need%20to%20declare%20the%20certs%20path%20for%20the%20built%2Din%20steps%20in%20addition%20to)

[Enable self-signed certificates - Self-hosted registry - DESTINATION_CA_PATH](https://65de2ab9e5606722554d9ada--harness-developer.netlify.app/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates#:~:text=out%2Dof%2Dthe%2Dbox%20step%20containers%20even%20if%20they%20are%20not%20specified%20in%20DESTINATION_CA_PATH.%20With%20this%20feature%2C%20you%20no%20longer%20need%20to%20declare%20the%20certs%20path%20for%20the%20built%2Din%20steps%20in%20addition%20to%20your%20own%20self%2Dsigned%20certificates)