### PR TITLE
Remove valueless `tags` metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,13 +108,28 @@ HDH is powered by [Markdown](https://daringfireball.net/projects/markdown/). Tak
 
 ## Additional metadata
 
-When adding a new Markdown file, above the initial H1 tag, a `description` is needed for SEO, and `keywords` are recommended. For example:
+When adding a new Markdown file, above the initial H1 tag, a `description` is needed for SEO. You can include optional `keywords`. For example:
 
 ```
 ---
+title: NodeJS and Docker pipeline
 sidebar_position: 1
 description: This build automation guide walks you through building a NodeJS and Docker Application in a CI Pipeline
-keywords: [Hosted Build, Continuous Integration, Hosted, CI Tutorial]
+keywords: [Tutorial, Continuous Integration, NodeJS, Docker]
+---
+
+```
+
+`keywords` are only available in the page metadata. They are not rendered when published.
+
+`tags` are similar to keywords; however, they offer interactive functionality. If included, tags appear at the bottom of the page. Selecting a tag directs the user to a page listing all pages with that tag. Only use tags if they are used holistically; otherwise the use of tags creates pages with only a few links, rather than accurately representing the full offering of thematically-related content.
+
+```
+---
+title: NodeJS and Docker pipeline
+sidebar_position: 1
+description: This build automation guide walks you through building a NodeJS and Docker Application in a CI Pipeline
+tags: [Tutorial, "Continuous Integration", NodeJS, Docker]
 ---
 
 ```

--- a/docs/platform/get-started/tutorials/gke-workload-identity.md
+++ b/docs/platform/get-started/tutorials/gke-workload-identity.md
@@ -1,7 +1,7 @@
 ---
 title: Install Harness Delegate on Google Kubernetes Engine (GKE) With Workload Identity
 description: This tutorial shows you how to deploy a Harness Delegate that uses Workload Identity to access Google Cloud Services.
-keywords: [Google,delegate,Terraform,GKE,workload identity]
+keywords: [Google, delegate, Terraform, GKE, workload identity]
 sidebar_position: 50
 redirect_from:
   - /tutorials/platform/gke-workload-identity

--- a/docs/platform/get-started/tutorials/secure-delegate-default-to-minimal.md
+++ b/docs/platform/get-started/tutorials/secure-delegate-default-to-minimal.md
@@ -3,7 +3,7 @@ title: Build and set up a delegate with a minimal image type
 description: This tutorial shows you how to build and set up a delegate with a minimal image type.
 sidebar_label: Configure a delegate with the minimal image type
 sidebar_position: 6
-keywords: [delegate,delegate minimal image]
+keywords: [delegate, delegate minimal image]
 ---
 
 Harness recommends that you use the Harness Delegate minimal image (*`yy.mm.xxxxx.minimal`*) when you set up the Harness Platform for production use. This image has been thoroughly scanned and is free of any high or critical vulnerabilities. Users focused on security tend to prefer this option. 

--- a/release-notes/chaos-engineering.md
+++ b/release-notes/chaos-engineering.md
@@ -1,7 +1,6 @@
 ---
 title: Chaos Engineering release notes
 sidebar_label: Chaos Engineering
-tags: [NextGen, "chaos engineering"]
 date: 2024-03-22T10:00
 sidebar_position: 5
 ---

--- a/release-notes/cloud-cost-management.md
+++ b/release-notes/cloud-cost-management.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Cost Management release notes
 sidebar_label: Cloud Cost Management
-tags: [NextGen, "cloud cost management"]
 date: 2024-03-19T10:00
 sidebar_position: 6
 ---

--- a/release-notes/code-repository.md
+++ b/release-notes/code-repository.md
@@ -1,7 +1,6 @@
 ---
 title: Code Repository release notes
 sidebar_label: Code Repository
-tags: [NextGen, "code repository"]
 date: 2024-03-22T10:00
 sidebar_position: 7
 ---

--- a/release-notes/continuous-delivery.md
+++ b/release-notes/continuous-delivery.md
@@ -2,7 +2,6 @@
 title: Continuous Delivery & GitOps release notes
 sidebar_label: Continuous Delivery & GitOps
 date: 2024-04-03:T10:00:15
-tags: [NextGen, "continuous delivery"]
 sidebar_position: 8
 ---
 

--- a/release-notes/continuous-error-tracking.md
+++ b/release-notes/continuous-error-tracking.md
@@ -1,7 +1,6 @@
 ---
 title: Continuous Error Tracking release notes
 sidebar_label: Continuous Error Tracking
-tags: [NextGen, "cet"]
 date: 2023-11-02T17:20
 sidebar_position: 9
 ---

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -1,7 +1,6 @@
 ---
 title: Continuous Integration release notes
 sidebar_label: Continuous Integration
-tags: [NextGen, "continuous integration"]
 date: 2024-04-03T10:00
 sidebar_position: 10
 ---

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -1,7 +1,6 @@
 ---
 title: Delegate release notes
 sidebar_label: Delegate
-tags: [NextGen, "Delegate"]
 date: 2024-04-02T10:00
 sidebar_position: 4
 ---

--- a/release-notes/feature-flags.md
+++ b/release-notes/feature-flags.md
@@ -2,7 +2,6 @@
 title: Feature Flags release notes
 sidebar_label: Feature Flags
 date: 2024-03-28T16:19:25
-tags: [NextGen, "feature flags"]
 sidebar_position: 11
 ---
 

--- a/release-notes/internal-developer-portal.md
+++ b/release-notes/internal-developer-portal.md
@@ -1,7 +1,6 @@
 ---
 title: Internal Developer Portal release notes
 sidebar_label: Internal Developer Portal
-tags: [NextGen, "Internal Developer Portal", "IDP"]
 date: 2023-08-09T10:00:15
 sidebar_position: 12
 ---

--- a/release-notes/platform.md
+++ b/release-notes/platform.md
@@ -1,7 +1,6 @@
 ---
 title: Platform release notes
 sidebar_label: Platform
-tags: [NextGen, "platform"]
 date: 2024-03-26:T10:00:30
 sidebar_position: 3
 ---

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -3,7 +3,6 @@ title: Security Testing Orchestration release notes
 sidebar_label: Security Testing Orchestration
 description: Provides an overview of new features and fixed issues.
 date: 2024-03-27T10:00
-tags: [NextGen, "security testing orchestration"]
 sidebar_position: 13
 ---
 

--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -1,7 +1,6 @@
 ---
 title: Self-Managed Enterprise Edition release notes
 sidebar_label: Self-Managed Enterprise Edition
-tags: [NextGen, "self-managed-ee"]
 date: 2024-03-29T10:00
 sidebar_position: 16
 ---

--- a/release-notes/service-reliability-management.md
+++ b/release-notes/service-reliability-management.md
@@ -2,7 +2,6 @@
 title: Service Reliability Management release notes
 sidebar_label: Service Reliability Management
 date: 2023-11-15T10:00:20
-tags: [NextGen, "service reliability management"]
 sidebar_position: 14
 ---
 

--- a/release-notes/software-engineering-insights.md
+++ b/release-notes/software-engineering-insights.md
@@ -1,7 +1,6 @@
 ---
 title: Software Engineering Insights release notes
 sidebar_label: Software Engineering Insights
-tags: [NextGen, "software engineering insights"]
 date: 2023-09-01T10:00:10
 sidebar_position: 15
 ---

--- a/release-notes/software-supply-chain-assurance.md
+++ b/release-notes/software-supply-chain-assurance.md
@@ -1,7 +1,6 @@
 ---
 title: Software Supply Chain Assurance release notes
 sidebar_label: Software Supply Chain Assurance
-tags: [NextGen, "software supply chain assurance"]
 date: 2023-09-18T10:00
 sidebar_position: 15
 ---


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Purpose

Tags have additional functionality tied to them, but we aren't currently using tags in a standardized, effective, or habitual way.

Only some release notes pages had tags in their metadata. Being on so few pages, these tags added no value, so I removed them. Impact is minimal to nonexistent.

I updated the guidance on using keywords and tags.

If we choose to use tags, we need to take on a site-wide project where we: 1) Agree on a set of standardized tags (such as "Tutorial", "Troubleshooting", "Kubernetes", etc.), 2) Agree when to use tags, and 3) Implement tags across the entire existing doc set at once so that the resulting "tag pages" are valuable. Then, the tag usage must be maintained going forward. Considering recent changes to doc workflow and knowledge gaps in Docusaurus functionality, I recommend holding off on tags until we have addressed other sticking points in our workflows.

## Merge requirements

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.
