### PR TITLE
Delegate RN - remove March 31 date from upcoming changes

### DIFF
--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -2,7 +2,7 @@
 title: Delegate release notes
 sidebar_label: Delegate
 tags: [NextGen, "Delegate"]
-date: 2024-03-29T10:00
+date: 2024-04-02T10:00
 sidebar_position: 4
 ---
 
@@ -26,7 +26,7 @@ These release notes describe recent changes to Harness Delegate.
 
 :::warning important changes
 
-Please note that the following important changes will occur **March 31, 2024**:
+Please note that the following important changes will occur in an upcoming release:
 
 - The `Switch back to old delegate install experience` link will be removed on the New Delegate page, and the old delegate installation flow will be deprecated.
 


### PR DESCRIPTION
Last month, we announced two delegate changes that were scheduled to take place by March EOM.
https://developer.harness.io/release-notes/delegate/#important-upcoming-changes

This PR removes the date since the changes are still pending.

For reviewers, a preview is available:

https://660c31d9e6829646ec91c9cc--harness-developer.netlify.app/release-notes/delegate#important-upcoming-changes

## What Type of PR is This?

- [ ] Issue
- [ ] Feature
- [x] Maintenance/Chore

If tied to an Issue, list the Issue(s) here:

* *Issue(s)*

## House Keeping
Some items to keep track of. Screen shots of changes are optional but would help the maintainers review quicker. 

- [ ] Tested Locally
- [ ] *Optional* Screenshot. 
