### PR TITLE
feat: [CHAOS-5067]: Adds docs for supporting destination ports filtering for destination IPs

### DIFF
--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-corruption.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-corruption.md
@@ -50,7 +50,7 @@ Linux network corruption:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of target IPs. For example, <code>1.1.1.1,8.8.8.8</code> </td>
+    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted. </td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of target IPs to chaos.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -116,7 +116,7 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"
 ```
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-corruption.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-corruption.md
@@ -50,13 +50,13 @@ Linux network corruption:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
+    <td> List of comma-separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted. </td>
   </tr>
   <tr>
     <td> packetCorruptionPercentage </td>
     <td> Percentage of packets to corrupt. For example, <code> 50 </code>. </td>
-    <td> Default: 100% </td>
+    <td> Default: 100 % </td>
   </tr>
   <tr>
     <td> sourcePorts </td>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. You can specify the ports to be targeted for an IP by using a pipe (`|`) as a separator. Providing ports is optional, omitting them will affect all the ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-duplication.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-duplication.md
@@ -50,7 +50,7 @@ Linux network duplication:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
+    <td> List of comma-separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names or domains are targeted. </td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. You can specify the ports to be targeted for an IP by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all the ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-duplication.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-duplication.md
@@ -50,7 +50,7 @@ Linux network duplication:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example, <code>1.1.1.1,8.8.8.8</code>. </td>
+    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names or domains are targeted. </td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -116,7 +116,7 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"
 ```
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-latency.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-latency.md
@@ -14,7 +14,7 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
 ![Linux network latency](./static/images/linux-network-latency.png)
 
 ## Use cases
-- Induces Network Latency on the target Linux machines.
+- Induces network latency on the target Linux machines.
 - Simulates latency in connectivity access by delaying the network requests of the machine.
 
 <Ossupport />
@@ -44,13 +44,13 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
   </tr>
     <tr>
     <td> destinationHosts </td>
-    <td> List of the target hostnames or keywords. For example: <code>google.com,litmuschaos.io</code> </td>
-    <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all hostnames/domains will be targeted </td>
+    <td> List of the target host names or keywords. For example: <code>google.com,litmuschaos.io</code> </td>
+    <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all host names/domains will be targeted </td>
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
-    <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all hostnames/domains will be targeted</td>
+    <td> List of comma- separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
+    <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all host names/domains will be targeted</td>
   </tr>
   <tr>
     <td> latency </td>
@@ -59,7 +59,7 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
   </tr>
   <tr>
     <td> jitter </td>
-    <td> Amount of jitter to be added in ms. Jitter will define the max randomised deviation from the provided latency value. For example: <code> 100 </code> </td>
+    <td> Amount of jitter to be added in ms. Jitter will define the max randomized deviation from the provided latency value. For example: <code> 100 </code> </td>
     <td> Defaults to 0 </td>
   </tr>
   <tr>
@@ -96,7 +96,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. You can specify the ports to be targeted for an IP by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all the ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-latency.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-latency.md
@@ -49,7 +49,7 @@ Linux network latency injects chaos to disrupt network connectivity in linux mac
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example: <code>1.1.1.1,8.8.8.8</code> </td>
+    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> and <code> destinationIPs</code> is provided, all hostnames/domains will be targeted</td>
   </tr>
   <tr>
@@ -96,7 +96,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -110,7 +110,7 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"
 ```
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-loss.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-loss.md
@@ -50,7 +50,7 @@ Linux network loss:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example, <code>1.1.1.1,8.8.8.8</code> </td>
+    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names or domains are targeted.</td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 
@@ -116,7 +116,7 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"
 ```
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-loss.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-loss.md
@@ -50,7 +50,7 @@ Linux network loss:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
+    <td> List of comma-separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names or domains are targeted.</td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. You can specify the ports to be targeted for an IP by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all the ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this environment variable:
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-rate-limit.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-rate-limit.md
@@ -50,7 +50,7 @@ Linux network rate limit:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of the target IPs. For example, <code>1.1.1.1,8.8.8.8</code>. </td>
+    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted. </td>
   </tr>
   <tr>
@@ -112,7 +112,7 @@ spec:
 
 ### Destination IPs
 
-Comma-separated names of the target IPs that are subject to chaos. Tune it using the `destinationIPs` input variable.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this input variable:
 
@@ -126,7 +126,7 @@ metadata:
     name: network-rate-limit
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"
 ```
 

--- a/docs/chaos-engineering/chaos-faults/linux/linux-network-rate-limit.md
+++ b/docs/chaos-engineering/chaos-faults/linux/linux-network-rate-limit.md
@@ -50,7 +50,7 @@ Linux network rate limit:
   </tr>
   <tr>
     <td> destinationIPs </td>
-    <td> List of comma separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
+    <td> List of comma-separated target IPs. Also supports a list of target destination ports for a given IP, that are separated by a pipe (<code>|</code>). For example, <code>1.1.1.1,35.24.108.92|3000|8080</code>. </td>
     <td> If neither <code>destinationHosts</code> nor <code> destinationIPs</code> is provided, all host names/domains are targeted. </td>
   </tr>
   <tr>
@@ -112,7 +112,7 @@ spec:
 
 ### Destination IPs
 
-The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. Ports to be targeted for an IP can be specified by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all ports associated with the destination IPs.
+The `destinationIPs` input variable subjects the comma-separated names of the target IPs to chaos. You can specify the ports to be targeted for an IP by using a pipe (`|`) as a separator. While providing ports is optional, omitting them will affect all the ports associated with the destination IPs.
 
 The following YAML snippet illustrates the use of this input variable:
 

--- a/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-corruption/destination-ips.yaml
+++ b/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-corruption/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-corruption
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"

--- a/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-duplication/destination-ips.yaml
+++ b/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-duplication/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-duplication
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"

--- a/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-latency/destination-ips.yaml
+++ b/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-latency/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-latency
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"

--- a/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-loss/destination-ips.yaml
+++ b/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-loss/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"

--- a/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-rate-limit/destination-ips.yaml
+++ b/docs/chaos-engineering/chaos-faults/linux/static/manifests/linux-network-rate-limit/destination-ips.yaml
@@ -6,5 +6,5 @@ metadata:
     name: network-loss
 spec:
   networkChaos/inputs:
-    destinationIPs: '1.1.1.1'
+    destinationIPs: '1.1.1.1,192.168.5.6|80|8080'
     networkInterfaces: "eth0"


### PR DESCRIPTION


## Description

* Please describe your changes: Adds docs for supporting destination ports filtering for destination IPs
* Jira/GitHub Issue numbers (if any): CHAOS-5067
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
