### PR TITLE
Update pipeline-retry-api.md

### DIFF
--- a/kb/continuous-delivery/articles/pipeline-retry-api.md
+++ b/kb/continuous-delivery/articles/pipeline-retry-api.md
@@ -2,29 +2,24 @@
 description: KB - Using API to retry pipleine with input set YAML
 title: Pipeline retry API
 ---
-# Introduction
 
 This knowledge base article provides step-by-step guidance on how to retry a pipeline based on the latest ExecutionId using Harness APIs.
 
-# Problem Statement
+## Problem
 
-Retrying a pipeline based on the latest ExecutionId can be a challenging task, especially when dealing with complex deployment scenarios. Retrying a pipeline with input set requires to use two API's : 
+Retrying a pipeline based on the latest ExecutionId can be a challenging task, especially when dealing with complex deployment scenarios. Retrying a pipeline with an input set requires two endpoints: 
 
-1. [API](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2) to get the inputset YAML used in the execution
-2. [API](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2)to retry the pipeline with input set YAML fetched from first API
+* Pipeline Execution Details API - [Get the inputSet YAML used for a given Plan Execution endpoint](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2)
+* Pipeline Execute API - [Retry an executed pipeline with inputSet pipeline YAML endpoint](https://apidocs.harness.io/tag/Pipeline-Execute/#operation/retryPipeline)
 
-# Solution
+## Solution
 
-First we will need the Api to get the the Input Set YAML used for given Plan Execution.
-[API](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2)
+1. Use the [Pipeline Execution Details API](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2) to get the the inputSet YAML used for the Plan Execution that you want to retry.
+2. Use the [Pipeline Execute API](https://apidocs.harness.io/tag/Pipeline-Execute/#operation/retryPipeline) to retry the pipeline with the inputSet pipeline YAML.
 
-2: Then use the Retry a executed pipeline with inputSet pipeline yaml Api to retry.
-[API](https://apidocs.harness.io/tag/Pipeline-Execution-Details/#operation/getInputsetYamlV2)
+Here is a Shell script that uses these two endpoints. To use this Shell script for yourself, replace placeholders, like `ExecutionId`, `YOUR_API_TOKEN`, `YOUR_APPLICATION_ID`, and `YOUR_PIPELINE_ID`, with actual values relevant to your Harness account.
 
-
-Here is an Shellscript example of how you can achieve it :
-
-```
+```sh
 microdnf install jq
 API_KEY=""
 PLAN_EXECUTION_ID=""
@@ -33,12 +28,16 @@ ORG_IDENTIFIER=""
 PROJECT_IDENTIFIER=""
 PipelineIdentifier=""
 Retrystages=""
+
 # API endpoint URL
 URL="https://app.harness.io/pipeline/api/pipelines/execution/${PLAN_EXECUTION_ID}/inputsetV2?accountIdentifier=${ACCOUNT_IDENTIFIER}&orgIdentifier=${ORG_IDENTIFIER}&projectIdentifier=${PROJECT_IDENTIFIER}&resolveExpressions=false&resolveExpressionsType=RESOLVE_ALL_EXPRESSIONS"
+
 # Capture the output of the curl command into the output variable
 output=$(curl -s -X GET "$URL" -H "x-api-key: $API_KEY" -H 'Content-Type: application/yaml')
+
 # Extract inputSetTemplateYaml using jq
 inputSetYaml=$(echo "$output" | jq -r '.data.inputSetYaml')
+
 # Store the inputSetTemplateYaml in a variable
 inputSetYaml1=$(echo "$inputSetYaml" | sed 's/\\n/\n/g')
 echo "$inputSetYaml1"
@@ -51,9 +50,4 @@ curl -i -X POST \
   --data-binary @- <<EOF
 $inputSetYaml1
 EOF
-
 ```
-
-Replace placeholders like ExecutionId, YOUR_API_TOKEN, YOUR_APPLICATION_ID, and YOUR_PIPELINE_ID with actual values relevant to your Harness setup.
-
-This script retrieves the Input Template YAML using the Harness API and then retries the desired pipeline with the extracted YAML.


### PR DESCRIPTION
Style/grammar/fix links

Per code review comments left on PR #5612 


Incorrect heading levels overwrites `title`: 
![image](https://github.com/harness/developer-hub/assets/36110273/df7b9836-ca14-449a-8541-4e3b28b3e761)

These two links went to the same endpoint, when the shell script example uses 2 different endpoints:
![image](https://github.com/harness/developer-hub/assets/36110273/fea22316-0231-46f7-b804-37208bb08ac5)

Various spelling/grammar/capitalization/syntax/style issues, for example:
![image](https://github.com/harness/developer-hub/assets/36110273/dbb10d44-6ebd-4a0b-99c6-4dcf0b458b8b)

