### PR TITLE
[PIPE-18334] Adding edge case for ternary operator and colon as constant

### DIFF
--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -321,6 +321,26 @@ pipeline:
 
 </details>
 
+Ternary operator and semicolon as constant in same expression is not supported.
+
+Expression : <+ 
+                Env name: <+env.name> 
+                Service Name: <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">
+             >
+
+Above expression will not get resolved as semicolon is used as constant string with ternary operator. As a workaround for this expression to work we should create
+a new variable for ternary expression and use this varible in original expression.
+
+Take above expression as example:
+
+We can create a test variable with this expression as value <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env"> and replace the original expression with same. suppose variable created is at pipeline level then our final expression will be as below and it will work.
+
+Expression: <+ 
+                Env name: <+env.name> 
+                Service Name: <+pipeline.variables.test>
+             >
+
+
 For more information about using ternary operators in Harness, go to [Using Ternary Operators with Triggers](https://developer.harness.io/kb/continuous-delivery/articles/ternary-operator/).
 
 ### Expressions as strings

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -321,19 +321,16 @@ pipeline:
 
 </details>
 
-Ternary operator and colon as constant in same expression is not supported.
+We do not support using a ternary operator with colon as constant in the same expression.
 
 Expression : <+ 
                 Env name: <+env.name> 
                 Service Name: <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">
              >
 
-Above expression will not get resolved as colon is used as constant string with ternary operator. As a workaround for this expression to work we should create
-a new variable for ternary expression and use this varible in original expression.
+The above expression will not get resolved as colon is used as a constant string with the ternary operator. As a workaround for this expression to work we should create a new variable for ternary expression and use this variable in the original expression.
 
-Take above expression as example:
-
-We can create a test variable with this expression as value <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env"> and replace the original expression with same. suppose variable created is at pipeline level then our final expression will be as below and it will work.
+In the example expression above, we can create a test variable with this expression as value `<+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">` and replace the original expression with the same. Suppose the variable created is at the pipeline level, then our final expression will be as shown below, and it will work.
 
 Expression: <+ 
                 Env name: <+env.name> 

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -321,14 +321,14 @@ pipeline:
 
 </details>
 
-Ternary operator and semicolon as constant in same expression is not supported.
+Ternary operator and colon as constant in same expression is not supported.
 
 Expression : <+ 
                 Env name: <+env.name> 
                 Service Name: <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">
              >
 
-Above expression will not get resolved as semicolon is used as constant string with ternary operator. As a workaround for this expression to work we should create
+Above expression will not get resolved as colon is used as constant string with ternary operator. As a workaround for this expression to work we should create
 a new variable for ternary expression and use this varible in original expression.
 
 Take above expression as example:

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -323,20 +323,25 @@ pipeline:
 
 We do not support using a ternary operator with colon as constant in the same expression.
 
-Expression : <+ 
-                Env name: <+env.name> 
-                Service Name: <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">
-             >
+Let's look at the following sample expression:
+
+```
+<+ 
+   Env name: <+env.name> 
+   Service Name: <+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">
+>
+```
 
 The above expression will not get resolved as colon is used as a constant string with the ternary operator. As a workaround for this expression to work we should create a new variable for ternary expression and use this variable in the original expression.
 
 In the example expression above, we can create a test variable with this expression as value `<+<+<+env.name>.contains("dev")>?<+env.name>:"No Env">` and replace the original expression with the same. Suppose the variable created is at the pipeline level, then our final expression will be as shown below, and it will work.
 
-Expression: <+ 
-                Env name: <+env.name> 
-                Service Name: <+pipeline.variables.test>
-             >
-
+```
+<+ 
+   Env name: <+env.name> 
+   Service Name: <+pipeline.variables.test>
+>
+```
 
 For more information about using ternary operators in Harness, go to [Using Ternary Operators with Triggers](https://developer.harness.io/kb/continuous-delivery/articles/ternary-operator/).
 


### PR DESCRIPTION
Ticket: https://harness.atlassian.net/browse/PIPE-18334

It's an edge case for using ternary operator and semicolon as constant string in expression which is not supported. This PR contains the same changes for mentioning the limitation of same.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
