### PR TITLE
fix: [SEI-5988]: HDH DOC FIX (SECURITY REPORTS & CHURN RATE)

### DIFF
--- a/docs/software-engineering-insights/sei-metrics-and-reports/security-metrics.md
+++ b/docs/software-engineering-insights/sei-metrics-and-reports/security-metrics.md
@@ -18,6 +18,7 @@ Coverity is a fast, accurate, and highly scalable static analysis (SAST) solutio
 * **Coverity Issues Single Stat:** Present a single statistic related to Coverity issues.
 * **Coverity Issues Trend Report:** Understand daily, weekly, and monthly trends in your Coverity issues.
 
+<!--
 ## Microsoft Threat Modeling
 
 The Microsoft Threat Modeling tool allows software architects to identify and mitigate potential security issues early, when they are relatively easy and cost-effective to resolve.
@@ -36,12 +37,7 @@ The NCC Group's Managed Vulnerability Scanning Services deliver hands-on rapid d
 3. Select **Available Integrations**, locate the **NCC Group Report** semi-automated integration, and select **Upload report**.
 4. Add the **NCC Group Vulnerability Report** to your [Insights](/docs/software-engineering-insights/insights/sei-insights). This report provides details on detected vulnerabilities. Vulnerabilities can be categorized by status.
 
-## Praetorian
-
-1. In your Harness project, go to the SEI module, and select **Account**.
-2. Select **SEI Integrations** under **Data Settings**.
-3. Select **Available Integrations**, locate the **Praetorian Report** semi-automated integration, and select **Upload report**.
-4. Add the **Praetorian Issues Report** to your [Insights](/docs/software-engineering-insights/insights/sei-insights). This report helps analyze security vulnerabilities reported by Praetorian.
+-->
 
 ## Snyk
 

--- a/docs/software-engineering-insights/sei-metrics-and-reports/velocity-metrics-reports/planning-sprint-metrics.md
+++ b/docs/software-engineering-insights/sei-metrics-and-reports/velocity-metrics-reports/planning-sprint-metrics.md
@@ -224,6 +224,22 @@ A creep ticket is a ticket added to a sprint after the sprint starts. The **cree
 
 **Creep missed tickets** is the total number of individual work items (tickets) that were added after the sprint started *and not* completed by the end of the sprint.
 
+### Churn rate
+
+**Churn Rate** measures the scope change during a sprint, providing insights into the volatility of the sprint backlog. It is calculated using the following formula:
+
+```bash
+Churn Rate = (Points added mid-sprint + Points removed mid-sprint + Positive difference of changes in planned issues) / Points committed at the start of the sprint
+
+```
+
+* Points added mid-sprint represent the sum of story points for items added during the sprint.
+* Points removed mid-sprint represent the sum of story points for items removed during the sprint
+* The Positive difference of changes in planned issues is the positive sum of story points for items with planned changes.
+* Points committed at the start of the sprint is the sum of story points for planned issues at the beginning of the sprint.
+
+This metric helps teams assess how much their scope is changing during a sprint, providing a quantitative measure of the impact of mid-sprint changes and adjustments.
+
 ### Done tickets
 
 **Done tickets** is the total number of individual work items (tickets) that were marked as done (or an equivalent completed status) before the end of the sprint.


### PR DESCRIPTION
# Harness Developer Pull Request
Fixed the errors on security report docs and added churn rate metric documentation as a sub-topic to the sprint reports topic. 

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screenshot. 
