### PR TITLE
Update resources across scopes for audit trail

### DIFF
--- a/docs/platform/platform-whats-supported.md
+++ b/docs/platform/platform-whats-supported.md
@@ -187,7 +187,7 @@ The following table lists some resources and their availability at various scope
 | **Secrets** | Yes | Yes | Yes |
 | **SMTP Configuration** | Yes | No | No |
 | **Templates** | Yes | Yes | Yes |
-| **Audit Trail** | Yes | Yes | Yes |
+| **Audit Trail** | Yes | Yes | No |
 | **Delegates** | Yes | Yes | Yes |
 | **Governance** | Yes | Yes | Yes |
 


### PR DESCRIPTION
A question came up in the community Slack. https://harnesscommunity.slack.com/archives/C02K03Q5L0J/p1711642188838719
The customer pointed out that the table here says that Audit Trail is available at the project scope.
https://developer.harness.io/docs/platform/platform-whats-supported/#resources-across-scopes
Here we have the info about viewing the Audit Trail and state that it's only org or account scope.
https://developer.harness.io/docs/platform/governance/audit-trail/#step-view-an-audit-trail

This PR updates the table with the correct info for the Audit Trial at the project scope

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [x] Tested Locally
- [ ] *Optional* Screenshot. 
