### PR TITLE
Adding documentation for default value can not be overridden in the parent entity if value is provided by the child entity

### DIFF
--- a/docs/platform/variables-and-expressions/runtime-inputs.md
+++ b/docs/platform/variables-and-expressions/runtime-inputs.md
@@ -212,13 +212,13 @@ pipeline:
                 value: <+input>.default(new york).executionInput()
 ```
 
-For any variable defined in a template, the default method can be added to either its declaration in the child entity(Template in this case), or else in the parent entity (Pipeline), but not both. Here's what the two different usages mean:
-- When the default value is specified in the child entity, all other entities that use it, cannot specify a different default. They can, however, specify a different value directly, by writing a fixed value for the variable.
+For any variable defined in a template, the default method can be added to either its declaration in the child entity (Template in this case), or else in the parent entity (Pipeline), but not both. Here's what the two different usages mean:
+- When the default value is specified in the child entity, all other entities that use it cannot specify a different default. They can, however, specify a different value directly, by writing a fixed value for the variable.
 
-  For example if you have specified any input like `<+input>.default(default_val)` in child entity then you can not override this default in the parent entity.
+  For example, if you have specified any input like `<+input>.default(default_val)` in the child entity, then you cannot override this default in the parent entity.
 - When there's no default value specified in the child entity, the parent entities may or may not add a default, and this default value can be different in each of these parents.
 
-  For example if you have specified input like `<+input>` for any field then you can provide default in the parent entity like `<+input>.default(default_val_in_parent)`.
+  For example, if you have specified input like `<+input>` for any field, then you can provide a default in the parent entity like `<+input>.default(default_val_in_parent)`.
 
 ### Allowed values
 

--- a/docs/platform/variables-and-expressions/runtime-inputs.md
+++ b/docs/platform/variables-and-expressions/runtime-inputs.md
@@ -212,10 +212,13 @@ pipeline:
                 value: <+input>.default(new york).executionInput()
 ```
 
-When defining a variable in a template, you can specify its default value in either the child entity (the template) or the parent entity (the pipeline), but not both. Here's what each usage means:
+For any variable defined in a template, the default method can be added to either its declaration in the child entity(Template in this case), or else in the parent entity (Pipeline), but not both. Here's what the two different usages mean:
+- When the default value is specified in the child entity, all other entities that use it, cannot specify a different default. They can, however, specify a different value directly, by writing a fixed value for the variable.
 
-- If the default value is specified in the child entity, any other entities that use it won't be able to specify a different default. However, you can still assign a different value directly by writing a fixed value for the variable.
-- If there's no default value specified in the child entity, the parent entities may or may not add a default value, and this default value can be different in each of these parents.
+  For example if you have specified any input like `<+input>.default(default_val)` in child entity then you can not override this default in the parent entity.
+- When there's no default value specified in the child entity, the parent entities may or may not add a default, and this default value can be different in each of these parents.
+
+  For example if you have specified input like `<+input>` for any field then you can provide default in the parent entity like `<+input>.default(default_val_in_parent)`.
 
 ### Allowed values
 

--- a/docs/platform/variables-and-expressions/runtime-inputs.md
+++ b/docs/platform/variables-and-expressions/runtime-inputs.md
@@ -212,6 +212,10 @@ pipeline:
                 value: <+input>.default(new york).executionInput()
 ```
 
+If you want to provide the default value in the parent entity(Pipeline), then you can define the field value as `<+input>` in the child entity(Template). And in parent entity(Pipeline) you can define the default value like `<+input>.deault(default_val)` for any input. 
+
+Kindly note that if default value is defined in the child entity(Template) then parent entity(Pipeline) can not override the default value for that input.
+
 ### Allowed values
 
 Use allowed values to provide a fixed range of acceptable values for a runtime input.

--- a/docs/platform/variables-and-expressions/runtime-inputs.md
+++ b/docs/platform/variables-and-expressions/runtime-inputs.md
@@ -212,9 +212,10 @@ pipeline:
                 value: <+input>.default(new york).executionInput()
 ```
 
-For any variable defined in a template, the default method can be added to either its declaration in the child entity(Template in this case), or else in the parent entity (Pipeline), but not both. Here's what the two different usages mean:
-1. When the default value is specified in the child entity, all other entities that use it, cannot specify a different default. They can, however, specify a different value directly, by writing a fixed value for the variable.
-2. When there's no default value specified in the child entity, the parent entities may or may not add a default, and this default value can be different in each of these parents.
+When defining a variable in a template, you can specify its default value in either the child entity (the template) or the parent entity (the pipeline), but not both. Here's what each usage means:
+
+- If the default value is specified in the child entity, any other entities that use it won't be able to specify a different default. However, you can still assign a different value directly by writing a fixed value for the variable.
+- If there's no default value specified in the child entity, the parent entities may or may not add a default value, and this default value can be different in each of these parents.
 
 ### Allowed values
 

--- a/docs/platform/variables-and-expressions/runtime-inputs.md
+++ b/docs/platform/variables-and-expressions/runtime-inputs.md
@@ -212,9 +212,9 @@ pipeline:
                 value: <+input>.default(new york).executionInput()
 ```
 
-If you want to provide the default value in the parent entity(Pipeline), then you can define the field value as `<+input>` in the child entity(Template). And in parent entity(Pipeline) you can define the default value like `<+input>.deault(default_val)` for any input. 
-
-Kindly note that if default value is defined in the child entity(Template) then parent entity(Pipeline) can not override the default value for that input.
+For any variable defined in a template, the default method can be added to either its declaration in the child entity(Template in this case), or else in the parent entity (Pipeline), but not both. Here's what the two different usages mean:
+1. When the default value is specified in the child entity, all other entities that use it, cannot specify a different default. They can, however, specify a different value directly, by writing a fixed value for the variable.
+2. When there's no default value specified in the child entity, the parent entities may or may not add a default, and this default value can be different in each of these parents.
 
 ### Allowed values
 


### PR DESCRIPTION
# Harness Developer Pull Request
Thanks for helping us make the Developer Hub better. The PR will be looked at
by the CODEOWNERS. 

## What Type of PR is This: This PR adds the documentation that a parent entity can not override the default value for any input if the default value is defined by child entity.

<img width="794" alt="Screenshot 2024-03-14 at 4 49 47 PM" src="https://github.com/harness/developer-hub/assets/67271723/14511eb6-8d97-4b46-a9c2-7e62d004a40e">


- [ ] Issue
- [ ] Feature
- [ ] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screenshot. 
