### PR TITLE
Update net-sdk-reference.md to not set analytics to false

### DIFF
--- a/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
+++ b/docs/feature-flags/ff-sdks/server-sdks/net-sdk-reference.md
@@ -174,7 +174,7 @@ CfClient.Instance.Initialize(apiKey, Config.Builder()
     .EventUrl("https://events.ff.harness.io/api/1.0")  
     .SetPollingInterval(60)  
     .SetStreamEnabled(true)  
-    .SetAnalyticsEnabled(false)  
+    .SetAnalyticsEnabled(true)  
     .Build());
 ```
 ### Complete the initialization


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: instructions tell the user by example to set analytics to false, which dosnt send target information to harness, which is not needed in most cases and especially for new users (who would be the ones copy/pasting from the docs) really do not need this set to false. setting to true makes sure their target information lands in harness.
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
