### PR TITLE
CHAOS-5103 Connect to infra via proxy

### DIFF
--- a/docs/chaos-engineering/get-started/ce-on-smp/ce-smp-roadmap.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/ce-smp-roadmap.md
@@ -11,6 +11,6 @@ The table below outlines the roadmap for the Harness Self-Managed Enterprise Edi
 | **Release version**| **Feature set** | **Deployment infrastructure** | **Supported platforms** | **Supported ingress** |
 | --- | --- | --- | --- | --- |
 | Limited GA (Current version)| Feature parity with SaaS | <ul><li> Cloud</li><li>Connected</li><li>Airgapped</li><li>Signed certificates</li></ul> | Kubernetes clusters | <ul><li>NGINX</li><li>Istio virtual services</li></ul> |
-| General Availability (Coming soon)| Feature parity with SaaS | 
+| General Availability (Coming soon)| Feature parity with SaaS |
 
 For more information, go to [What's supported](/docs/chaos-engineering/whats-supported.md).

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/_category_.json
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/_category_.json
@@ -1,0 +1,13 @@
+{
+  "position": 2,
+  "label": "Configure proxy on Self-Managed Enterprise Edition",
+  "collapsible": "true",
+  "collapsed": "true",
+  "link":{
+      "type":"generated-index",
+      "title":"Configure proxy on Self-Managed Enterprise Edition"
+   },
+  "customProps": {
+    "description": "Guide to configure proxy on Self-Managed Enterprise Edition"
+  }
+}

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
@@ -30,20 +30,20 @@ where:
 
 - `HTTPS_PROXY` is set only if you are trying to connect to an SCM server deployed over HTTPS or [GitHub](https://github.com) (required for Enterprise ChaosHub).
 
-The above environment variables are set without providing any credentials. An example of proxy without credentials:
+The above environment variables are set without providing any credentials. An example of a proxy without credentials:
 ```
 http://<proxy-ip>:<proxy-port>
 ```
 
 :::tip
 - You can provide `HTTP_PROXY` and `HTTPS_PROXY` with endpoints that have credentials. For this, you have to first URL Encode the username and the password and provide them.
-- An example of proxy with credentials:
+- An example of a proxy with credentials:
 
 ```
 http://<url-encoded-username>:<url-encoded-password>@<proxy-ip>:<proxy-port>
 ```
 :::
 
-- `NO_PROXY` is set with cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
+- `NO_PROXY` is set with the cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, the proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
 
 - `GIT_SSL_NO_PROXY` is set using self-signed certificates to skip SSL certificate validation.

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
@@ -1,0 +1,49 @@
+---
+title: Connect Enterprise ChaosHub via proxy
+sidebar_position: 2
+description: Connect Enterprise ChaosHub in an air-gapped setup via proxy
+---
+
+This topic describes the method to connect Enterprise ChaosHub (https://github.com/) in an air-gapped setup via proxy
+
+If you don't have access to [GitHub](https://github.com/), you will not be able to deploy Harness SMP in an air-gapped cluster. As a consequence, the Enterprise ChaosHub will be in a `DISCONNECTED` state.
+
+To address this,
+1. Use a proxy that can access [GitHub](https://app.harness.io);
+2. Provide the configuration under chaos manager deployment;
+3. Use this setup in the `override.yaml` file of the Helm chart before deployment.
+
+An example of changes to the `override.yaml` file:
+
+```
+chaos-manager:
+    config:
+     HTTP_PROXY:
+     HTTPS_PROXY:
+     NO_PROXY:
+     GIT_SSL_NO_VERIFY:
+```
+
+where:
+
+- `HTTP_PROXY` is set only if you are trying to connect to an SCM server deployed over HTTP (optional for Enterprise ChaosHub).
+
+- `HTTPS_PROXY` is set only if you are trying to connect to an SCM server deployed over HTTPS or [GitHub](https://github.com) (required for Enterprise ChaosHub).
+
+The above environment variables are set without providing any credentials. An example of proxy without credentials:
+```
+http://<proxy-ip>:<proxy-port>
+```
+
+:::tip
+- You can provide `HTTP_PROXY` and `HTTPS_PROXY` with endpoints that have credentials. For this, you have to first URL Encode the username and the password and provide them.
+- An example of proxy with credentials:
+
+```
+http://<url-encoded-username>:<url-encoded-password>@<proxy-ip>:<proxy-port>
+```
+:::
+
+- `NO_PROXY` is set with cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
+
+- `GIT_SSL_NO_PROXY` is set using self-signed certificates to skip SSL certificate validation.

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-enterprise-chaoshub.md
@@ -6,10 +6,10 @@ description: Connect Enterprise ChaosHub in an air-gapped setup via proxy
 
 This topic describes the method to connect Enterprise ChaosHub (https://github.com/) in an air-gapped setup via proxy
 
-If you don't have access to [GitHub](https://github.com/), you will not be able to deploy Harness SMP in an air-gapped cluster. As a consequence, the Enterprise ChaosHub will be in a `DISCONNECTED` state.
+If you don't have access to [GitHub](https://github.com/), you will not be able to deploy Harness SMP in an air-gapped cluster completely. As a consequence, the Enterprise ChaosHub will be in a `DISCONNECTED` state.
 
 To address this,
-1. Use a proxy that can access [GitHub](https://app.harness.io);
+1. Use a proxy that can access [GitHub](https://github.com/);
 2. Provide the configuration under chaos manager deployment;
 3. Use this setup in the `override.yaml` file of the Helm chart before deployment.
 
@@ -46,4 +46,4 @@ http://<url-encoded-username>:<url-encoded-password>@<proxy-ip>:<proxy-port>
 
 - `NO_PROXY` is set with the cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, the proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
 
-- `GIT_SSL_NO_PROXY` is set using self-signed certificates to skip SSL certificate validation.
+- `GIT_SSL_NO_PROXY` is set when you are using self-signed certificates to skip SSL certificate validation.

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-infrastructure.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-infrastructure.md
@@ -6,26 +6,26 @@ description: Connect chaos infrastructure to the control plane via proxy
 
 This topic describes the method to connect your chaos infrastructure to the control plane on [app.harness.io](https://app.harness.io) or Self-Managed Platform (SMP) via proxy.
 
-If you want to deploy a chaos infrastructure in an air-gapped cluster that accesses [app.harness.io](https://app.harness.io) or SMP control plane via proxy, you need to add `HTTP_PROXY` , `HTTPS_PROXY` and `NO_PROXY` environment variables for the subscriber, where:
+If you want to deploy a chaos infrastructure in an air-gapped cluster that accesses [app.harness.io](https://app.harness.io) or SMP control plane via proxy, you need to add `HTTP_PROXY` , `HTTPS_PROXY`, and `NO_PROXY` environment variables for the subscriber, where:
 
-- `HTTP_PROXY` is set if you deploy SMP control plane over HTTP.
+- `HTTP_PROXY` is set if you deploy the SMP control plane over HTTP.
 
-- `HTTPS_PROXY` is set if you deploy SMP control plane over HTTPS or if you want to connect to [app.harness.io](https://app.harness.io).
+- `HTTPS_PROXY` is set if you deploy the SMP control plane over HTTPS or if you want to connect to [app.harness.io](https://app.harness.io).
 
-The above environment variables are set without providing any credentials. An example of proxy without credentials:
+The above environment variables are set without providing any credentials. An example of a proxy without credentials:
 ```
 http://<proxy-ip>:<proxy-port>
 ```
 
 :::tip
 - You can provide `HTTP_PROXY` and `HTTPS_PROXY` with endpoints that have credentials. For this, you have to first URL Encode the username and the password and provide them.
-- An example of proxy with credentials:
+- An example of a proxy with credentials:
 
 ```
 http://<url-encoded-username>:<url-encoded-password>@<proxy-ip>:<proxy-port>
 ```
 :::
 
-- `NO_PROXY` is set with cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
+- `NO_PROXY` is set with the cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, the proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
 
 You can provide these environment variables directly on the subscriber deployment or with the help of ConfigMap subscriber configuration in the chaos infrastructure manifest that is generated from the UI.

--- a/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-infrastructure.md
+++ b/docs/chaos-engineering/get-started/ce-on-smp/configure-proxy/connect-infrastructure.md
@@ -1,0 +1,31 @@
+---
+title: Connect chaos infrastructure via proxy
+sidebar_position: 1
+description: Connect chaos infrastructure to the control plane via proxy
+---
+
+This topic describes the method to connect your chaos infrastructure to the control plane on [app.harness.io](https://app.harness.io) or Self-Managed Platform (SMP) via proxy.
+
+If you want to deploy a chaos infrastructure in an air-gapped cluster that accesses [app.harness.io](https://app.harness.io) or SMP control plane via proxy, you need to add `HTTP_PROXY` , `HTTPS_PROXY` and `NO_PROXY` environment variables for the subscriber, where:
+
+- `HTTP_PROXY` is set if you deploy SMP control plane over HTTP.
+
+- `HTTPS_PROXY` is set if you deploy SMP control plane over HTTPS or if you want to connect to [app.harness.io](https://app.harness.io).
+
+The above environment variables are set without providing any credentials. An example of proxy without credentials:
+```
+http://<proxy-ip>:<proxy-port>
+```
+
+:::tip
+- You can provide `HTTP_PROXY` and `HTTPS_PROXY` with endpoints that have credentials. For this, you have to first URL Encode the username and the password and provide them.
+- An example of proxy with credentials:
+
+```
+http://<url-encoded-username>:<url-encoded-password>@<proxy-ip>:<proxy-port>
+```
+:::
+
+- `NO_PROXY` is set with cluster IP of the cluster where you deploy the chaos infrastructure. This allows requests to be directed to the Kube API server directly instead of going through a proxy. In addition, proxy may not be able to connect to the Kube API server if it is deployed outside the cluster.
+
+You can provide these environment variables directly on the subscriber deployment or with the help of ConfigMap subscriber configuration in the chaos infrastructure manifest that is generated from the UI.


### PR DESCRIPTION
[Steps to connect chaos infra and enterprise ChaosHub via proxy](https://6620f7917b10263f90002430--harness-developer.netlify.app/docs/category/configure-proxy-on-self-managed-enterprise-edition)