### PR TITLE
CHAOS-4870 update hce cli api

### DIFF
--- a/docs/chaos-engineering/api-reference/hce-saas-api.md
+++ b/docs/chaos-engineering/api-reference/hce-saas-api.md
@@ -13,13 +13,56 @@ HCE SAAS API is a tool to introduce chaos experiments into your environment. Thi
 ## Why use the HCE SAAS API?
 * The CLI helps you easily simulate various failure scenarios and observe how your services behave under stress. This helps uncover potential vulnerabilities and weaknesses in your system.
 
-
 * It simplifies the process of executing complex API commands in your CI (Continuous Integration) pipelines. This helps in the seamless integration of the HCE platform with any CI tool, such as Jenkins, GitLab, GitHub Actions, and more.
-
 
 * It provides an efficient way to define and execute chaos experiments on your APIs, making it a valuable tool for ensuring the robustness and reliability of your applications in production environments.
 
-## How to use the API
+## How to install the API?
+
+HCE offers pre-compiled binaries available for download.
+
+### For Linux:
+
+* For AMD64 / x86_64:
+
+```bash
+[ $(uname -m) = x86_64 ] && curl -Lo ./hce_cli_api https://app.harness.io/public/shared/tools/chaos/hce-cli/0.0.3/hce-cli-0.0.3-linux-amd64
+```
+
+* For Arm64:
+
+```bash
+[ $(uname -m) = aarch64 ] && curl -Lo ./hce_cli_api https://app.harness.io/public/shared/tools/chaos/hce-cli/0.0.3/hce-cli-0.0.3-linux-arm64
+```
+
+	* After downloading, add execution permissions and move it to your binary installation directory:
+
+```bash
+chmod +x ./hce_cli_api
+sudo mv ./hce_cli_api /usr/local/bin/hce_cli_api
+```
+### For MacOS:
+
+* For Intel Macs:
+
+```bash
+[ $(uname -m) = x86_64 ] && curl -Lo ./hce_cli_api https://github.com/harness/onboard_hce_aws/releases/download/0.1.0/cli-darwin-amd64
+```
+
+* For M1 / ARM Macs:
+
+```bash
+[ $(uname -m) = arm64 ] && curl -Lo ./hce_cli_api https://app.harness.io/public/shared/tools/chaos/onboard_hce_aws/0.2.0/onboard_hce_cli-0.2.0-darwin-arm64
+```
+
+	* After downloading, add execution permissions and move it to your binary installation directory:
+
+```bash
+chmod +x ./hce_cli_api
+mv ./hce_cli_api /some-dir-in-your-PATH/hce_cli_api
+```
+
+## How to use the API?
 The HCE SAAS API provides a command-line interface (CLI) to launch and monitor chaos experiments and validate the resilience scores of workflows. The available commands are listed below:
 
 


### PR DESCRIPTION
Add steps to install CLI API on Linux and MacOS 