### PR TITLE
fix: [IDP-2694]: Updated the broken URLs due to introduction of community plugins 

### DIFF
--- a/docs/internal-developer-portal/plugins/available-plugins/azure-devops.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/azure-devops.md
@@ -7,7 +7,7 @@ description: Easily view your Azure Pipelines within the Software Catalog.
 | -------------- | ----------------------------------------------------------------------------- |
 | **Created by** | keyloop                                                                      |
 | **Category**   | CI/CD                                                                         |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/tree/master/plugins/azure-devops) |
+| **Source**     | [GitHub](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/azure-devops#azure-devops-plugin) |
 | **Type**       | Open-source plugin                                                            |
 
 ## Configuration
@@ -116,4 +116,4 @@ In this case `<project-name>` will be the name of your Team Project and `<build-
 
 ## Support
 
-The plugin is owned by keyloop and managed in the [Backstage repository](https://github.com/backstage/backstage) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by keyloop and managed in the [Backstage repository](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.

--- a/docs/internal-developer-portal/plugins/available-plugins/circleci.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/circleci.md
@@ -7,7 +7,7 @@ description: View CI/CD pipeline executions running in CircleCI.
 | -------------- | ----------------------------------------------------------------------------- |
 | **Created by** | Spotify                                                                       |
 | **Category**   | CI/CD                                                                         |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/tree/master/plugins/circleci) |
+| **Source**     | [GitHub](https://github.com/CircleCI-Public/backstage-plugin/tree/main/plugins/circleci#circleci-plugin) |
 | **Type**       | Open-source plugin                                                            |
 
 ## Configuration
@@ -77,4 +77,4 @@ metadata:
 
 ## Support
 
-The plugin is owned by Spotify and managed in the [Backstage repository](https://github.com/backstage/backstage) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by Spotify and managed in the [Backstage repository](https://github.com/CircleCI-Public/backstage-plugin) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.

--- a/docs/internal-developer-portal/plugins/available-plugins/dynatrace.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/dynatrace.md
@@ -7,7 +7,7 @@ description: View monitoring info from Dynatrace for services in your Software C
 | -------------- | ------------------------------------------------------------------------------ |
 | **Created by** | [Dynatrace](https://www.dynatrace.com/)                                                      |
 | **Category**   | Monitoring                                                                        |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/tree/master/plugins/dynatrace) |
+| **Source**     | [GitHub](https://github.com/backstage/community-plugins/tree/main/workspaces/dynatrace/plugins/dynatrace#dynatrace) |
 | **Type**       | Open-source plugin                                                             |
 
 
@@ -86,5 +86,5 @@ The `SYNTHETIC_ID` can be found in Dynatrace by browsing to the Synthetic monito
 
 ## Support
 
-The plugin is owned by Backstage and managed in this [repository](https://github.com/backstage/backstage/tree/master/plugins/dynatrace) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by Backstage and managed in this [repository](https://github.com/backstage/community-plugins/tree/main/workspaces/dynatrace/plugins/dynatrace#dynatrace) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
 

--- a/docs/internal-developer-portal/plugins/available-plugins/github-actions.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/github-actions.md
@@ -7,7 +7,7 @@ description: View CD/CD pipeline executions from GitHub Actions.
 | -------------- | ----------------------------------------------------------------------------------- |
 | **Created by** | Spotify                                                                             |
 | **Category**   | CI/CD                                                                               |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/tree/master/plugins/github-actions) |
+| **Source**     | [GitHub](https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions#github-actions-plugin) |
 | **Type**       | Open-source plugin                                                                  |
 
 ## Configuration
@@ -66,4 +66,4 @@ metadata:
 
 ## Support
 
-The plugin is owned by Spotify and managed in the [Backstage repository](https://github.com/backstage/backstage/tree/master/plugins/github-actions) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by Spotify and managed in the [Backstage repository](https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions#github-actions-plugin) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.

--- a/docs/internal-developer-portal/plugins/available-plugins/jenkins.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/jenkins.md
@@ -7,7 +7,7 @@ description: View CI/CD executions running within your Jenkins instance.
 | -------------- | ---------------------------------------------------------------------------- |
 | **Created by** | [@timja](https://github.com/timja)                                           |
 | **Category**   | CI/CD                                                                        |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/tree/master/plugins/jenkins) |
+| **Source**     | [GitHub](https://github.com/backstage/community-plugins/tree/main/workspaces/jenkins/plugins/jenkins#jenkins-plugin-alpha) |
 | **Type**       | Open-source plugin                                                           |
 
 ## Configuration
@@ -71,4 +71,4 @@ metadata:
 
 ## Support
 
-The plugin is owned by [@timja](https://github.com/timja) and managed in the [Backstage repository](https://github.com/backstage/backstage/tree/master/plugins/jenkins) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by [@timja](https://github.com/timja) and managed in the [Backstage repository](https://github.com/backstage/community-plugins/tree/main/workspaces/jenkins/plugins) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.

--- a/docs/internal-developer-portal/plugins/available-plugins/rafay-kubernetes.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/rafay-kubernetes.md
@@ -7,7 +7,7 @@ description: Deploy and view clusters, namespaces, workloads and more using Rafa
 | -------------- | ------------------------------------------------------------------------------- |
 | **Created by** | Rafay Systems                                                                         |
 | **Category**   | Monitoring                                                                      |
-| **Source**     | [GitHub](https://docs.rafay.co/backstage/setup/) |
+| **Source**     | [GitHub](https://docs.rafay.co/backstage/overview/#backstage-plugin) |
 | **Type**       | Open-source plugin                                                              |
 
 ## Configuration
@@ -31,7 +31,7 @@ In the above YAML, replace `<rafay_console_url>` with the real console url eg.,`
 
 ### Secrets
 
-Since the `X-RAFAY-API-KEYID` variable is used in the application configuration, you must generate a RAFAY API key and set it as the value of variable `X-RAFAY-API-KEYID`. For information about how to generate a API key, go to the [instructions](https://docs.rafay.co/automation/api/apis/#api-keys).
+Since the `X-RAFAY-API-KEYID` variable is used in the application configuration, you must generate a RAFAY API key and set it as the value of variable `X-RAFAY-API-KEYID`. For information about how to generate a API key, go to the [instructions](https://docs.rafay.co/security/rbac/users/#api-keys).
 
 ![](./static/rafay-variable.png)
 
@@ -121,4 +121,4 @@ This plugin exports new cards under overview tab for a service or for any other 
 
 ## Support
 
-The plugin is owned by Rafay Systems and managed in the public [npm package](https://www.npmjs.com/package/@rafaysystems/backstage-plugin-rafay/v/0.1.9?activeTab=code). Reach out to [Rafay Systems](https://rafay.co/) to report bugs or suggest new features for the plugin.
+The plugin is owned by Rafay Systems and managed in the public [npm package](https://www.npmjs.com/package/@rafaysystems/backstage-plugin-rafay/v/0.1.9?activeTab=code). Reach out to [Rafay Systems](https://docs.rafay.co/) to report bugs or suggest new features for the plugin.

--- a/docs/internal-developer-portal/plugins/available-plugins/sonarqube.md
+++ b/docs/internal-developer-portal/plugins/available-plugins/sonarqube.md
@@ -7,7 +7,7 @@ description: Components to display code quality metrics from SonarCloud and Sona
 | -------------- | ------------------------------------------------------------------------------ |
 | **Created by** | [SDA SE](https://sda.se/)                                                      |
 | **Category**   | Quality                                                                        |
-| **Source**     | [GitHub](https://github.com/backstage/backstage/blob/master/plugins/sonarqube) |
+| **Source**     | [GitHub](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube#sonarqube-plugin) |
 | **Type**       | Open-source plugin                                                             |
 
 
@@ -58,8 +58,8 @@ metadata:
     sonarqube.org/project-key: <instance-name>/<project-key>
 ```
 
-[Read more](https://github.com/backstage/backstage/blob/master/plugins/sonarqube/README.md#getting-started)
+[Read more](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube#sonarqube-plugin)
 
 ## Support
 
-The plugin is owned by SDA SE and managed in the [Backstage repository](https://github.com/backstage/backstage) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.
+The plugin is owned by SDA SE and managed in the [Backstage repository](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins) as an open-source project. Create a GitHub issue to report bugs or suggest new features for the plugin.

--- a/release-notes/internal-developer-portal.md
+++ b/release-notes/internal-developer-portal.md
@@ -600,7 +600,7 @@ contents:
 
 - The Backstage version has been upgraded to [1.14](https://backstage.io/docs/releases/v1.14.0). (IDP-632)
 - The following GitHub-based plugins are now available in IDP:
-  - [GitHub Actions](https://github.com/backstage/backstage/tree/master/plugins/github-actions)
+  - [GitHub Actions](https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions#github-actions-plugin)
   - [GitHub Insights](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-github-insights)
   - [GitHub Pull Requests](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-github-pull-requests).
 - IDP now includes support for GitHub and Google OAuth applications. You can configure a GitHub or Google OAuth application in the IDP Admin view. These applications are used by the GitHub-based plugins to use the logged-in user's credentials when making API requests. (IDP-676, IDP-661, IDP-647)


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Updated the broken URLs due to introduction of community plugins and introduction of additional yarn workspaces to maintain plugins separately out side of the Backstage codebase. 

## PR lifecycle

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
