### PR TITLE
CI-11768

### DIFF
--- a/docs/continuous-integration/shared/build-and-push-runtime-flags.md
+++ b/docs/continuous-integration/shared/build-and-push-runtime-flags.md
@@ -2,18 +2,40 @@
 
 These plugins have a number of additional runtime flags that you might need for certain use cases. For information about the flags, go to the [kaniko plugin documentation](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#additional-flags) and the [drone-docker plugin documentation](https://plugins.drone.io/plugins/docker).
 
-In **Build and Push** steps, you use the **Environment Variables** setting to set these plugin runtime flags. You must input a **Name** and **Value** for each variable. Format the name as `PLUGIN_FLAG_NAME`.
+How you configure plugin runtime flags depends on your build infrastructure.
+
+<details>
+<summary>Set plugin runtime flags with Kubernetes cluster build infrastructure</summary>
+
+With a Kubernetes cluster build infrastructure, you use the **Environment Variables** setting in **Build and Push** steps to set kaniko plugin runtime flags.
 
 :::warning
 
-Unlike in other Harness CI steps, the **Environment Variables** setting in **Build and Push** steps *only* accepts the known plugin runtime flags. You must set other types of environment variables in your Dockerfile, build arguments, or as stage variables, depending on their usage and purpose in your build.
+Unlike in other Harness CI steps, the **Environment Variables** setting in **Build and Push** steps *only* accepts the known kaniko plugin runtime flags. You must set other types of environment variables in your Dockerfile, build arguments, or as stage variables, depending on their usage and purpose in your build.
 
 :::
 
-<details>
-<summary>YAML example: Build and Push step with environment variables</summary>
+In **Environment Variables**, you must input a **Name** and **Value** for each variable. Format the name as `PLUGIN_FLAG_NAME`.
 
-This YAML example shows a Build and Push to GAR step with `PLUGIN` environment variables.
+For example, to set `--skip-tls-verify`, add an environment variable named `PLUGIN_SKIP_TLS_VERIFY` and set the variable value to `true`.
+
+```yaml
+              - step:
+                  identifier: buildandpush
+                  name: buildandpush
+                  type: BuildAndPush---
+                  spec:
+                    ...
+                    envVariables:
+                      PLUGIN_SKIP_TLS_VERIFY: true
+```
+
+To [build without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push), use the `no-push` kaniko flag.
+
+<details>
+<summary>YAML example: Build and Push step with multiple environment variables</summary>
+
+This YAML example shows a Build and Push to GAR step with several `PLUGIN` environment variables.
 
 ```yaml
               - step:
@@ -21,7 +43,7 @@ This YAML example shows a Build and Push to GAR step with `PLUGIN` environment v
                   name: push GCR
                   type: BuildAndPushGAR ## Type depends the selected Build and Push step, such as Docker, GAR, ACR, and so on.
                   spec: ## Some parts of 'step.spec' vary by Build and Push step type (Docker, GAR, ACR, etc).
-                    connectorRef: YOUR_GCR_CONNECTOR
+                    connectorRef: GCR_CONNECTOR
                     host: "us.gcr.io"
                     projectID: "some-gcp-project"
                     imageName: "some-image-name"
@@ -48,32 +70,41 @@ This YAML example shows a Build and Push to GAR step with `PLUGIN` environment v
 
 </details>
 
-For example, to set `--skip-tls-verify` for kaniko, add an environment variable named `PLUGIN_SKIP_TLS_VERIFY` and set the variable value to `true`.
-
-```yaml
-              - step:
-                  identifier: buildandpush
-                  name: buildandpush
-                  type: BuildAndPush---
-                  spec:
-                    ...
-                    envVariables:
-                      PLUGIN_SKIP_TLS_VERIFY: true
-```
-
-To set `custom_dns` for drone-docker, add an environment variable named `PLUGIN_CUSTOM_DNS` and set the variable value to your custom DNS address.
-
-```yaml
-                    envVariables:
-                      PLUGIN_CUSTOM_DNS: "vvv.xxx.yyy.zzz"
-```
-
-Plugin runtime flags are also used to [build without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push).
-
 :::info Stage variables
 
-Previously, you could set some plugin runtime flags as [stage variables](/docs/platform/pipelines/add-a-stage/#stage-variables). If you had done this, Harness recommends moving these stage variables to the **Environment Variables** in your **Build and Push** step.
+Previously, you could set some kaniko runtime flags as [stage variables](/docs/platform/pipelines/add-a-stage/#stage-variables). If you had done this *and you are using Kubernetes cluster build infrastructure*, then Harness recommends moving these kaniko plugin stage variables to the **Environment Variables** in your **Build and Push** step. Don't change non-kaniko plugin variables, such as `PLUGIN_USER_ROLE_ARN`.
 
 For other types of environment variables (that aren't Build and Push plugin runtime flags), stage variables are still inherently available to steps as environment variables. However, where you declare environment variables depends on their usage and purpose in your build. You might need to set them in your Dockerfile, build args, or otherwise.
 
 :::
+
+</details>
+
+<details>
+<summary>Set plugin runtime flags with other build infrastructures</summary>
+
+With Harness Cloud, self-managed VM, or local runner build infrastructures, you can set *some* drone-docker plugin runtime flags as stage variable.
+
+Currently, Harness supports the following drone-docker flags:
+
+* `auto_tag`: Enable auto-generated build tags.
+* `auto_tag_suffix`: Auto-generated build tag suffix.
+* `custom_labels`: Additional arbitrary key-value labels.
+* `artifact_file`: Harness uses this to show links to uploaded artifacts on the [Artifacts tab](/docs/continuous-integration/use-ci/viewing-builds).
+* `dry_run`: Disables pushing to the registry. Used to [build without pushing](./build-without-push.md).
+* `custom_dns`: Provide your custom CNS address.
+
+To set these flags in your Build and Push steps, add [stage variables](/docs/platform/pipelines/add-a-stage/#option-stage-variables) formatted as `PLUGIN_FLAG_NAME`.
+
+For example, to set `custom_dns`, add a stage variable named `PLUGIN_CUSTOM_DNS` and set the variable value to your custom DNS address.
+
+```yaml
+        variables:
+          - name: PLUGIN_CUSTOM_DNS
+            type: String
+            description: ""
+            required: false
+            value: "vvv.xxx.yyy.zzz"
+```
+
+</details>

--- a/docs/continuous-integration/shared/build-and-push-runtime-flags.md
+++ b/docs/continuous-integration/shared/build-and-push-runtime-flags.md
@@ -7,7 +7,7 @@ How you configure plugin runtime flags depends on your build infrastructure.
 <details>
 <summary>Set plugin runtime flags with Kubernetes cluster build infrastructure</summary>
 
-With a Kubernetes cluster build infrastructure, you use the **Environment Variables** setting in **Build and Push** steps to set kaniko plugin runtime flags.
+When using the built-in **Build and Push** steps with a Kubernetes cluster build infrastructure, you can use the **Environment Variables** setting to set kaniko plugin runtime flags.
 
 :::warning
 
@@ -91,10 +91,10 @@ Currently, Harness supports the following drone-docker flags:
 * `auto_tag_suffix`: Auto-generated build tag suffix.
 * `custom_labels`: Additional arbitrary key-value labels.
 * `artifact_file`: Harness uses this to show links to uploaded artifacts on the [Artifacts tab](/docs/continuous-integration/use-ci/viewing-builds).
-* `dry_run`: Disables pushing to the registry. Used to [build without pushing](./build-without-push.md).
+* `dry_run`: Disables pushing to the registry. Used to [build without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push).
 * `custom_dns`: Provide your custom CNS address.
 
-To set these flags in your Build and Push steps, add [stage variables](/docs/platform/pipelines/add-a-stage/#option-stage-variables) formatted as `PLUGIN_FLAG_NAME`.
+To set these flags in your Build and Push steps, add [stage variables](/docs/platform/pipelines/add-a-stage/#stage-variables) formatted as `PLUGIN_FLAG_NAME`.
 
 For example, to set `custom_dns`, add a stage variable named `PLUGIN_CUSTOM_DNS` and set the variable value to your custom DNS address.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md
@@ -7,7 +7,9 @@ sidebar_position: 23
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-With a Kubernetes cluster build infrastructure, all **Build and Push** steps use [kaniko](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md). Other build infrastructures use [drone-docker](https://github.com/drone-plugins/drone-docker/blob/master/README.md). Kaniko requires root access to build the Docker image. It doesn't support non-root users.
+With a Kubernetes cluster build infrastructure, all **Build and Push** steps use [kaniko](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md). Other build infrastructures use [drone-docker](https://github.com/drone-plugins/drone-docker/blob/master/README.md).
+
+Kaniko requires root access to build the Docker image. It doesn't support non-root users. If your Kubernetes cluster build infrastructure is configured to run as non-root, you can either [enable root access individual steps](#enable-root-access-for-a-single-step) or [use the Buildah plugin](#use-the-buildah-plugin), which doesn't require root access.
 
 ## Enable root access for a single step
 
@@ -27,10 +29,8 @@ To use the Buildah plugin, you must meet the following requirements:
 
 ### Add a Plugin step
 
-
 <Tabs>
   <TabItem value="Visual" label="Visual">
-
 
 At the point in your pipeline where you want to build and upload an image, add a [Plugin step](../use-drone-plugins/plugin-step-settings-reference.md) that uses the `buildah` plugin.
 
@@ -56,10 +56,8 @@ At the point in your pipeline where you want to build and upload an image, add a
    * `password`: An [expression](/docs/platform/variables-and-expressions/runtime-inputs/#expressions) referencing a [Harness secret](/docs/category/secrets) or [pipeline variable](/docs/platform/variables-and-expressions/add-a-variable) containing the password to access the push destination, such as `<+pipeline.variables.DOCKER_HUB_SECRET>`.
    * For more information and additional settings, including AWS S3 settings, go to [Buildah plugin settings](#buildah-plugin-settings).
 
-
 </TabItem>
   <TabItem value="YAML" label="YAML" default>
-
 
 At the point in your pipeline where you want to build and upload an image, add a [Plugin step](../use-drone-plugins/plugin-step-settings-reference.md) that uses the `buildah` plugin, for example:
 
@@ -105,10 +103,8 @@ This step requires the following specifications:
    * `password`: An [expression](/docs/platform/variables-and-expressions/runtime-inputs/#expressions) referencing a [Harness secret](/docs/category/secrets) or [pipeline variable](/docs/platform/variables-and-expressions/add-a-variable) containing the password to access the push destination, such as `<+pipeline.variables.DOCKER_HUB_SECRET>`.
    * For more information and additional settings, including AWS S3 settings, go to [Buildah plugin settings](#buildah-plugin-settings).
 
-
 </TabItem>
 </Tabs>
-
 
 #### Buildah plugin settings
 
@@ -174,7 +170,7 @@ This YAML example shows a Build (`CI`) stage with a Kubernetes cluster build inf
 
 You can use your CI pipeline to test a Dockerfile used in your codebase and verify that the resulting image is correct before you push it to your Docker repository.
 
-The following configuration is valid with the Docker Buildah plugin (`plugins/buildah-docker`) only.
+The following configuration is valid with the Docker Buildah plugin (`plugins/buildah-docker`) only. For other configurations, go to [Build without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push).
 
 1. In your CI pipeline, go to the **Build** stage that includes the **Plugin** step with the Docker Buildah plugin.
 2. In the **Build** stage's **Overview** tab, expand the **Advanced** section.

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md
@@ -4,10 +4,8 @@ description: Use the buildah plugin if you can't use the built-in Build and Push
 sidebar_position: 23
 ---
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
 
 With a Kubernetes cluster build infrastructure, all **Build and Push** steps use [kaniko](https://github.com/GoogleContainerTools/kaniko/blob/main/README.md). Other build infrastructures use [drone-docker](https://github.com/drone-plugins/drone-docker/blob/master/README.md). Kaniko requires root access to build the Docker image. It doesn't support non-root users.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-acr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-acr.md
@@ -137,7 +137,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `<container-registry-name>.azurecr.io/<image-name>`.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-jfrog.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-jfrog.md
@@ -157,13 +157,28 @@ The [Docker build-time variables](https://docs.docker.com/engine/reference/comma
 
 The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-### Remote Cache Image
+### Remote Cache Image (Docker layer caching)
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `NAMESPACE/IMAGE_NAME`.
 
 The remote cache repository must exist in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+
+<details>
+<summary>Early access feature: Docker layer caching with Harness Cloud</summary>
+
+:::note
+
+Currently, Docker layer caching with Harness Cloud is behind the feature flags `CI_ENABLE_DLC` and `CI_HOSTED_CONTAINERLESS_OOTB_STEP_ENABLED`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
+:::
+
+Harness Cloud can manage the Docker layer [cache backend](https://docs.docker.com/build/cache/backends/) for you without relying on your Docker registry. This ensures that layers are always pulled from the fastest available source.
+
+If your build runs on [Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure), you can enable Docker layer caching for Harness Cloud, select **Enable Docker layer caching** in your **Build and Push to Docker** step.
+
+</details>
 
 ### Environment Variables (plugin runtime flags)
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
@@ -149,13 +149,28 @@ The [Docker build-time variables](https://docs.docker.com/engine/reference/comma
 
 The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-### Remote Cache Image
+### Remote Cache Image (Docker layer caching)
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `<container-registry-repo-name>/<image-name>`.
 
 The remote cache repository must exist in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+
+<details>
+<summary>Early access feature: Docker layer caching with Harness Cloud</summary>
+
+:::note
+
+Currently, Docker layer caching with Harness Cloud is behind the feature flags `CI_ENABLE_DLC` and `CI_HOSTED_CONTAINERLESS_OOTB_STEP_ENABLED`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
+:::
+
+Harness Cloud can manage the Docker layer [cache backend](https://docs.docker.com/build/cache/backends/) for you without relying on your Docker registry. This ensures that layers are always pulled from the fastest available source.
+
+If your build runs on [Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure), you can enable Docker layer caching for Harness Cloud, select **Enable Docker layer caching** in your **Build and Push to Docker** step.
+
+</details>
 
 ### Environment Variables (plugin runtime flags)
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ecr-step-settings.md
@@ -176,7 +176,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, for example, `app/myImage`.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gar.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gar.md
@@ -142,7 +142,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/IMAGE_NAME`.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gcr.md
@@ -153,7 +153,7 @@ The [Docker target build stage](https://docs.docker.com/engine/reference/command
 
 ### Remote Cache Image
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `gcr.io/project-id/<image>`.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ghcr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ghcr.md
@@ -145,13 +145,28 @@ The [Docker build-time variables](https://docs.docker.com/engine/reference/comma
 
 The [Docker target build stage](https://docs.docker.com/engine/reference/commandline/build/#target), equivalent to the `--target` flag, such as `build-env`.
 
-### Remote Cache Image
+### Remote Cache Image (Docker layer caching)
 
-Use this setting to enable remote Docker layer caching where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
+Use this setting to [enable remote Docker layer caching](/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching) where each Docker layer is uploaded as an image to a Docker repo you identify. If the same layer is used in later builds, Harness downloads the layer from the Docker repo. You can also specify the same Docker repo for multiple **Build and Push** steps, enabling these steps to share the same remote cache. This can dramatically improve build time by sharing layers across pipelines, stages, and steps.
 
 For **Remote Cache Image**, enter the name of the remote cache registry and image, such as `NAMESPACE/IMAGE_NAME`.
 
 The remote cache repository must exist in the same host and project as the build image. The repository will be automatically created if it doesn't exist. For caching to work, the entered image name must exist.
+
+<details>
+<summary>Early access feature: Docker layer caching with Harness Cloud</summary>
+
+:::note
+
+Currently, Docker layer caching with Harness Cloud is behind the feature flags `CI_ENABLE_DLC` and `CI_HOSTED_CONTAINERLESS_OOTB_STEP_ENABLED`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
+:::
+
+Harness Cloud can manage the Docker layer [cache backend](https://docs.docker.com/build/cache/backends/) for you without relying on your Docker registry. This ensures that layers are always pulled from the fastest available source.
+
+If your build runs on [Harness Cloud build infrastructure](/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure), you can enable Docker layer caching for Harness Cloud, select **Enable Docker layer caching** in your **Build and Push to Docker** step.
+
+</details>
 
 ### Environment Variables (plugin runtime flags)
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push.md
@@ -4,31 +4,58 @@ description: You can build images without pushing them.
 sidebar_position: 22
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 In Harness CI, you can build images without pushing them. For example, you can use your CI pipeline to test a Dockerfile from your codebase to verify that the resulting image is correct before you push it to your Docker repository.
 
-The configuration depends on your build infrastructure:
+The build dry run configuration depends on your build infrastructure and the step or plugin you use for your build.
 
 ## Harness Cloud, local runner, or self-managed VM
 
-To build without pushing on Harness Cloud, a local runner, or a self-managed VM build infrastructure, add the following environment variable to your [Build and Push step](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact):
+Use these instructions for build dry runs on Harness Cloud, self-managed VM, or local runner build infrastructure.
 
-```yaml
-                    envVariables:
-                      PLUGIN_DRY_RUN: true
-```
+<Tabs>
+<TabItem value="builtin" label="Built-in Build and Push steps" default>
 
-## Kubernetes cluster running as root
+For built-in [Build and Push steps](/docs/category/build-and-push), you need to add a [stage variable](/docs/platform/pipelines/add-a-stage/#stage-variables) named `PLUGIN_DRY_RUN`.
 
-To build without pushing on a Kubernetes cluster build infrastructure running as root, add the following environment variable to your [Build and Push step](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact):
+1. In your CI pipeline, go to the **Build** stage that includes a [Build and Push step](/docs/category/build-and-push).
+2. In the **Build** stage's **Overview** tab, expand the **Advanced** section.
+3. Select **Add Variable** and enter the following:
+   * **Name:** `PLUGIN_DRY_RUN`
+   * **Type:** **String**
+   * **Value:** `true`
+4. Save and run the pipeline.
+
+</TabItem>
+<TabItem value="run" label="Run step">
+
+For build scripts executed in [Run steps](/docs/continuous-integration/use-ci/run-step-settings), refer to your build tool's documentation for dry run specifications.
+
+</TabItem>
+</Tabs>
+
+## Kubernetes cluster build infrastructure
+
+Use these instructions for build dry runs on Kubernetes cluster build infrastructure.
+
+<Tabs>
+<TabItem value="builtin" label="Built-in Build and Push steps" default>
+
+For the built-in [Build and Push steps](/docs/category/build-and-push), add the `PLUGIN_NO_PUSH` variable to the **Build and Push** step's **Environment Variables**.
 
 ```yaml
                     envVariables:
                       PLUGIN_NO_PUSH: true
 ```
 
-## Kubernetes cluster running as non-root
+</TabItem>
+<TabItem value="buildah" label="Buildah plugin (Plugin step)">
 
-To build without pushing with the Buildah plugin, which is used to [build and push with non-root users](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md), add the following [stage variable](/docs/platform/pipelines/add-a-stage/#option-stage-variables) to the stage where you use the Buildah plugin:
+The Buildah plugin is used to [build and push with non-root users](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push-nonroot.md).
+
+To configure a build dry run with this plugin, add the following [stage variable](/docs/platform/pipelines/add-a-stage/#stage-variables) to the stage where you run the Buildah plugin:
 
 ```yaml
         variables:
@@ -38,3 +65,11 @@ To build without pushing with the Buildah plugin, which is used to [build and pu
             required: false
             value: "true"
 ```
+
+</TabItem>
+<TabItem value="run" label="Run step">
+
+For build scripts executed in [Run steps](/docs/continuous-integration/use-ci/run-step-settings), refer to your build tool's documentation for dry run specifications.
+
+</TabItem>
+</Tabs>

--- a/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/docker-layer-caching.md
@@ -10,10 +10,6 @@ Write your Dockerfiles to [use the cache efficiently](https://docs.docker.com/bu
 
 ## Docker layer caching with Harness Cloud
 
-[Harness Cloud](../set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md) can manage the Docker layer [cache backend](https://docs.docker.com/build/cache/backends/) for you, without relying on your Docker registry. This ensures that layers are always pulled from the fastest available source.
-
-Enable Docker layer caching by selecting __Enable Docker layer caching__ in your Build and Push to Docker step.
-
 :::note
 
 Currently, Docker layer caching with Harness Cloud is behind the feature flags `CI_ENABLE_DLC` and `CI_HOSTED_CONTAINERLESS_OOTB_STEP_ENABLED`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
@@ -22,13 +18,17 @@ Currently, Docker layer caching with Harness Cloud is behind the feature flags `
 
 :::
 
+[Harness Cloud](../set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md) can manage the Docker layer [cache backend](https://docs.docker.com/build/cache/backends/) for you without relying on your Docker registry. This ensures that layers are always pulled from the fastest available source.
+
+To enable Docker layer caching for Harness Cloud, select __Enable Docker layer caching__ in your [Build and Push to Docker step](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry).
+
 ## Docker layer caching with other build infrastructures
 
 Other build infrastructures can leverage remote Docker caching using your existing Docker registry.
 
 :::note
 
-Support for other storage backends with self-managed runners is in development.
+Harness is developing support for other storage backends with self-managed runners.
 
 :::
 

--- a/docs/continuous-integration/use-ci/optimize-and-more/ci-env-var.md
+++ b/docs/continuous-integration/use-ci/optimize-and-more/ci-env-var.md
@@ -39,7 +39,8 @@ You can automatically [trigger pipelines using Git events](/docs/platform/trigge
 `PLUGIN_` variables represent [plugin](../use-drone-plugins/explore-ci-plugins.md) settings, and they are defined in either:
 
 * The [plugin step's settings](../use-drone-plugins/plugin-step-settings-reference.md#settings). For example, `setting.url` becomes `PLUGIN_URL` at runtime.
-* Stage variables. For example, you can use the `PLUGIN_DRY_RUN` stage variable to [Build a Docker image without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push.md).-->
+* Stage variables. For example, you can use the `PLUGIN_DRY_RUN` stage variable to [Build a Docker image without pushing](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-without-push.md).
+* Environment variables for Build and Push steps running on Kubernetes cluster build infrastructure. -->
 
 <!-- ## Codebase and trigger variables
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -2,7 +2,7 @@
 title: Continuous Integration release notes
 sidebar_label: Continuous Integration
 tags: [NextGen, "continuous integration"]
-date: 2024-03-18T10:00
+date: 2024-03-22T10:00
 sidebar_position: 10
 ---
 
@@ -36,6 +36,16 @@ You will be impacted by this deprecation if:
 Contact [Harness Support](mailto:support@harness.io) if you have any questions.
 
 ## March 2024
+
+### Correction
+
+<!-- 22 Mar 24 -->
+
+A prior release note announced that you could set plugin runtime flags as environment variables for [Build and Push steps](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact).
+
+This announcement incorrectly implied that the feature applied to all build infrastructures.
+
+**Correction:** Currently, this feature applies to Kubernetes cluster build infrastructure only. Other build infrastructures can set a limited subset of drone-docker runtime flags as stage variables. The prior release notes and supporting documentation have been updated to reflect this correction.
 
 ### Version 1.18.2
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -104,7 +104,7 @@ Fixed an issue where the Get Started wizard failed to generate some pipeline YAM
 
 #### New features and enhancements
 
-* [Build and Push steps](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact) support all kaniko and drone-docker runtime flags. You can specify these flags as environment variables in the Build and Push step settings. (CI-10165, CI-11031)
+* With Kubernetes cluster build infrastructure, [Build and Push steps](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-upload-an-artifact) support all kaniko runtime flags. You can specify these flags as environment variables in the Build and Push step settings. Currently, this is only supported for Kubernetes cluster build infrastructure. Other build infrastructures can set a limited subset of drone-docker runtime flags as stage variables. (CI-10165, CI-11031)
 * To address security vulnerabilities, Reactor-netty libraries have been updated to the latest version in [Harness CI images](/docs/continuous-integration/use-ci/set-up-build-infrastructure/harness-ci). (CI-10929, ZD-52222, ZD-55562)
 * The Harness Community team has developed two new plugins to help you automate more processes in your CI pipelines:
    * The [Helm Push plugin](/docs/continuous-integration/use-ci/build-and-upload-artifacts/upload-artifacts/upload-helm-chart) streamlines packaging and distribution of Helm charts to container registries.


### PR DESCRIPTION
Build and Push step Environment Variable setting is only valid for K8s infra, even though it is visible for other infras.
   * Add back “stage variable” method for cloud, local runner, and self-managed VM build infra. 
   * Separate K8s (env var) method from other infras. Other infras are limited bc stage variables don’t support all flags.
   * Build without push needs to show both env var and stage var methods.

Update “Remote Cache Image" to include early access option on some pages.
