### PR TITLE
[PL-49148] Add option to Configure an optional registry mirror for delegate images

### DIFF
--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -245,7 +245,7 @@ delegateConfig:
   managerHost: <MANAGER_HOST>
 ```
 
-During an upgrade, when upgrader seeks to update the delegate to `harness/delegate:verno`, it will utilize the image from `us.gsr.io/gcr-mirror/harness/delegate:verno`.
+During an upgrade, when `upgrader` seeks to update the delegate to `harness/delegate:verno`, it will utilize the image from `us.gsr.io/gcr-mirror/harness/delegate:verno`.
 
 ## Use automatic upgrade with custom delegate images
 

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -227,6 +227,26 @@ To configure the delegate upgrade schedule, do the following:
 
    The schedule change for CronJob will take effect immediately, and the next upgrade run will follow the new schedule. If you have made any other changes to the YAML file, such as updating the image, configuration, environment variables, and so on, those changes will take effect during the next run.
 
+### Configure an optional registry mirror for delegate images
+
+If you use Docker pull through registry cache (`https://docs.docker.com/docker-hub/mirror/`), you can configure `upgrader` to use an optional registry mirror for your delegate images.
+
+If this feature is configured, Harness Delegate images will not be pulled from the public Docker Hub, but from the configured mirror.
+
+```yaml
+mode: Delegate
+dryRun: false
+workloadName: delegate-name
+namespace: harness-delegate-ng
+containerName: delegate
+registryMirror: us.gsr.io/gcr-mirror
+delegateConfig:
+  accountId: <YOUR_ACCOUNT_ID>
+  managerHost: <MANAGER_HOST>
+```
+
+When `upgrader` wants to upgrade the delegate to `harness/delegate:verno`, it will use the image from `us.gsr.io/gcr-mirror/harness/delegate:verno`.
+
 ## Use automatic upgrade with custom delegate images
 
 You may choose to use a custom delegate image for the following reasons:

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -231,7 +231,7 @@ To configure the delegate upgrade schedule, do the following:
 
 If you use Docker pull through registry cache (`https://docs.docker.com/docker-hub/mirror/`), you can configure `upgrader` to use an optional registry mirror for your delegate images.
 
-When this feature is configured, Harness Delegate images won't be fetched from the public Docker Hub but from the designated mirror.
+When this feature is configured, Harness Delegate images are fetched from the designated mirror, instead of public Docker Hub.
 
 ```yaml
 mode: Delegate

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -231,7 +231,7 @@ To configure the delegate upgrade schedule, do the following:
 
 If you use Docker pull through registry cache (`https://docs.docker.com/docker-hub/mirror/`), you can configure `upgrader` to use an optional registry mirror for your delegate images.
 
-If this feature is configured, Harness Delegate images will not be pulled from the public Docker Hub, but from the configured mirror.
+When this feature is configured, Harness Delegate images won't be fetched from the public Docker Hub but from the designated mirror.
 
 ```yaml
 mode: Delegate
@@ -245,7 +245,7 @@ delegateConfig:
   managerHost: <MANAGER_HOST>
 ```
 
-When `upgrader` wants to upgrade the delegate to `harness/delegate:verno`, it will use the image from `us.gsr.io/gcr-mirror/harness/delegate:verno`.
+During an upgrade, when upgrader seeks to update the delegate to `harness/delegate:verno`, it will utilize the image from `us.gsr.io/gcr-mirror/harness/delegate:verno`.
 
 ## Use automatic upgrade with custom delegate images
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Add option to Configure an optional registry mirror for delegate images
* Jira/GitHub Issue numbers (if any): PL-49148
* Preview links/images (Internal contributors only): https://6621719baf7a7614f8d642df--harness-developer.netlify.app/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration#configure-an-optional-registry-mirror-for-delegate-images

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
