### PR TITLE
Remove references to immutable in delegate-mtls-support.md

### DIFF
--- a/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
+++ b/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
@@ -87,13 +87,13 @@ In the following examples, OpenSSL is used to create the required certificates. 
 
 ## Move delegates to mTLS
 
-You can move existing delegates with an immutable image type (image tag `yy.mm.xxxxx`) to mTLS.
+You can move existing delegates (with the image tag in `yy.mm.xxxxx` format) to mTLS, legacy delegates are not supported. For more information on delegate types, go to [Delegate image types](/docs/platform/delegates/delegate-concepts/delegate-image-types).
 
 ### Prerequisites for delegate migration
 
 Before you migrate an existing delegate to an mTLS-enabled delegate, make sure that you meet the following prerequisites.
 
-- The delegate must have an immutable image type (image tag _`yy.mm.xxxxx`_). For information on delegate types, go to [Delegate image types](/docs/platform/delegates/delegate-concepts/delegate-image-types).
+- The delegate must not be legacy delegate (it has image tag in _`yy.mm.xxxxx`_ format).
 
 - You must have access to the delegate YAML.
 

--- a/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
+++ b/docs/platform/delegates/secure-delegates/delegate-mtls-support.md
@@ -93,7 +93,7 @@ You can move existing delegates (with the image tag in `yy.mm.xxxxx` format) to 
 
 Before you migrate an existing delegate to an mTLS-enabled delegate, make sure that you meet the following prerequisites.
 
-- The delegate must not be legacy delegate (it has image tag in _`yy.mm.xxxxx`_ format).
+- The delegate must have an image tag in _`yy.mm.xxxxx`_ format). It cannot be a legacy delegate.
 
 - You must have access to the delegate YAML.
 


### PR DESCRIPTION
Immutable delegates or image types don't exist any more, we are trying to rebrand them as just delegates (old thing called delegate now being called legacy delegate)

# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screenshot. 
