### PR TITLE
add Gitleak workflows based on WW input STO-7396

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference.md
@@ -14,32 +14,67 @@ For a description of the end-to-end workflow, go to [Ingest SARIF data](/docs/se
 
 ## Important notes
 
-You can write up your own rules in Gitleaks:
+This section describes recommended best practices and references to useful information. 
 
-- You can specify an allowlist of secrets that are inactive, rotated, deactivated, or false positives. Gitleaks ignores these secrets during a scan. Set up your allowlist in a [.gitleaks.toml file](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml) and place it at the root of your repository. 
+### Update your allowlist with inactive secrets
 
-  :::note
+You can specify an allowlist of secrets that are inactive, rotated, deactivated, or false positives. Gitleaks ignores these secrets during a scan. Set up your allowlist in a [.gitleaks.toml file](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml) and place it at the root of your repository. For more information about this format, 
 
-  It is best practice to update your allowlist with secrets that are inactive, rotated, deactivated, or false positives. Otherwise, Gitleaks will continue to detect these secrets in your commit history even after they have been updated in your code.
+:::note
 
-  :::
-  
-  The following steps outline the recommended workflow:
+It is best practice to update your allowlist with secrets that are inactive, rotated, deactivated, or false positives. Otherwise, Gitleaks will continue to detect these secrets in your commit history even after they have been updated in your code.
 
-  1. Run a Gitleaks scan and review the detected passwords, tokens, and other secrets.
+:::
 
-  2. Rotate or deactivate all secrets that are currently active.
+The following steps outline the recommended workflow:
 
-  2. Compile a list of all secrets that are now inactive, rotated, deactivated, or false positives.
+1. Run a Gitleaks scan and review the detected passwords, tokens, and other secrets.
 
-  4. Update the allowlist in `.gitleaks.toml`  to include these secrets.
+2. Rotate or deactivate all secrets that are currently active.
 
-- You can also write your own [custom detection rules](https://github.com/gitleaks/gitleaks?tab=readme-ov-file#configuration).
+2. Compile a list of all secrets that are now inactive, rotated, deactivated, or false positives.
+
+4. Update the allowlist in `.gitleaks.toml`  to include these secrets.
+
+Harness recommends that you add your secrets as plain text to the `regexes` array, as shown in this example. This is the most reliable method to ensure that Gitleaks detects only active secrets when you run another scan. 
+
+<details>
+
+<summary>.gitleaks.toml example</summary>
+
+
+```toml
+title = "example gitleaks config"
+
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+[allowlist]
+# Recommended practice is to add your secrets to a regexes array, 
+# not to a commits array.
+regexTarget = "match"
+description = "whitelist public and test secrets"
+regexes = [
+  '''1234567890abcdef1234567890abcdef''',
+  '''abcdef1234567890abcdef1234567890''',
+]
+
+```
+
+</details>
+
+### Write custom detection rules
+
+You can also write your own [custom detection rules](https://github.com/gitleaks/gitleaks?tab=readme-ov-file#configuration).
 
   - For examples, go to the [default Gitleaks config](https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml).
   - If you want to contribute to the default configuration, go to the [Contributing guidelines](https://github.com/zricethezav/gitleaks/blob/master/README.md).
   - For information about advanced configurations, go to [Stop leaking secrets - configuration](https://blog.gitleaks.io/stop-leaking-secrets-configuration-2-3-aeed293b1fbf).
 
+
+### For more information
 
 import StoMoreInfo from '/docs/security-testing-orchestration/sto-techref-category/shared/_more-information.md';
 

--- a/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference.md
@@ -12,7 +12,33 @@ Gitleaks can publish results to [Static Analysis Results Interchange Format (SAR
 
 For a description of the end-to-end workflow, go to [Ingest SARIF data](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data).
 
-## For more information
+## Important notes
+
+You can write up your own rules in Gitleaks:
+
+- You can specify an allowlist of secrets that are inactive, rotated, deactivated, or false positives. Gitleaks ignores these secrets during a scan. Set up your allowlist in a [.gitleaks.toml file](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml) and place it at the root of your repository. 
+
+  :::note
+
+  It is best practice to update your allowlist with secrets that are inactive, rotated, deactivated, or false positives. Otherwise, Gitleaks will continue to detect these secrets in your commit history even after they have been updated in your code.
+
+  :::
+  
+  The following steps outline the recommended workflow:
+
+  1. Run a Gitleaks scan and review the detected passwords, tokens, and other secrets.
+
+  2. Rotate or deactivate all secrets that are currently active.
+
+  2. Compile a list of all secrets that are now inactive, rotated, deactivated, or false positives.
+
+  4. Update the allowlist in `.gitleaks.toml`  to include these secrets.
+
+- You can also write your own [custom detection rules](https://github.com/gitleaks/gitleaks?tab=readme-ov-file#configuration).
+
+  - For examples, go to the [default Gitleaks config](https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml).
+  - If you want to contribute to the default configuration, go to the [Contributing guidelines](https://github.com/zricethezav/gitleaks/blob/master/README.md).
+  - For information about advanced configurations, go to [Stop leaking secrets - configuration](https://blog.gitleaks.io/stop-leaking-secrets-configuration-2-3-aeed293b1fbf).
 
 
 import StoMoreInfo from '/docs/security-testing-orchestration/sto-techref-category/shared/_more-information.md';
@@ -26,11 +52,6 @@ import StoMoreInfo from '/docs/security-testing-orchestration/sto-techref-catego
 
 The recommended workflow is to add a GitLeaks step to a Security Tests or CI Build stage and then configure it as described below.  
 
-<!--
-
-
-
--->
 
 ### Scan Mode
 
@@ -290,7 +311,7 @@ pipeline:
         repoName: dvpwa
         build: <+input>
   identifier: Gitleaks_docsexample_INGESTION
-  name: Gitleaks docs-example INGESTION
+  name: Gitleaks_docsexample_INGESTION
 
 
 ```
@@ -360,5 +381,5 @@ pipeline:
         repoName: dvpwa
         build: <+input>
   identifier: gitleaks_docs_example_ORCHESTRATION
-  name: gitleaks docs example - ORCHESTRATION
+  name: gitleaks_docs_example_ORCHESTRATION
 ```


### PR DESCRIPTION
Preview link: Gitleaks scanner reference > [Important notes](https://662197a33721d635a73dbc90--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference/#important-notes)

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Peer review (BF reviewed draft in [previous PR](https://github.com/harness/developer-hub/pull/6318#pullrequestreview-1997790920))
- [x] SME review (this PR has updates  based on WW review comments [here](https://github.com/harness/developer-hub/pull/6318/files/d977c454236a875f3cb678ece7f0810a5633a865#r1562880859) and [here](https://github.com/harness/developer-hub/pull/6318/files/d977c454236a875f3cb678ece7f0810a5633a865#r1562899759) in previous PR)
- [x] No merge conflicts.
