### PR TITLE
harness-cloud-windows-amd64-ingestion-only-is-now-supported-sto-5428

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/shared/_supported-infrastructures.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_supported-infrastructures.md
@@ -28,7 +28,7 @@ STO uses [CI build infrastructures](/docs/continuous-integration/use-ci/set-up-b
     <tr>
         <td>Windows</td>
         <td>amd64</td>
-        <td align="center">Roadmap</td>
+        <td align="center">✅ Ingestion mode only</td>
         <td align="center">❌ Not supported</td>
         <td align="center">Roadmap</td>
         <td align="center">❌ Not supported</td>

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -42,7 +42,7 @@ The following features are now generally available:
 
 - Issues tables in **Security Tests** now include a **Target** column. (STO-4918)
 
-- Harness STO now supports ingesting scan results in CI stages that run on Harness Cloud Windows AMD64 build infrastructures. This eliminates the need to cache results from a previous Windows stage and then ingest them in a Linux stage. (STO-5428)  
+- Harness STO now supports ingesting scan results in stages that run on Harness Cloud Windows AMD64 build infrastructures. This eliminates the need to cache results from a previous Windows stage and then ingest them in a Linux stage. (STO-5428)  
 
 #### Fixed issues
 

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -42,6 +42,8 @@ The following features are now generally available:
 
 - Issues tables in **Security Tests** now include a **Target** column. (STO-4918)
 
+- Harness STO now supports ingesting scan results in CI stages that run on Harness Cloud Windows AMD64 build infrastructures. This eliminates the need to cache results from a previous Windows stage and then ingest them in a Linux stage. (STO-5428)  
+
 #### Fixed issues
 
 - Fixed an issue with database migrations that impacted upgrading Self-Managed Platform from version 0.13.x to 0.14.x. (STO-7309)


### PR DESCRIPTION
Preview
- STO release notes > [Version 198.2](https://66074a1dd2b5ac6c58a8c6f4--harness-developer.netlify.app/release-notes/security-testing-orchestration#version-1982) > New features and enhancements, last bullet