### PR TITLE
Recreate PR 3873

### DIFF
--- a/docs/cloud-cost-management/get-started/onboarding-guide/set-up-cost-visibility-for-kubernetes.md
+++ b/docs/cloud-cost-management/get-started/onboarding-guide/set-up-cost-visibility-for-kubernetes.md
@@ -1,6 +1,7 @@
 ---
-title: Kubernetes
+title: Set up CCM for Kubernetes cluster
 description: This topic describes how to connect your Kubernetes cluster to CCM.
+sidebar_label: Kubernetes
 # sidebar_position: 2
 helpdocs_topic_id: ltt65r6k39
 helpdocs_category_id: 7vy86n7cws
@@ -10,31 +11,163 @@ redirect_from:
   - /docs/cloud-cost-management/getting-started-ccm/set-up-cloud-cost-management/set-up-cost-visibility-for-kubernetes
 ---
 
-# Set up CCM for Kubernetes cluster
-
 Harness Cloud Cost Management (CCM) monitors the cloud costs of your Kubernetes clusters, namespaces, nodes, workloads, and labels. CCM also allows you to optimize your Kubernetes cluster resources using intelligent cloud AutoStopping rules.
 
 This topic describes how to connect your Kubernetes cluster to CCM.
 
-:::note
-After you enable CCM, for the first cluster, the data is available within a few minutes for viewing and analysis. However, you would not be able to see the idle cost because of the lack of utilization data. CCM generates the last 30 days of the cost data based on the first events. From the second cluster onwards, it takes about 2 to 3 hours for the data to be available for viewing and analysis.
+To fully enable CCM for a Kubernetes cluster, you need to:
+
+- **Deploy a delegate into the target cluster.** This gives Harness a connection into your cluster.
+- **Create a Harness Kubernetes connector that targets the delegate.** This ties your cluster and delegate to a representation of your cluster in Harness.
+- **Create a Harness CCM Kubernetes connector that targets the Kubernetes connector.** This enables the delegate to start collecting usage metrics to be sent back to Harness for use in CCM.
+- **(Optional) Deploy the autostopping controller and router into the target cluster.** This enables you to create CCM autostopping rules to reduce costs of your cluster.
+
+:::info
+
+After you enable CCM in your first cluster, the data is available within a few minutes for viewing and analysis.
+
+However, you can't see the idle cost due to missing utilization data. CCM generates the last 30 days of the cost data based on the first events.
+
+From the second cluster onwards, it takes about 2 to 3 hours for the data to be available for viewing and analysis.
 
 If you are using a CCM cloud connector, the data generation is delayed. Since CCM performs cost true-up based on cost information available at cloud provider source.
+
 :::
 
-## Kubernetes Connector requirements and workflow
+## Kubernetes connector requirements and workflow
 
-For CCM, Kubernetes connectors are available only at the Account level in Harness. To set up the CCM K8s Connector, you need to perform the following tasks:
+For CCM, you can only use Kubernetes connectors at the Account level in Harness. This section describes how to set up the CCM Kubernetes connector.
 
-## Create a cloud provider Kubernetes connector
-You need to have completed the following tasks before creating a CCM connector for your Kubernetes cluster:
-* You need to set up a Harness Delegate for each Cloud Provider (Kubernetes cluster) connector. Delegates are installed when adding a connector. For more information, go to [Install a Kubernetes delegate](/docs/platform/get-started/tutorials/install-delegate). The delegate is responsible for collecting metrics from the Kubernetes connector.
+Here's a visual representation of the CCM Kubernetes connector requirements and workflow:
 
-  ### Delegate role requirements for CCM visibility features and recommendations:
-  
-    The YAML provided for the Harness Delegate defaults to the `cluster-admin` role. If you can't use cluster-admin because you are using a cluster in your company, you'll need to edit the delegate YAML.
-	
+![](./static/set-up-cost-visibility-for-kubernetes-14.png)
+
+### Deploy a delegate
+
+#### Prerequisites
+
+Make sure you have the following set up before you create a Kubernetes connector for CCM:
+
+- **Kubernetes cluster**:
+You need a target Kubernetes cluster for the Harness Delegate and deployment. Make sure your cluster meets the following requirements:
+  * **Number of nodes**: 2
+  * **vCPUs, Memory, Disk Size**: 4vCPUs, 16GB memory, 100GB disk. In GKE, the **e2-standard-4** machine type is enough for this quickstart.
+  * **Networking**: outbound HTTPS for the Harness connection to **app.harness.io**, **github.com**, and **hub.docker.com**. Allow TCP port 22 for SSH.
+  * **Kubernetes service account** with permission to create entities in the target namespace is required. The set of permissions should include `list`, `get`, `create`, and `delete` permissions. In general, the cluster-admin permission or namespace admin permission is enough.
+	For more information, see [User-Facing Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) from Kubernetes.
+
+:::warning
+
+You must not rename the cluster. If you're setting up a new connector with this cluster, it is identified by the `clustername`. Renaming the cluster results in duplicate entries in the dashboard.
+
+:::
+
+- **Delegate size**:
+Your Kubernetes cluster must have unallocated resources required to run the Harness Delegate workload:
+
+  - Laptop - 2GB memory, 0.5CPU
+  - Small - 4GB memory, 1CPU
+  - Medium - 8GB memory, 2CPU
+  - Large - 16GB memory, 4CPU
+
+:::warning
+
+- These sizing requirements are for the Delegate only. Your cluster will require more memory for Kubernetes, the operating system, and other services. Ensure that the cluster has enough memory, storage, and CPU for all of its resource consumers.
+- We recommend using one delegate per cluster and Large size delegates for production clusters for optimal performance.
+
+:::
+
+- **Delegate permissions**: You can choose one of the following permissions for CCM:
+
+ **Install Delegate with cluster-wide read/write access**
+
+	Creates a new namespace called "harness-delegate-ng" with the service account bound to Cluster Admin role. This Delegate will be able to read tasks (capture change events etc., needed for Harness Cloud Cost Management) anywhere on the K8s cluster where the Delegate is installed.
+
+ **Install Delegate with cluster-wide read access**
+
+	(Requires read-only Cluster Admin role) Creates a new namespace called "harness-delegate-ng" with the service account bound to Cluster Admin role. This Delegate will be able to perform read-only tasks (capture change events etc., needed for Harness Cloud Cost Management) anywhere on the K8s cluster where the Delegate is installed.
+
+- **Metrics Server**: Metrics Server must be running on the Kubernetes cluster where your Harness Kubernetes Delegate is installed. Before enabling CCM for Kubernetes, you must make sure the utilization data for pods and nodes is available.
+
+
+:::info
+Metrics Server is installed by default on GKE and AKS clusters; however, you need to install it on the AWS EKS cluster.
+:::
+
+The Metrics Server is a cluster-wide aggregator of resource usage data. It collects resource metrics from kubelets and exposes them in the Kubernetes API server through Metrics API. CCM polls the utilization data every minute on the Delegate. The metrics are aggregated for 20 minutes and then CCM keeps one data point per 20 minutes. For more information, see [Installing the Kubernetes Metrics Server](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) from AWS.
+To install the metrics server on your EKS clusters, run the following command:
+
 ```
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.5.0/components.yaml
+```
+Resources can be adjusted proportionally based on number of nodes in the cluster. For clusters exceeding 100 nodes, allocate the following additional resources:
+
+  * 1m core per node
+  * 2MiB memory per node
+
+#### Delegate installation
+
+[Install a Harness Kubernetes delegate.](/docs/platform/delegates/install-delegates/overview)
+
+### Create a Kubernetes connector
+
+:::info
+
+In Harness, the ratio of Delegates to Connectors is 1:2. If you have 20 clusters you need 20 Delegates and 40 Connectors (1 Cloud Provider K8s Connector and 1 CCM Connector each).
+
+Alternatively, if you wish to use a single Delegate to access multiple Kubernetes clusters, you need to specify the Kubernetes master node URL.
+
+:::
+
+Once the delegate is deployed you will need to create a Kubernetes connector at the account level. This connector should be created to `Use credentials of a specific Harness delegate` and select the delegate you deployed into the target cluster.
+
+Make sure the connector passes its connection test to validate the delegate has been installed correctly and can make outbound connections to the Harness Manager.
+
+### Create a CCM Kubernetes connector
+
+To have your delegate start to collect usage metrics, you need to create a CCM Kubernetes connector at the Account level. This connector should point to the regular Kubernetes connector created in the previous step.
+
+For the CCM Kubernetes connector, you need to reference an existing Cloud Provider Kubernetes Connector. Otherwise, you need to create one.
+For each cluster, you need to create a CCM Kubernetes connector. CCM can now connect to the K8s connector and collect CCM metrics for deep cloud cost visibility.
+
+#### Connect your Kubernetes cluster to CCM
+
+Perform the following steps to connect your Kubernetes cluster to CCM.
+
+1. Create a new Kubernetes connector using one of the two options below:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs queryString="tab-number">
+<TabItem value="4" label="From Account Settings">
+
+1. Go to **Account Resources** > **Connectors**.
+2. Select **+ New Connector**.
+3. Under **Cloud Costs**, select **Kubernetes**.
+
+</TabItem>
+<TabItem value="5" label="From Cloud Costs">
+
+1. Go to **Setup** > **Cloud Integration**.
+2. Select **New Cluster/Cloud account**.
+3. Select **Kubernetes**.
+4. Select **Advanced**.
+
+:::note
+
+For the Quick Create option, go to [Kubernetes Quick Create](/docs/cloud-cost-management/get-started/onboarding-guide/use-quick-create-k8s).
+
+:::
+
+</TabItem>
+</Tabs>
+
+#### Delegate role requirements for CCM visibility features and recommendations:
+
+The YAML provided for the Harness Delegate defaults to the `cluster-admin` role. If you can't use cluster-admin because you are using a cluster in your company, you'll need to edit the delegate YAML to include the role below. If you deployed your delegate with Helm, you can also set the value `ccm.visibility: true` to have this role and binding created.
+
+```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -92,238 +225,127 @@ rules:
   - list
   - watch
 ```
-  
-* You need to create a Kubernetes Cloud Provider Connector for each Kubernetes cluster. One connector can access only one cluster. See [Add a Kubernetes Cluster Connector](/docs/platform/connectors/cloud-providers/add-a-kubernetes-cluster-connector).
- 
-## Create CCM Connector
-For the CCM Kubernetes connector, you need to reference an existing Cloud Provider Kubernetes Connector. Otherwise, you need to create one.
-For each cluster, you need to create a CCM Kubernetes connector. CCM can now connect to the K8s connector and collect CCM metrics for deep cloud cost visibility.
 
+#### Detailed CCM Kubernetes connector guide
 
-:::note
-In Harness, the ratio of Delegates to Connectors is 1:2. If you have 20 clusters you need 20 Delegates and 40 Connectors (1 Cloud Provider K8s Connector and 1 CCM Connector each).  
-  
-Alternatively, if you wish to use a single Delegate to access multiple Kubernetes clusters, you need to specify the Kubernetes master node URL.
-
-Please note, the delegate will be working only on a Linux machine. In cases where the cluster comprises mixed nodes, you can consider utilizing delegate selectors. 
-:::
-
-
-## Visual summary
-
-Here's a visual representation of the CCM Kubernetes connector requirements and workflow:
-
-![](./static/set-up-cost-visibility-for-kubernetes-14.png)
-
-## Prerequisites
-
-Make sure you have the following set up before you create a Kubernetes connector for CCM:
-
-- **Kubernetes cluster**:
-You need a target Kubernetes cluster for the Harness Delegate and deployment. Make sure your cluster meets the following requirements:
-  * **Number of nodes**: 2
-  * **vCPUs, Memory, Disk Size**: 4vCPUs, 16GB memory, 100GB disk. In GKE, the **e2-standard-4** machine type is enough for this quickstart.
-  * **Networking**: outbound HTTPS for the Harness connection to **app.harness.io**, **github.com**, and **hub.docker.com**. Allow TCP port 22 for SSH.
-  * **Kubernetes service account** with permission to create entities in the target namespace is required. The set of permissions should include `list`, `get`, `create`, and `delete` permissions. In general, the cluster-admin permission or namespace admin permission is enough.  
-	For more information, see [User-Facing Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) from Kubernetes.
-	
-	
-:::note
-You must not rename the cluster. If you're setting up a new connector with this cluster, it is identified by the `clustername`. Renaming the cluster results in duplicate entries in the dashboard.
-:::
- 
-	
-- **Delegate size**: 
-Your Kubernetes cluster must have unallocated resources required to run the Harness Delegate workload:
-
-  - Laptop - 2GB memory, 0.5CPU
-  - Small - 4GB memory, 1CPU
-  - Medium - 8GB memory, 2CPU
-  - Large - 16GB memory, 4CPU
-
-:::warning
-- These sizing requirements are for the Delegate only. Your cluster will require more memory for Kubernetes, the operating system, and other services. Ensure that the cluster has enough memory, storage, and CPU for all of its resource consumers. 
-- We recommend using one delegate per cluster and Large size delegates for production clusters for optimal performance.
-:::
-
-- **Delegate permissions**: You can choose one of the following permissions for CCM:
-
- **Install Delegate with cluster-wide read/write access**
-
-	Creates a new namespace called "harness-delegate-ng" with the service account bound to Cluster Admin role. This Delegate will be able to read tasks (capture change events etc., needed for Harness Cloud Cost Management) anywhere on the K8s cluster where the Delegate is installed.
-
- **Install Delegate with cluster-wide read access**
-
-	(Requires read-only Cluster Admin role) Creates a new namespace called "harness-delegate-ng" with the service account bound to Cluster Admin role. This Delegate will be able to perform read-only tasks (capture change events etc., needed for Harness Cloud Cost Management) anywhere on the K8s cluster where the Delegate is installed.
-
-- **Metrics Server**: Metrics Server must be running on the Kubernetes cluster where your Harness Kubernetes Delegate is installed. Before enabling CCM for Kubernetes, you must make sure the utilization data for pods and nodes is available.
-
-
-:::info
-Metrics Server is installed by default on GKE and AKS clusters; however, you need to install it on the AWS EKS cluster.
-:::
-
-The Metrics Server is a cluster-wide aggregator of resource usage data. It collects resource metrics from kubelets and exposes them in the Kubernetes API server through Metrics API. CCM polls the utilization data every minute on the Delegate. The metrics are aggregated for 20 minutes and then CCM keeps one data point per 20 minutes. For more information, see [Installing the Kubernetes Metrics Server](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) from AWS.  
-To install the metrics server on your EKS clusters, run the following command:
-```
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.5.0/components.yaml  
-
-```
-Resources can be adjusted proportionally based on number of nodes in the cluster. For clusters exceeding 100 nodes, allocate the following additional resources:
-
-  * 1m core per node
-  * 2MiB memory per node
-
-## Connect Your Kubernetes Cluster to CCM
-
-Perform the following steps to connect your Kubernetes cluster to CCM.
-
-1. Create a new Kubernetes connector using one of the two options below:
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-
-
-<Tabs queryString="tab-number">
-<TabItem value="4" label="From Account Settings">
-
-1. Go to **Account Resources** > **Connectors**.
-2. Select **+ New Connector**.
-3. Under **Cloud Costs**, select **Kubernetes**.
-
-</TabItem>
-<TabItem value="5" label="From Cloud Costs">
-
-1. Go to **Setup** > **Cloud Integration**.  
-2. Select **New Cluster/Cloud account**.
-3. Select **Kubernetes**.
-4. Select **Advanced**.
-
-:::note
-   For the Quick Create option, go to [Kubernetes Quick Create](/docs/cloud-cost-management/get-started/onboarding-guide/use-quick-create-k8s).
-:::
-
-</TabItem>
-</Tabs>
-
-
-### Overview
- 
-1. In the **Kubernetes Connector** wizard, in the **Overview** section, from the **Reference an existing connector** drop-down list, select your Cloud Provider Kubernetes Connector.  
+1. In the **Kubernetes Connector** wizard, in the **Overview** section, from the **Reference an existing connector** drop-down list, select your Cloud Provider Kubernetes Connector.
 If you do not have Cloud Provider Kubernetes Connector already created, select **Create a new connector**. See [Add a Kubernetes Cluster Connector](/docs/platform/connectors/cloud-providers/add-a-kubernetes-cluster-connector).
 2. The name for your connector is automatically populated. You can choose to edit the name. This name appears on the **Perspectives** page to identify this cluster.
-   
 3. Select **Save and Continue**.
 
-### Choose Requirements
+##### Choose Requirements
 
 In **Choose Requirements**, select the Cloud Cost Management features that you would like to enable for your Kubernetes clusters. Based on your selection Harness requires specific permissions.
 
 You need to provide different permissions depending on the features that you enable for your Kubernetes clusters. CCM offers the following features:
 
-| **Features**  | **Capabilities** | 
-| --- | --- | 
+| Feature | Capabilities |
+| --- | --- |
 | **Cost Visibility** (Required)| This feature is available by default. Provides the following capabilities:<ul><li>Insights into cluster costs by pods, namespace, workloads, etc.</li><li>Idle and unallocated cluster costs</li><li><li>Workload recommendations</li>Root cost analysis using cost perspectives </li><li>Cost anomaly detection</li><li>Governance using budgets and forecasts</li><li>Alert users using Email and Slack notification</li></ul>|
 | **Kubernetes optimization using AutoStopping rules** (Required for AutoStopping Rules)| This feature allows you to enable Intelligent Cloud AutoStopping for Kubernetes. For more information, see [Create AutoStopping Rules for AWS](/docs/cloud-cost-management/use-ccm-cost-optimization/optimize-cloud-costs-with-intelligent-cloud-auto-stopping-rules/create-auto-stopping-rules/create-autostopping-rules-aws).<ul><li>Orchestrate GCE VMs based on idleness</li><li>Set dependencies between VMs</li><li>Granular savings visibility</li><li>Simple one-time setup</li></ul>|
 
-
 :::note
+
 For [AWS](set-up-cost-visibility-for-aws.md) and [Azure](set-up-cost-visibility-for-azure.md), if the cloud connectors are set up, then the cost will be trued-up to the pricing received from the CUR/billing export. However, for [GCP](set-up-cost-visibility-for-gcp.md) the list pricing is used.
+
 :::
 
-Make your selection and select **Continue**.
+Make your selection and select **Continue**.
 
-### (Optional) Create a Secret
+##### (Optional) Create a Secret
 
 The secret creation settings appear only if you have selected **Kubernetes Optimization by AutoStopping** feature in the **Feature Selection** step. In this step, you are providing permissions for intelligent cloud AutoStopping rules. For more information, see [Create AutoStopping Rules for AWS](/docs/cloud-cost-management/use-ccm-cost-optimization/optimize-cloud-costs-with-intelligent-cloud-auto-stopping-rules/create-auto-stopping-rules/create-autostopping-rules-aws).
 
 1. In **Secret creation**, select create an API key here and create an API key. Go to [Create an API Key](/docs/platform/automation/api/add-and-manage-api-keys) for more information.
 2. Run the following commands in your Kubernetes cluster:
-	1. Create a namespace.  
-	
+
+	1. Create a namespace.
+
 	```
 	kubectl create namespace harness-autostopping
 	```
+
 	2. In the following YAML, add the API token that you created (in step 1) and run the command in your K8s cluster.  
-	
+
 	```
-	apiVersion: v1  
-	data:  
-	    token: <*paste token here*>  
-	kind: Secret  
-	metadata:  
-	    name: harness-api-key  
-	    namespace: harness-autostopping  
+	apiVersion: v1
+	data:
+	    token: TOKEN
+	kind: Secret
+	metadata:
+	    name: harness-api-key
+	    namespace: harness-autostopping
 	type: Opaque
 	```
-	3. Run the following command:  
-	
+
+	3. Run the following command:
+
 	```
 	kubectl apply -f secret.yaml
 	```
+
 3. Select **Continue**.
 
-### Provide Permissions
+##### Provide Permissions
 
 If the cluster does not already have additional permissions, you will apply them in this step. See Delegate Permissions in the Prerequisites section for additional details.
 
-1. In **Provide Permissions**, select **Download YAML**.
+1. In **Provide Permissions**, select **Download YAML**.
 2. Copy the downloaded YAML to a machine where you have `kubectl`installed and have access to your Kubernetes cluster.
-3. Run the following command to apply the Harness Delegate permissions to your Kubernetes Cluster.  
-  
+3. Run the following command to apply the Harness Delegate permissions to your Kubernetes Cluster.
 
-```
-$ kubectl apply -f ccm-kubernetes.yaml
-```
+   ```
+   $ kubectl apply -f ccm-kubernetes.yaml
+   ```
+
 4. Select **Done** and **Continue**.
-5. In **Verify connection**, once the Test Connection succeeds, select **Finish**.  
-  
+5. In **Verify connection**, once the Test Connection succeeds, select **Finish**.
+
 The Connector is now listed in **Connectors**.
 
-  ![](./static/set-up-cost-visibility-for-kubernetes-19.png)
+![](./static/set-up-cost-visibility-for-kubernetes-19.png)
 
-### Troubleshooting
+## Troubleshooting
 
-In **Verify connection** step if you get `few of the visibility permissions are missing` error message, you need to review the CCM permissions required for Harness Delegate.
+In **Verify connection** step, if you get an error message like `few of the visibility permissions are missing`, then you need to review the CCM permissions required for Harness Delegate.
 
-![](./static/set-up-cost-visibility-for-kubernetes-20.png)Verify that you have all the required permissions for the Service account using the following commands:
+![](./static/set-up-cost-visibility-for-kubernetes-20.png)
 
+Verify that you have all the required permissions for the Service account using the following commands:
 
 ```
-kubectl auth can-i watch pods   
---as=system:serviceaccount:<your-namespace>:<your-service-account>   
---all-namespaces  
-kubectl auth can-i watch nodes   
---as=system:serviceaccount:<your-namespace>:<your-service-account>   
+kubectl auth can-i watch pods
+--as=system:serviceaccount:<your-namespace>:<your-service-account>
+--all-namespaces
+kubectl auth can-i watch nodes
+--as=system:serviceaccount:<your-namespace>:<your-service-account>
 --all-namespaces
 ```
 
 ```
-  
-kubectl auth can-i get nodemetrics   
---as=system:serviceaccount:<your-namespace>:<your-service-account>   
---all-namespaces  
-kubectl auth can-i get podmetrics   
---as=system:serviceaccount:<your-namespace>:<your-service-account>   
+kubectl auth can-i get nodemetrics
+--as=system:serviceaccount:<your-namespace>:<your-service-account>
+--all-namespaces
+kubectl auth can-i get podmetrics
+--as=system:serviceaccount:<your-namespace>:<your-service-account>
 --all-namespaces
 ```
+
 Here is an example showing the commands and output using the default Delegate Service account name and namespace:
 
-
 ```
-$ kubectl auth can-i watch pods --as=system:serviceaccount:harness-delegate:default --all-namespaces  
-yes  
-$ kubectl auth can-i watch nodes --as=system:serviceaccount:harness-delegate:default --all-namespaces                                                                      
-yes  
-$ kubectl auth can-i watch nodemetrics --as=system:serviceaccount:harness-delegate:default --all-namespaces                                                                
-yes  
-$ kubectl auth can-i watch podmetrics --as=system:serviceaccount:harness-delegate:default --all-namespaces   
+$ kubectl auth can-i watch pods --as=system:serviceaccount:harness-delegate:default --all-namespaces
+yes
+$ kubectl auth can-i watch nodes --as=system:serviceaccount:harness-delegate:default --all-namespaces
+yes
+$ kubectl auth can-i watch nodemetrics --as=system:serviceaccount:harness-delegate:default --all-namespaces
+yes
+$ kubectl auth can-i watch podmetrics --as=system:serviceaccount:harness-delegate:default --all-namespaces
 yes
 ```
+
 ## Next Steps
 
 * [Optimize Cloud Costs with AutoStopping Rules](/docs/cloud-cost-management/use-ccm-cost-optimization/optimize-cloud-costs-with-intelligent-cloud-auto-stopping-rules/create-auto-stopping-rules/autostopping-dashboard)
 * [Root Cost Analysis](../../3-use-ccm-cost-reporting/3-root-cost-analysis/perform-root-cost-analysis.md)
 * [Create Cost Perspectives](../../3-use-ccm-cost-reporting/1-ccm-perspectives/1-create-cost-perspectives.md)
-

--- a/release-notes/cloud-cost-management.md
+++ b/release-notes/cloud-cost-management.md
@@ -2,7 +2,7 @@
 title: Cloud Cost Management release notes
 sidebar_label: Cloud Cost Management
 tags: [NextGen, "cloud cost management"]
-date: 2023-09-20T10:00
+date: 2024-03-19T10:00
 sidebar_position: 6
 ---
 
@@ -30,7 +30,7 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 #### Fixed issues
 
-- Fixed intermittent issues which resulted in failure in S3 data sync and data ingestion for seamless and on-time updation of data. [CCM-14988]
+- Fixed intermittent issues which resulted in failure in S3 data sync and data ingestion for seamless and on-time updating of data. [CCM-14988]
 
 ### Version 1.9.5
 
@@ -44,7 +44,7 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 
 #### Fixed issues
 
--  We added a default value (CURRENT_MONTH) for the overviewTimeFilter parameter in the Overview Forecasting API, ensuring consistency and simplifying usage. [CCM-16458]
+- We added a default value (CURRENT_MONTH) for the overviewTimeFilter parameter in the Overview Forecasting API, ensuring consistency and simplifying usage. [CCM-16458]
 - We identified and resolved a high memory and CPU utilization issue in our delegate pods, traced back to improper handling of Chronicle libraries. The fix involved ensuring the StoreTailer objects are closed after each use, significantly improving system performance and stability. [CCM-16052]
 
 ### Version 1.7.3
@@ -99,51 +99,56 @@ Harness deploys changes to Harness SaaS clusters on a progressive basis. This me
 - When creating or updating a perspective with an "invalid" cost category. If a cost category shares the exact same name as the attribute "shared cost," attempting to include it in a perspective results in a failure message: "Oops, something went wrong on our end. Please contact Harness Support." We have improved the error message with details telling that the cost category name cannot be same as shared cost bucket name. [CCM-15536]
 - Horizontal scrolling was absent from all pages except perspective-details. This has now been successfully addressed and resolved. [CCM-14720]
 
-## December 2023
+## Previous releases
 
-### Version 81801
+<details>
+<summary>2023 releases</summary>
 
-#### Fixed issues
+#### December 2023
+
+##### Version 81801
+
+###### Fixed issues
 
 - Previously, clicking on "Log Section" in the Review Screen redirected users to Compute Coverage instead of defaulting to the Events Logs Section as intended. Now, from the review section of commitment orchestration, the link for the log section correctly directs users to the Events Logs Section. This issue has been successfully resolved. [CCM-15189]
 - Sometimes, changing filters in the default Perspective interface would reset the page but fail to display the table initially. This issue has now been resolved, with the table consistently appearing after filter and groupby adjustments. [CCM-14990]
 
-## November 2023
+#### November 2023
 
-### Version 81700
+##### Version 81700
 
-#### New features and enhancements
+###### New features and enhancements
 
 - Pagination for perspectives has been added for faster loading times of perspectives. By default only 20 perspectives will be shown. To see all the perspectives set the pageSize as 10,000 and pageNo as 0. By default all perspectives are ordered by most recent. (CCM-15124)
 
-### Version 81601
+##### Version 81601
 
-#### New features and enhancements
+###### New features and enhancements
 
 - RBAC (Role-Based Access Control) support has been implemented for the Commitment Orchestrator. CCM Admins now possess the authority to configure the Commitment Orchestrator for master accounts. On the other hand, CCM Viewers are granted access to visibility screens within the Commitment Orchestrator interface. (CCM-15040)
 - Earlier, we didn't support adding relevant rule filters for perspectives created through cloud providers. As a result, all anomalies were being displayed on the cloud providers' perspective, regardless of whether they were relevant to that perspective or not. In this release, we have now added rule filters for cloud providers to address this issue. (CCM-15068)
 
-#### Fixed issues
+###### Fixed issues
 
 - Previously, entering connector names resulted in incorrect error message "Delegate with that name already exists." This hindered the quick connection setup. Now, the system accurately reflects the correct error message for when Delegate validation failures. (CCM-14963)
 
-### Version 81501
+##### Version 81501
 
-#### New features and enhancements
+###### New features and enhancements
 
 - The perspectives page has been enhanced with pagination for both the Card and List views. Each page will display a maximum of 20 perspectives, addressing the issue where some customers experienced lag during the initial rendering of the perspectives list pages. (CCM-14018)
 
-#### Fixed issues
+###### Fixed issues
 
 - In the updated functionality for K8s connectors, the "View Costs" feature is now enabled based on the presence of cluster data rather than relying solely on the last events received. This enhancement ensures that users retain the ability to view historical costs. (CCM-14984)
 
-### Version 81402
+##### Version 81402
 
-#### New features and enhancements
+###### New features and enhancements
 
 - Previously, there was no option to export Recommendations as CSV files. Now, we have added a new feature that enables users to export Recommendations as comma-separated values (CSV) files. (CCM-14274)
 
-#### Fixed issues
+###### Fixed issues
 
 - Previously, changing the project in JIRA didn't clear fields, causing potential creation failures. (CCM-14842)
 
@@ -156,11 +161,6 @@ Now, we have implemented a threshold of $3 for anomaly detection on K8s Services
 - Previously, incorrect entity types for Azure in anomalies caused misdirected notifications on Slack and email. (CCM-14864)
 
 However, this issue is fixed now by changing the logic for Azure entity types.
-
-## Previous releases
-
-<details>
-<summary>2023 releases</summary>
 
 #### October 26, 2023, version 81300
 

--- a/release-notes/cloud-cost-management.md
+++ b/release-notes/cloud-cost-management.md
@@ -13,45 +13,38 @@ import TabItem from '@theme/TabItem';
 
 Review the notes below for details about recent changes to Harness Cloud Cost Management. For release notes for Harness Self-Managed Enterprise Edition, go to [Self-Managed Enterprise Edition release notes](/release-notes/self-managed-enterprise-edition). Additionally, Harness publishes security advisories for every release. Go to the [Harness Trust Center](https://trust.harness.io/?itemUid=c41ff7d5-98e7-4d79-9594-fd8ef93a2838&source=documents_card) to request access to the security advisories.
 
-:::info note
+:::info
+
 Harness deploys changes to Harness SaaS clusters on a progressive basis. This means that the features and fixes that these release notes describe may not be immediately available in your cluster. To identify the cluster that hosts your account, go to the **Account Overview** page.
+
 :::
+
 ## March 2024
 
 ### Version 1.10.2
+
 #### New features and enhancements
+
 - Perspectives update: Added a new query parameter called `updateTotalCost` in the create and update perspective call. When set to false, the total cost that is displayed on the list perspective page will not be calculated. Instead,  only create/update operation for the perspective will be performed.[CCM-16724]
 - New limits for cost categories: Per account, there can be up to 25 cost categories, 1000 cost buckets, and 10 shared buckets. Additionally, nested cost category hierarchy can extend up to 5 levels per cost category. [CCM-13843]
 
-#### Early access features
-This release does not include any early access features.
-
 #### Fixed issues
+
 - Fixed intermittent issues which resulted in failure in S3 data sync and data ingestion for seamless and on-time updation of data. [CCM-14988]
 
 ### Version 1.9.5
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-This release does not include any early access features.
 
 #### Fixed issues
+
 - Previously the exported CSV was not reflecting the Perspective Preferences set by the user. Now it has been fixed and the rows of Perspective Grid and exported CSV should match. [CCM-16586]
 
 ## February 2024
+
 ### Version 1.8.1
 
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-
-This release does not include any early access features.
-
 #### Fixed issues
--  We added a default value (CURRENT_MONTH) for the overviewTimeFilter parameter in the Overview Forecasting API, ensuring consistency and simplifying usage. [CCM-16458]
 
+-  We added a default value (CURRENT_MONTH) for the overviewTimeFilter parameter in the Overview Forecasting API, ensuring consistency and simplifying usage. [CCM-16458]
 - We identified and resolved a high memory and CPU utilization issue in our delegate pods, traced back to improper handling of Chronicle libraries. The fix involved ensuring the StoreTailer objects are closed after each use, significantly improving system performance and stability. [CCM-16052]
 
 ### Version 1.7.3
@@ -59,10 +52,6 @@ This release does not include any early access features.
 #### New features and enhancements
 
 - We have seamlessly integrated Azure preferences into the Account Settings. Users can conveniently configure your preferences there, and once the Azure preferences feature is launched, they will be applied across all Azure perspectives for enhanced customization and consistency. [ccm-15789]
-
-#### Early access features
-
-This release does not include any early access features.
 
 #### Fixed issues
 
@@ -73,137 +62,66 @@ This release does not include any early access features.
 #### New features and enhancements
 
 - In the Azure connector flow, a new field named "billing type" has been incorporated to identify users' billing types. This enhancement sets the groundwork for enabling Azure cost preferences in future updates. [CCM-15978]
-
 - We've implemented the edit flow for commitment orchestration, granting users the ability to modify their commitment orchestration details seamlessly. [CCM-11304]
 
-#### Early access features
-
-This release does not include any early access features.
-
 #### Fixed issues
+
 - The Filter API is paginated; however, the UI filter component lacked pagination support. To address this, we have implemented a result limit of 1000. Now users will be able to see all the saved filters in the recommendation filters. [CCM-16364]
-
 - Previously, users faced limitations when attempting to adjust constituents within budget groups, hindering adaptability to organizational changes. Now, Budget group edit flow will not block the budgets or budget groups selected in that budget group eliminating constraints and enhancing flexibility. [CCM-16196]
-
 - After upgrading to SMP version 0.120, users encountered issues with BI Dashboards loading, prompting them to add connectors despite existing connectors at the account level. In response, for SMP Environment, we've implemented redirects to the Dashboards module to facilitate viewing BI Dashboards seamlessly. [CCM-15995]
-
 
 ## January 2024
 
 ### Version 1.5.1
 
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-This release does not include any early access features.
-
 #### Fixed issues
-- Previously, it was a bit difficult editing cost categories, especially on smaller monitors or when the web browser isn't maximized. To address this, we've implemented a fix in the layout of rules specifically for smaller windows. With this adjustment, users can now seamlessly edit cost categories even on smaller screens, ensuring a smoother experience across different viewing contexts. [CCM-15991]
 
+- Previously, it was a bit difficult editing cost categories, especially on smaller monitors or when the web browser isn't maximized. To address this, we've implemented a fix in the layout of rules specifically for smaller windows. With this adjustment, users can now seamlessly edit cost categories even on smaller screens, ensuring a smoother experience across different viewing contexts. [CCM-15991]
 - Upon clicking back from the shared cost screen, users encountered a non-functional continue button due to form validation issues. We have resolved this impediment from the UI side, ensuring users can proceed seamlessly without hindrance. [CCM-15990]
 
 ### Version 1.4.2
-
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-This release does not include any early access features.
 
 #### Fixed issues
 
 - In Commitment Orchestrator, the exclusion of resource instances was found confusing sometimes, necessitating a clearer flow. We've made enhancements to the commitment orchestration setup flow. [CCM-15844]
 
 ### Version 1.3.0
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-This release does not include any early access features.
 
 #### Fixed issues
+
 - While filtering for a GCP anomaly and clicking on the Anomaly link in perspectives redirected users to the Azure-based anomaly screen. To rectify this, we've implemented a solution to ensure that only relevant anomalies are displayed by adding an "EQUAL" case in the switch condition with the appropriate condition format for equal cases. [CCM-15649]
 
 ### Version 1.2.1
-#### New features and enhancements
-This release does not include any new features.
-
-#### Early access features
-This release does not include any early access features.
 
 #### Fixed issues
 
 - Users without edit permissions for perspectives were still able to see the "+ New Perspective" button, which was not grayed out, leading to confusion. Now, if users lack edit access on perspectives or folders, the "+ New Perspective" button will be disabled, preventing confusion. Furthermore, error messages have been refined to provide clearer feedback. [CCM-15611]
-
-- when creating or updating a perspective with an "invalid" cost category. If a cost category shares the exact same name as the attribute "shared cost," attempting to include it in a perspective results in a failure message: "Oops, something went wrong on our end. Please contact Harness Support." We have improved the error message with details telling that the cost category name cannot be same as shared cost bucket name. [CCM-15536]
-
+- When creating or updating a perspective with an "invalid" cost category. If a cost category shares the exact same name as the attribute "shared cost," attempting to include it in a perspective results in a failure message: "Oops, something went wrong on our end. Please contact Harness Support." We have improved the error message with details telling that the cost category name cannot be same as shared cost bucket name. [CCM-15536]
 - Horizontal scrolling was absent from all pages except perspective-details. This has now been successfully addressed and resolved. [CCM-14720]
 
 ## December 2023
 
-### Version 82001
-
-#### New features and enhancements
-
-This release does not include any new features.
-#### Early access features
-
-This release does not include any early access features.
-
-#### Fixed issues
-This release does not include any fixed issues.
-
-### Version 81904
-
-#### New features and enhancements
-
-This release does not include any new features.
-#### Early access features
-
-This release does not include any early access features.
-
-#### Fixed issues
-This release does not include any fixed issues.
-
 ### Version 81801
 
-#### New features and enhancements
-
-This release does not include any new features.
-
-#### Early access features
-
-This release does not include any early access features.
-
 #### Fixed issues
+
 - Previously, clicking on "Log Section" in the Review Screen redirected users to Compute Coverage instead of defaulting to the Events Logs Section as intended. Now, from the review section of commitment orchestration, the link for the log section correctly directs users to the Events Logs Section. This issue has been successfully resolved. [CCM-15189]
-
 - Sometimes, changing filters in the default Perspective interface would reset the page but fail to display the table initially. This issue has now been resolved, with the table consistently appearing after filter and groupby adjustments. [CCM-14990]
-
 
 ## November 2023
 
 ### Version 81700
 
 #### New features and enhancements
+
 - Pagination for perspectives has been added for faster loading times of perspectives. By default only 20 perspectives will be shown. To see all the perspectives set the pageSize as 10,000 and pageNo as 0. By default all perspectives are ordered by most recent. (CCM-15124)
-
-#### Early access features
-This release does not include any early access features.
-
-#### Fixed issues
-This release does not include any fixed issues.
 
 ### Version 81601
 
 #### New features and enhancements
+
 - RBAC (Role-Based Access Control) support has been implemented for the Commitment Orchestrator. CCM Admins now possess the authority to configure the Commitment Orchestrator for master accounts. On the other hand, CCM Viewers are granted access to visibility screens within the Commitment Orchestrator interface. (CCM-15040)
-
 - Earlier, we didn't support adding relevant rule filters for perspectives created through cloud providers. As a result, all anomalies were being displayed on the cloud providers' perspective, regardless of whether they were relevant to that perspective or not. In this release, we have now added rule filters for cloud providers to address this issue. (CCM-15068)
-
-#### Early access features
-This release does not include any early access features.
 
 #### Fixed issues
 
@@ -215,10 +133,6 @@ This release does not include any early access features.
 
 - The perspectives page has been enhanced with pagination for both the Card and List views. Each page will display a maximum of 20 perspectives, addressing the issue where some customers experienced lag during the initial rendering of the perspectives list pages. (CCM-14018)
 
-#### Early access features
-
-This release does not include any early access features.
-
 #### Fixed issues
 
 - In the updated functionality for K8s connectors, the "View Costs" feature is now enabled based on the presence of cluster data rather than relying solely on the last events received. This enhancement ensures that users retain the ability to view historical costs. (CCM-14984)
@@ -227,13 +141,7 @@ This release does not include any early access features.
 
 #### New features and enhancements
 
-- Previously, there was no option to export Recommendations as CSV files. (CCM-14274)
-
-Now, we have added a new feature that enables users to export Recommendations as comma-separated values (CSV) files.
-
-#### Early access features
-
-This release does not include any early access features.
+- Previously, there was no option to export Recommendations as CSV files. Now, we have added a new feature that enables users to export Recommendations as comma-separated values (CSV) files. (CCM-14274)
 
 #### Fixed issues
 
@@ -256,14 +164,6 @@ However, this issue is fixed now by changing the logic for Azure entity types.
 
 #### October 26, 2023, version 81300
 
-##### New features and enhancements
-
-This release does not include any new features.
-
-##### Early access features
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Previously, the search functionality in the perspective grid was nonfunctional when grouped by cost categories, causing inconvenience in data retrieval. (CCM-14384)
@@ -279,14 +179,6 @@ This release does not include any early access features.
   This issue is fixed by removing the "group by" from the budget time-series query, ensuring more accurate cost representation.
 
 #### October 20, 2023, version 81202
-
-##### New features and enhancements
-
-This release does not include any new features.
-
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -311,14 +203,6 @@ This release does not include any early access features.
 
 #### October 12, 2023, version 81100
 
-##### New features and enhancements
-
-This release does not include any new features.
-
-##### Early access features
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Previously, attempting to edit a cost bucket with operands selected as "NOT NULL/NULL" led to an unexpected error, subsequently hindering the editing of other buckets. (CCM-14519)
@@ -330,14 +214,6 @@ This release does not include any early access features.
   As of this release, we have discontinued support for fetching anomalies in perspectives created solely through labels. This change is aimed at improving the accuracy of anomaly reporting and ensuring that only relevant anomalies are presented.
 
 #### October 5, 2023, version 81000
-
-##### New features and enhancements
-
-This release does not include any new features.
-
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -351,11 +227,7 @@ This is fixed by switching to totalMonthlyCost and totalMonthlySavings for the p
 
 - Previously, CCM displayed only the essential Jira or ServiceNow fields in Recommendation Workflows. However, with this enhancement, CCM introduces a new field _+ Fields_ that allows users to add optional fields as needed.
 
-  <DocImage path={require('./static/ccm-jira-ticket-enhancement.png')} width="40%" height="40%" title="Click to view full size image" />
-
-##### Early access features
-
-This release does not include any early access features.
+<DocImage path={require('./static/ccm-jira-ticket-enhancement.png')} width="40%" height="40%" title="Click to view full size image" />
 
 ##### Fixed issues
 
@@ -368,14 +240,6 @@ This release does not include any early access features.
   This issue is fixed by using SUM of `awsUnblendedCost` to detect AWS (Account, Service and UsageType) anomalies.
 
 #### September 20, 2023, version 80804
-
-##### New features and enhancements
-
-This release does not include any new features.
-
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -393,11 +257,8 @@ Implemented a new feature that enables users to copy cost buckets from one cost 
 
 However, it's important to note that while copying you may encounter issues if the destination cost category already has a bucket with the same name as the copied one. In such cases, you can address the conflict by renaming the bucket before attempting the copy operation again.
 
-    <DocImage path={require('./static/ccm-copy-cost-buckets.gif')} width="60%" height="60%" title="Click to view full size image" />
+<DocImage path={require('./static/ccm-copy-cost-buckets.gif')} width="60%" height="60%" title="Click to view full size image" />
 
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -424,10 +285,6 @@ This release does not include any early access features.
   Previously, our graph in perspectives didn't display refunds or discounts, resulting in empty spots when values were negative. This enhancement improves this by aggregating negative values into a red-colored bar chart. You can now toggle a button in **General Preferences** to view these previously hidden negative costs.
 
   <DocImage path={require('./static/aws-preferences-ccm13443.png')} width="60%" height="60%" title="Click to view full size image" />
-
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -463,10 +320,6 @@ This release does not include any early access features.
   - Line item type
 
   For more information, go to [Analyze AWS costs by using perspectives](/docs/cloud-cost-management/use-ccm-cost-reporting/root-cost-analysis/analyze-cost-for-aws).
-
-##### Early access features
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -507,10 +360,6 @@ The current configurations for **Show others** and **Show unallocated cost in cl
     <DocImage path={require('./static/ccm-overview-2.png')} width="60%" height="60%" title="Click to view full size image" />
     <DocImage path={require('./static/ccm-overview-3.png')} width="60%" height="60%" title="Click to view full size image" />
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Previously, configuring both the redirect URL and target port for redirection while creating a redirect-based AutoStopping rule led to an error. (CCM-13475)
@@ -524,20 +373,6 @@ This release does not include any early access features.
 - Previously, users experienced performance delays while editing cost categories with more than 50 buckets, and every subsequent action took several seconds to trigger. (CCM-13205)
 
   The issue has been resolved, and the overall user experience has been enhanced by streamlining the process of managing cost categories even with a large number of buckets.
-
-#### July 21, 2023, version 80202
-
-##### What's new
-
-This release does not include any new features.
-
-##### Early access
-
-This release does not include any early access features.
-
-##### Fixed issues
-
-This release does not include any fixed issues.
 
 #### July 13, 2023, version 80102
 
@@ -556,10 +391,6 @@ By default, the first two options are enabled, and you can modify the toggles to
 &nbsp <DocImage path={require('./static/ccm-toggle-options-recommendations-filter.png')} width="40%" height="40%" title="Click to view full size image" />
 
 <DocImage path={require('./static/ccm-tooltip-recommendations.png')} width="60%" height="60%" title="Click to view full size image" />
-
-##### Early access
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -589,10 +420,6 @@ This release does not include any early access features.
 
   You can now easily move recommendations from the **Applied** state back to the **Open** state. This enhancement allows you to easily rectify accidental closure of recommendations or marking Jira tickets as done by returning them to an actionable state.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Nodepool recommendations displayed incorrect savings data. (CCM-12816)
@@ -620,10 +447,6 @@ Implemented a check to exclude nodepools that have more than one instance family
 
     <DocImage path={require('./static/ccm-budget-grp-slack-msg.png')} width="60%" height="60%" title="Click to view full size image" />
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The cost data was not displayed on the **Perspectives** page. (CCM-12752)
@@ -646,10 +469,6 @@ The payload for adding EC2 recommendations to the **Ignore List** was incorrect.
 
   Previously, in the **Asset Governance** > **Evaluations** page, only the target accounts with `execute` permissions were included in the **Target Accounts** field in the filter panel. Now, this functionality is enhanced so that all target accounts with `view` permissions are also included in the list.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The budget screen displayed inconsistent margins, leading to overlapping text in different columns. To address this issue, the columns in the budget list have been readjusted, ensuring that the text in each column no longer coincides with the text in adjacent columns. (CCM-10980)
@@ -658,10 +477,6 @@ This release does not include any early access features.
   The detection of routing rules on the Azure Application Gateway was impacted due to the presence of an additional custom probe configuration. To address this issue, during the detection of routing rules for the specified port configuration, any custom probes are now ignored. However, the custom probe will continue to be utilized for the selected rule.
 
 #### June 09, 2023, version 79701
-
-##### What's new
-
-This release does not include any new features.
 
 ##### Early access
 
@@ -672,10 +487,6 @@ You can now propagate force cool down from primary rule to dependent rules.
 Earlier, when stopping a rule from the UI, you had to stop its dependant rules one by one. With this enhancement, you can propagate the stop operation to dependant rules as well.
 
 Propagating cool down to dependant rules is optional. You can stop the primary rule with or without propagating cool down to dependent rules.
-
-##### Fixed issues
-
-This release does not include any fixed issues.
 
 #### June 06, 2023, version 79601
 
@@ -690,10 +501,6 @@ When building a cost category, it is now possible to incorporate another cost ca
 - You cannot create cyclic nested cost categories, where a cost category is nested within each other.
 - You can nest cost categories to a maximum of 20 levels.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Budgets that contain the `/` character in their names were previously experiencing issues with correctly opening the budget details page. (CCM-12062)
@@ -707,10 +514,6 @@ This release does not include any early access features.
 **Azure VM recommendations**
 
 Introducing Azure VM recommendations that identifies idle or under utilized VMs, ensuring efficient resource allocation and significant cost savings. For more information, go to [Azure recommendations](/docs/cloud-cost-management/use-ccm-cost-optimization/ccm-recommendations/azure-vm/).
-
-##### Early access
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -736,14 +539,6 @@ This release does not include any early access features.
 
 #### May 19, 2023, version 79400
 
-##### What's new
-
-This release does not include any new features.
-
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Budget group missing from the Budget page. (CCM-12334)
@@ -755,10 +550,6 @@ This release does not include any early access features.
   Saving the AutoStopping rule did not append custom domain providers for non-AWS cloud providers. This resulted in a validation error at the back-end. This issue has been resolved. The required field `custom_domain_provider` is now being set for all cloud providers.
 
 #### May 05, 2023, version 79300
-
-##### What's new
-
-This release does not include any new features.
 
 ##### Early access
 
@@ -799,10 +590,6 @@ The issue is resolved now.
 
   A new filter has been added to recommendations, which allows the selection of the age of the recommendations. This filter allows you to specify how many days old recommendations should be included in the results.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The **Recommendations** page displayed incorrect savings value. (CCM-12082)
@@ -828,10 +615,6 @@ This release does not include any early access features.
 - Workload recommendations enhancement. (CCM-9161)(Zendesk Ticket ID 34658)
 
   Introduced support for 100th percentile in workload recommendations. Recommendations will be displayed for 100% usage of workloads.
-
-##### Early access
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -864,10 +647,6 @@ This release does not include any early access features.
 
   For more information, go to [Use Cost Categories](/docs/cloud-cost-management/use-ccm-cost-reporting/ccm-cost-categories/cost-categories-usage).
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The error message displayed while creating a Jira ticket to apply recommendations was not meaningful. (CCM-10822)
@@ -885,10 +664,6 @@ This release does not include any early access features.
   - If the **Cost Category** is `NULL`, it indicates that the cost buckets are not considered in the perspective. `Unattributed` is taken into account.
   - Previously, all shared cost buckets were displayed as `No Groupby`. Now, when you apply a GroupBy option other than the cost category, the cost of the rules present in the shared cost bucket are displayed in a separate entity based on the GroupBy selection you have made. However, it is important to note that this change will be effective only if you have incorporated cost category with shared buckets in perspective rules.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Previously, deleting a cost category caused the perspectives that utilized the cost category in their rule or GroupBy to crash. (CCM-9902)
@@ -903,14 +678,6 @@ This release does not include any early access features.
   This issue has been fixed. Now, the Health Check option remains disabled when you edit the AutoStopping rule.
 
 #### March 06, 2023
-
-##### What's new
-
-This release does not include any new features.
-
-##### Early access
-
-This release does not include any early access features.
 
 ##### Fixed issues
 
@@ -933,10 +700,6 @@ This release does not include any early access features.
 - Introducing support for adding more than one CCM GCP connector when you have two or more billing export tables with different billing account IDs in the same dataset. (CCM-11244)
 - Introducing support for assigning a custom static port as the source port in the port configuration of the TCP traffic-based AutoStopping rule. (CCM-11264)
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - Previously, the **Start Date** selected when creating a budget was not being saved and instead the date of budget creation was being displayed as the **Start Date**. (CCM-10952)
@@ -957,10 +720,6 @@ This release does not include any early access features.
 
 Harness CCM introduces **AutoStopping Proxy** to support AutoStopping for HTTPS and TCP connections. For more information, go to [Add load balancers](/docs/category/add-load-balancers-for-autostopping-rules) and [Create AutoStopping rules](/docs/category/create-autostopping-rules).
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The potential monthly savings displayed on the UI did not match with the Spot or On-Demand recommendations. (CCM-10698)
@@ -979,14 +738,6 @@ Now, the API returns both account name and ID.
 
 #### January 31, 2023
 
-##### What's new
-
-This release does not include any new features.
-
-##### Early access
-
-This release does not includeany early access features.
-
 ##### Fixed issues
 
 - Hourly data on the **Perspectives** page showed an incorrect billing amount for multiple accounts. CloudFunction was unable to delete the existing records but continued ingesting a new entry in clusterDataHourly in BigQuery. (CCM-10711)
@@ -999,14 +750,6 @@ This release does not includeany early access features.
 
 #### January 18, 2023
 
-##### What's new
-
-This release does not include any new features.
-
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - While creating a Jira ticket to apply EC2 recommendations, the **Account Name** field in the Jira description incorrectly displayed the Account ID. (CCM-10507)
@@ -1014,10 +757,6 @@ This release does not include any early access features.
   Now, the issue is fixed, and the account name is displayed correctly.
 
 #### January 04, 2023
-
-##### What's new
-
-This release does not include any new features.
 
 ##### Early access
 
@@ -1028,10 +767,6 @@ This release does not include any new features.
 - API implementation for the Currency Preferences feature (CCM-9632)
 
   You can now use the Currency Preference API to select the currency in which you want to view your entire CCM application across different cloud providers. Go to [Harness API Documentation](https://apidocs.harness.io/) for more information.
-
-##### Fixed issues
-
-This release does not include any fixed issues.
 
 </details>
 
@@ -1046,23 +781,11 @@ This release does not include any fixed issues.
 
   While adding a node pool name, Harness CCM looked only for the exact match. Now, CCM has introduced support to check if the node label key contains the string node-pool-name. CCM falls back to _contains_ if an exact match is not found. See [Labels for node pool recommendations](/docs/cloud-cost-management/use-ccm-cost-optimization/ccm-recommendations/node-pool-recommendations#prerequisites) for more information.
 
-##### Early access
-
-This release does not include any early access features.
-
 ##### Fixed issues
 
 - The messages in budget alert notification emails were misleading. Now, the emails convey more meaningful and dynamic messages. They provide the cost type and the period for which the alert is created. (CCM-9291)
 
 #### December 07, 2022, version 77716
-
-##### What's new
-
-This release does not include new features.
-
-##### Early access
-
-This release does not include early access features.
 
 ##### Fixed issues
 
@@ -1084,14 +807,6 @@ This release does not include early access features.
 
 #### November 29, 2022, version 77608
 
-##### What's new
-
-NA
-
-##### Early access
-
-NA
-
 ##### Fixed issues
 
 - The bars in the Perspectives chart grouped by cost categories were not rendering properly. (CCM-9502)
@@ -1112,10 +827,6 @@ NA
 
 This release adds validation to ensure that the load balancer domain name specified in the YAML file to create an AutoStopping rule is valid and exists in your Harness account. (CCM-9101)
 
-##### Early access
-
-NA
-
 ##### Fixed issues
 
 - When the Harness account ID of the customer begins with a hyphen, sts assume-role step in the data ingestion pipeline interpreted it as an additional argument, and thus failed to run the command.
@@ -1132,10 +843,6 @@ NA
 
 You can now add labels to enable node pool recommendations. `kops cluster` node label has been added for node pool recommendations. See [Labels for node pool recommendations](/docs/cloud-cost-management/use-ccm-cost-optimization/ccm-recommendations/node-pool-recommendations#prerequisites) for more information. (CCM-9309)
 
-##### Early access
-
-NA
-
 ##### Fixed issues
 
 The AWS cost shown in the Perspective section and the dashboard mismatched. Duplicate account name entries that belonged to the same account ID caused this issue in the dashboards. (CCM-9344)
@@ -1145,14 +852,6 @@ This issue is resolved.
 #### October 07, 2022, version 77025
 
 Delegate version: 77021
-
-##### What's new
-
-NA
-
-##### Early access
-
-NA
 
 ##### Fixed issues
 
@@ -1198,32 +897,16 @@ NA
 
   Now, while updating the connector name, the cluster name is also updated to fix this issue. However, it isn't recommended to update the connector name.
 
-#### September 29, 2022, version 76921​
+#### September 29, 2022, version 76921
 
 ##### What's new
 
-- First-class Support for Istio is released with version 1.0.8 of autostopping-controller.​ (CCM-8386)
-  You can now onboard Istio virtualservices-based workloads to AutoStopping without editing the virtualservice manually​.
+- First-class Support for Istio is released with version 1.0.8 of autostopping-controller. (CCM-8386)
+  You can now onboard Istio virtualservices-based workloads to AutoStopping without editing the virtualservice manually.
 
-- Now, you can sort perspective filters while creating cost categories, perspectives, etc. You can search for a filter quickly and apply it easily.​ (CCM-8597)​​
-
-##### Early access​
-
-NA
-
-##### Fixed issues
-
-NA
+- Now, you can sort perspective filters while creating cost categories, perspectives, etc. You can search for a filter quickly and apply it easily. (CCM-8597)
 
 #### September 14, 2022, version 76708
-
-##### What's new
-
-NA
-
-##### Early access
-
-N/A
 
 ##### Fixed issues
 
@@ -1279,16 +962,22 @@ N/A
 
 - List BI Dashboards API (CCM-7649)
   You can now query a new API to list all the BI Dashboards specific to CCM: Cloud Cost BI Dashboards.
+
   Example query:
+
+  ```
   curl -i -X GET \
    'https://app.harness.io/gateway/ccm/api/bi-dashboards?accountIdentifier=H5W8ioxxxA2MXg' \
    -H 'x-api-key: pat.H5xxxA2MXg.6xxxmD'
+  ```
 
 Example response:
-\{
+
+```
+{
 "status": "SUCCESS",
 "data": [
-\{
+{
 "dashboardName": "AWS Cost Dashboard",
 "dashboardId": "226",
 "cloudProvider": "AWS",
@@ -1297,7 +986,7 @@ Example response:
 "redirectionURL": "#/account/H5W8ioxxxA2MXg/dashboards/folder/shared/view/226"
 },
 ...
-\{
+{
 "dashboardName": "AWS RDS Inventory Cost Dashboard",
 "dashboardId": "3309",
 "cloudProvider": "AWS",
@@ -1309,6 +998,7 @@ Example response:
 "metaData": null,
 "correlationId": "bc71c537-048f-4d53-80cd-8462158e1471"
 }
+```
 
 ##### Fixed issues
 
@@ -1318,7 +1008,7 @@ Example response:
 
 - CCM Perspectives seem to be broken in new UI (CCM-8484, ZD-33142)
 
-In the Perspective Preview section, we were not considering whether it’s a cluster perspective or not. Therefore, we always query unifiedtable. This issue has been resolved. Now, in Perspective Preview section, we are checking whether it’s a cluster perspective or not and based on that querying the correct table.
+In the Perspective Preview section, we were not considering whether it's a cluster perspective or not. Therefore, we always query unifiedtable. This issue has been resolved. Now, in Perspective Preview section, we are checking whether it's a cluster perspective or not and based on that querying the correct table.
 
 - Azure Existing connector validation is failing at test connection (CCM-8423)
 
@@ -1345,10 +1035,6 @@ When you create a CCM Perspective you can now set Preferences for Include Others
 
 For details, go to Perspective Preferences in Create Cost Perspectives.
 
-##### Early access
-
-N/A
-
 ##### Enhancements
 
 Perspective Preferences: Unallocated and Include Others cost support added (CCM-7436)
@@ -1374,18 +1060,6 @@ Now while creating a perspective, you will see a Preferences tab to select the p
   Converting queries to Batch queries. Removing certain Alter statements as they are no longer required.
 
 #### July 18th, 2022, version 75921
-
-##### What's new
-
-N/A
-
-##### Early access
-
-N/A
-
-##### Enhancements
-
-N/A
 
 ##### Fixed issues
 
@@ -1433,10 +1107,6 @@ N/A
 - Slack notifications for Budgets (CCM-7816)
   You can now set the notification channel to Slack and add multiple webhook URLs when creating a budget.
   For more information, refer to Create a Budget.
-
-##### Early access
-
-n/a
 
 ##### Fixed issues
 


### PR DESCRIPTION
- Recreate PR 3873
- Remove empty headings from CCM release notes (please refer to release notes style guide on Confluence. Subheadings are not necessary when there is no content of that type in the release).