### PR TITLE
Update scanner support table sto 7461

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference.md
@@ -1,11 +1,11 @@
 ---
 title: Metasploit scanner reference for STO
-description: Scan application instances with Metasploit.
-sidebar_label: Metasploit scanner reference
+description: Scan application instances with Metasploit Framework.
+sidebar_label: Metasploit Framework scanner reference
 sidebar_position: 230
 ---
 
-You can scan your application instances and ingest results from Metasploit.
+You can scan your application instances and ingest results from Metasploit Framework.
 
 
 ## For more information

--- a/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference.md
@@ -13,7 +13,7 @@ This section describes how to set up each of the external scanners supported by 
 
 For more information about STO support, go to [What's supported in STO](/docs/security-testing-orchestration/whats-supported).
 
-
+<!-- 
 ### Scanner categories supported by STO
 
 
@@ -33,55 +33,51 @@ import StoSupportedMethods from './shared/_sto-supported-methods.md';
 
 The scanner, targets, and scan approach combinations are covered in the next section.
 
+-->
+
 
 ### Scanners supported by STO
 
-
 import StoSupportedScanners from './shared/_sto-supported-scanners.md';
-
 
 <StoSupportedScanners />
 
-### Scanner binaries used in STO container images
-
-
-import StoSupportedBinaries from './shared/_sto-supported-binaries.md';
-
-
-<StoSupportedBinaries />
-
-### Ingestion formats supported by STO
-
-
-import StoSupportedFormats from './shared/_sto-supported-ingestion-formats.md';
-
-
-<StoSupportedFormats />
-
 ###  Operating systems and architectures supported by STO
-
 
 import StoInfraSupport from '/docs/security-testing-orchestration/sto-techref-category/shared/_supported-infrastructures.md';
 
-
-
 <StoInfraSupport />
+
+
+### Ingestion formats supported by STO
+
+import StoSupportedFormats from './shared/_sto-supported-ingestion-formats.md';
+
+<StoSupportedFormats />
+
+
+
 
 ### Docker-in-Docker requirements for STO
 
-
 import StoDinDRequirements from '/docs/security-testing-orchestration/sto-techref-category/shared/dind-bg-step.md';
-
 
 <StoDinDRequirements />
 
-### Root access requirements for STO
 
+### Root access requirements for STO
 
 import StoRootRequirements from '/docs/security-testing-orchestration/sto-techref-category/shared/root-access-requirements.md';
 
-
 <StoRootRequirements />
+
+
+### Scanner binaries used in STO container images
+
+import StoSupportedBinaries from './shared/_sto-supported-binaries.md';
+
+<StoSupportedBinaries />
+
 
 ### Security steps and scanner templates in STO
 

--- a/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference.md
@@ -5,6 +5,13 @@ sidebar_label: Semgrep settings reference
 sidebar_position: 20
 ---
 
+<DocsTag  backgroundColor= "#cbe2f9" textColor="#0b5cad" text="Code repo scanners"  link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners"  />
+<DocsTag  text="Orchestration" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/run-an-orchestrated-scan-in-sto"  />
+<DocsTag  text="Ingestion" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/sto-workflows-overview#extraction-workflows-in-sto" />
+
+<br/>
+<br/>
+
 You can ingest scan results from [Semgrep](https://www.semgrep.com), an open-source static analysis engine for detecting dependency vulnerabilities and other issues in your code repositories.
 
 The following tutorials include detailed examples of how to run a [Semgrep scan](https://semgrep.dev/docs/cli-reference) in a Run step and ingest the results:

--- a/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference.md
@@ -5,14 +5,8 @@ sidebar_label: Semgrep settings reference
 sidebar_position: 20
 ---
 
-<DocsTag  backgroundColor= "#cbe2f9" textColor="#0b5cad" text="Code repo scanners"  link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners"  />
-<DocsTag  text="Orchestration" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/run-an-orchestrated-scan-in-sto"  />
-<DocsTag  text="Ingestion" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/sto-workflows-overview#extraction-workflows-in-sto" />
 
-<br/>
-<br/>
-
-You can ingest scan results from [Semgrep](https://www.semgrep.com), an open-source static analysis engine for detecting dependency vulnerabilities and other issues in your code repositories.
+You can ingest scan results from [Semgrep](https://www.semgrep.com).
 
 The following tutorials include detailed examples of how to run a [Semgrep scan](https://semgrep.dev/docs/cli-reference) in a Run step and ingest the results:
 - [SAST code scans using Semgrep](./sast-scan-semgrep)

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
@@ -1,7 +1,7 @@
 Harness STO can automatically ingest, aggregate, normalize, and deduplicate data from the following scanners and formats. 
 
-:::note
-Static Analysis Results Interchange Format (SARIF) is an open JSON format supported by many scan tools, especially tools available as GitHub Actions. You can [ingest SARIF 2.1.0 data](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data) from any tool that supports this format.
+:::info
+Static Analysis Results Interchange Format (SARIF) is an open JSON format supported by many scan tools, especially tools available as GitHub Actions. Harness STO can [ingest SARIF 2.1.0 data](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data) from any tool that supports this format.
 
 Harness recommends that you publish and ingest using the scanner-specific JSON format when available, because it tends to include more useful information.
 

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
@@ -10,14 +10,14 @@ Harness STO can automatically ingest, aggregate, normalize, and deduplicate data
 - **Brakeman** — JSON
 - **Burp** — XML
 - **Checkmarx** — XML, SARIF  <!-- - **Clair** — JSON -->
-- **CodeQL** — JSON, SARIF
+- **CodeQL** — JSON (_recommended_), SARIF
 - **Coverity** — XML
 - **Data Theorem** — JSON
 - **Docker Content Trust** — JSON
 - **Fortify** — JSON
 - **Fortify on Demand** — JSON
 - **Fossa** — JSON
-- **Gitleaks** — JSON, SARIF
+- **Gitleaks** — JSON (_recommended_), SARIF
 - **HQL AppScan** — XML 
 - **Grype** — JSON
 - **Mend (_formerly Whitesource_)** — JSON  
@@ -33,7 +33,7 @@ Harness STO can automatically ingest, aggregate, normalize, and deduplicate data
 - **Qwiet** — JSON
 - **Reapsaw** — JSON    <!-- - **Scoutsuite** — JSON -->
 - **Semgrep** — SARIF
-- **Snyk** — JSON, SARIF
+- **Snyk** — JSON (_recommended_), SARIF
 - **SonarQube** — JSON
 - **Sysdig** — JSON 
 - **Tenable** — JSON

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
@@ -3,28 +3,28 @@ Harness STO can automatically ingest, aggregate, normalize, and deduplicate data
 :::note
 Static Analysis Results Interchange Format (SARIF) is an open JSON format supported by many scan tools, especially tools available as GitHub Actions. You can [ingest SARIF 2.1.0 data](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data) from any tool that supports this format.
 
-Harness recommends that you publish and ingest using the scanner-specific data format when available, because this format tends to include more useful information.
+Harness recommends that you publish and ingest using the scanner-specific JSON format when available, because it tends to include more useful information.
 
 :::
 
 - **Anchore Enterprise** — JSON
 - **Aqua Security** — JSON
-- **Aqua Trivy** — JSON
+- **Aqua Trivy** — JSON (_recommended_), SARIF
 - **AWS ECR** — JSON
 - **AWS Security Hub** — JSON
-- **Bandit** — JSON
+- **Bandit** — JSON (_recommended_), SARIF
 - **Black Duck Hub** — JSON
-- **Brakeman** — JSON, SARIF
+- **Brakeman** — JSON
 - **Burp** — XML
 - **Checkmarx** — XML, SARIF  <!-- - **Clair** — JSON -->
-- **CodeQL** — JSON, SARIF
+- **CodeQL** — SARIF
 - **Coverity** — XML
 - **Data Theorem** — JSON
 - **Docker Content Trust** — JSON
 - **Fortify** — JSON
 - **Fortify on Demand** — JSON
 - **Fossa** — JSON
-- **Gitleaks** — JSON, SARIF
+- **Gitleaks** — JSON (_recommended_), SARIF
 - **HQL AppScan** — XML 
 - **Grype** — JSON
 - **Mend (_formerly Whitesource_)** — JSON  
@@ -40,11 +40,11 @@ Harness recommends that you publish and ingest using the scanner-specific data f
 - **Qwiet** — JSON
 - **Reapsaw** — JSON    <!-- - **Scoutsuite** — JSON -->
 - **Semgrep** — SARIF
-- **Snyk** — JSON, SARIF
+- **Snyk** — JSON (_recommended_), SARIF
 - **SonarQube** — JSON
 - **Sysdig** — JSON 
 - **Tenable** — JSON
 - **Veracode** — XML
 - **JFrog Xray** — JSON
-- **Wiz** - JSON, SARIF
+- **Wiz** - JSON (_recommended_), SARIF
 - **Zed Attack Proxy (ZAP)** — JSON

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
@@ -1,5 +1,12 @@
 Harness STO can automatically ingest, aggregate, normalize, and deduplicate data from the following scanners and formats. 
 
+:::note
+Static Analysis Results Interchange Format (SARIF) is an open JSON format supported by many scan tools, especially tools available as GitHub Actions. You can [ingest SARIF 2.1.0 data](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data) from any tool that supports this format.
+
+Harness recommends that you publish and ingest using the scanner-specific data format when available, because this format tends to include more useful information.
+
+:::
+
 - **Anchore Enterprise** — JSON
 - **Aqua Security** — JSON
 - **Aqua Trivy** — JSON
@@ -7,17 +14,17 @@ Harness STO can automatically ingest, aggregate, normalize, and deduplicate data
 - **AWS Security Hub** — JSON
 - **Bandit** — JSON
 - **Black Duck Hub** — JSON
-- **Brakeman** — JSON
+- **Brakeman** — JSON, SARIF
 - **Burp** — XML
 - **Checkmarx** — XML, SARIF  <!-- - **Clair** — JSON -->
-- **CodeQL** — JSON (_recommended_), SARIF
+- **CodeQL** — JSON, SARIF
 - **Coverity** — XML
 - **Data Theorem** — JSON
 - **Docker Content Trust** — JSON
 - **Fortify** — JSON
 - **Fortify on Demand** — JSON
 - **Fossa** — JSON
-- **Gitleaks** — JSON (_recommended_), SARIF
+- **Gitleaks** — JSON, SARIF
 - **HQL AppScan** — XML 
 - **Grype** — JSON
 - **Mend (_formerly Whitesource_)** — JSON  
@@ -33,11 +40,11 @@ Harness STO can automatically ingest, aggregate, normalize, and deduplicate data
 - **Qwiet** — JSON
 - **Reapsaw** — JSON    <!-- - **Scoutsuite** — JSON -->
 - **Semgrep** — SARIF
-- **Snyk** — JSON (_recommended_), SARIF
+- **Snyk** — JSON, SARIF
 - **SonarQube** — JSON
 - **Sysdig** — JSON 
 - **Tenable** — JSON
 - **Veracode** — XML
 - **JFrog Xray** — JSON
-- **Wiz** - JSON (_recommended_), SARIF
+- **Wiz** - JSON, SARIF
 - **Zed Attack Proxy (ZAP)** — JSON

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-ingestion-formats.md
@@ -9,10 +9,10 @@ Harness recommends that you publish and ingest using the scanner-specific JSON f
 
 - **Anchore Enterprise** — JSON
 - **Aqua Security** — JSON
-- **Aqua Trivy** — JSON (_recommended_), SARIF
+- **Aqua Trivy** — JSON _(recommended)_, SARIF
 - **AWS ECR** — JSON
 - **AWS Security Hub** — JSON
-- **Bandit** — JSON (_recommended_), SARIF
+- **Bandit** — JSON _(recommended)_, SARIF
 - **Black Duck Hub** — JSON
 - **Brakeman** — JSON
 - **Burp** — XML
@@ -24,10 +24,10 @@ Harness recommends that you publish and ingest using the scanner-specific JSON f
 - **Fortify** — JSON
 - **Fortify on Demand** — JSON
 - **Fossa** — JSON
-- **Gitleaks** — JSON (_recommended_), SARIF
+- **Gitleaks** — JSON _(recommended)_, SARIF
 - **HQL AppScan** — XML 
 - **Grype** — JSON
-- **Mend (_formerly Whitesource_)** — JSON  
+- **Mend _(formerly Whitesource)_** — JSON  
 - **Nessus** — XML
 - **Nexus** — JSON
 - **Nikto** — XML
@@ -40,11 +40,11 @@ Harness recommends that you publish and ingest using the scanner-specific JSON f
 - **Qwiet** — JSON
 - **Reapsaw** — JSON    <!-- - **Scoutsuite** — JSON -->
 - **Semgrep** — SARIF
-- **Snyk** — JSON (_recommended_), SARIF
+- **Snyk** — JSON _(recommended)_, SARIF
 - **SonarQube** — JSON
 - **Sysdig** — JSON 
 - **Tenable** — JSON
 - **Veracode** — XML
 - **JFrog Xray** — JSON
-- **Wiz** - JSON (_recommended_), SARIF
+- **Wiz** - JSON _(recommended)_, SARIF
 - **Zed Attack Proxy (ZAP)** — JSON

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -116,6 +116,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
    <tr>
         <td valign="top">
           <ul>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Framework</a> Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>           
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
@@ -129,7 +130,6 @@ For information about the specific vulnerabilities detected by each scanner, go 
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HQL AppScan</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Pro</a> Orchestration, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus web app scan</a> Orchestration, Ingestion </li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -1,21 +1,21 @@
 The following sections describe the scanners supported by Harness STO, based on the target type:
 
-- [Code repo scanners](#code-repository-scanners)
+- [Code repo scanners](#code-repo-scanners)
 - [Artifact scanners](#artifact-scanners)
 - [Instance scanners](#instance-scanners)
-- [Cloud Provider scanners](#cloud-provider-scanners)
+- [Configuration scanners](#configuration-scanners)
 - [Other scanners](#other-scanners)
 
 
 #### Code repo scanners
 
-A code scanner can detect one or more of the following types of issues in your source code. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+A code scanner can detect one or more of the following issue types in your source code. For information about the specific vulnerabilities detected by each scanner, go to the scanner provider's documentation. 
 
-* **SAST (Static Application Security Testing)** Known vulnerabilities in open-source and proprietary code.
-* **SCA (Software Composition Analysis)** Known vulnerabilities in open-source libraries and packages used by the code. 
-* **Secrets** Hard-coded secrets such as access keys and passwords.
-* **IaC** Known vulnerabilties in Infrastructure-as-Code files such as Terraform configurations.
-* **Misconfigurations** Known vulnerabilities in software configurations. 
+* **SAST (Static Application Security Testing):** Known vulnerabilities in open-source and proprietary code.
+* **SCA (Software Composition Analysis):** Known vulnerabilities in open-source libraries and packages used by the code.
+* **Secrets:** Hard-coded secrets such as access keys and passwords.
+* **IaC:** Known vulnerabilities in Infrastructure-as-Code files such as Terraform configurations.
+* **Misconfigurations:** Known vulnerabilities in software configurations.
 
 
 <table>
@@ -29,9 +29,9 @@ A code scanner can detect one or more of the following types of issues in your s
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>        
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a> Orchestration, Ingestion </li>        
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code(<i>open-source option</i>) </a> Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code (<i>open-source option</i>) </a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>
          </ul>
         </td>
@@ -64,10 +64,10 @@ A code scanner can detect one or more of the following types of issues in your s
 
 #### Artifact scanners
 
-An artifact scanner can detect one or more of the following types of issues in your container images and other artifacts. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+An artifact scanner can detect one or more of the following issue types in your container images and other artifacts. For information about the specific vulnerabilities detected by each scanner, go to the scanner provider's documentation.
 
-* **SCA (Software Composition Analysis)** Known vulnerabilities in open-source libraries and packages used by the code. 
-* **Container Scanning** identifies vulnerabilities in container images.
+* **SCA (Software Composition Analysis):** Known vulnerabilities in open-source libraries and packages used by the code. 
+* **Container Scanning:** Identify vulnerabilities in container images.
 
 <table>
     <tr>
@@ -103,9 +103,9 @@ An artifact scanner can detect one or more of the following types of issues in y
 
 #### Instance scanners
 
-A instance scanner scans a running application for vulnerabilties by simulating a malicious external actor exploiting known vulnerabilties. This is also known as a DAST (Dynamic Application Security Testing) scan. 
+An instance scanner scans a running application for vulnerabilities by simulating a malicious external actor exploiting known vulnerabilities. This is also known as a DAST (Dynamic Application Security Testing) scan.
 
-For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+For information about the specific vulnerabilities detected by each scanner, go to the scanner provider's documentation. 
 
 <table>
     <tr>
@@ -139,7 +139,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
 
 #### Configuration scanners
 
-The following scanners detect misconfigurations in your cloud environment that can result in vulnerabilities. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation.
+The following scanners detect misconfigurations in your cloud environment that can result in vulnerabilities. For information about the specific vulnerabilities detected by each scanner, go to the scanner provider's documentation.
 
 <table>
     <tr>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -156,7 +156,7 @@ The following scanners detect misconfigurations in your cloud environment that c
         </td>
         <td valign="top">
          <ul>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a>  Extraction </li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a>  Extraction, Ingestion </li>
          </ul>
      </td>
    </tr>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -118,7 +118,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
           <ul>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">OWASP ZAP</a> Orchestration, Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
          </ul>
         </td>
         <td valign="top">

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -31,6 +31,7 @@ A code scanner can detect one or more of the following types of issues in your s
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>        
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code(<i>open-source option</i>) </a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>
          </ul>
@@ -52,7 +53,6 @@ A code scanner can detect one or more of the following types of issues in your s
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Orchestration, Extraction, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Extraction, Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -150,7 +150,7 @@ The following scanners detect misconfigurations in your cloud environment that c
        <tr>
         <td valign="top">
           <ul>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/scoutsuite-scanner-reference">ScoutSuite</a> Orchestration, Extraction, Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/scoutsuite-scanner-reference">ScoutSuite</a> Ingestion</li>
           </ul>
         </td>
         <td valign="top">

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -15,7 +15,7 @@ A code scanner can detect one or more of the following types of issues in your s
 * **SCA (Software Composition Analysis)** Known vulnerabilities in open-source libraries and packages used by the code. 
 * **Secrets** Hard-coded secrets such as access keys and passwords.
 * **IaC** Known vulnerabilties in Infrastructure-as-Code files such as Terraform configurations.
-* **Misconfiguration** Known vulnerabilities in software configurations. 
+* **Misconfigurations** Known vulnerabilities in software configurations. 
 
 
 <table>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -151,12 +151,12 @@ The following scanners detect misconfigurations in your cloud environment that c
         <td valign="top">
           <ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/scoutsuite-scanner-reference">ScoutSuite</a> Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/prowler-scanner-reference">Prowler</a> Orchestration, Ingestion</li>
           </ul>
         </td>
         <td valign="top">
          <ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a>  Extraction </li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/prowler-scanner-reference">Prowler</a> Orchestration, Ingestion</li>
          </ul>
      </td>
    </tr>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -117,7 +117,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
           <ul>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Framework</a> Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
-          <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>           
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion </li>           
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
          </ul>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -1,149 +1,171 @@
-If you use a scanner that isn't listed in the following table, you can still ingest your scan results into STO. 
+The following sections describe the scanners supported by Harness STO, based on the target type:
 
-- If your scanner can publish to SARIF format, go to [Ingest SARIF scan results into STO](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data). 
+- [Code repo scanners](#code-repository-scanners)
+- [Artifact scanners](#artifact-scanners)
+- [Instance scanners](#instance-scanners)
+- [Cloud Provider scanners](#cloud-provider-scanners)
+- [Other scanners](#other-scanners)
 
-- For other scanners, go to [Ingest results from unsupported scanners](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners.md). 
+
+#### Code repo scanners
+
+A code scanner can detect one or more of the following types of issues in your source code. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+
+* **SAST (Static Application Security Testing)** Known vulnerabilities in open-source and proprietary code.
+* **SCA (Software Composition Analysis)** Known vulnerabilities in open-source libraries and packages used by the code. 
+* **Secrets** Hard-coded secrets such as access keys and passwords.
+* **IaC** Known vulnerabilties in Infrastructure-as-Code files such as Terraform configurations.
+* **Misconfiguration** Known vulnerabilities in software configurations. 
+
 
 <table>
     <tr>
-        <th>Scan Mode</th>
         <th>Open Source</th>
         <th>Commercial</th>
     </tr>
     <tr>
-        <td valign="top">SAST</td> 
         <td valign="top">
-         	<ul>
-        		<li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
-         		<li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
+          <ul>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
+           <li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/codeql-scanner-reference">CodeQL</a> Ingestion </li>
-         		<li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li> 
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>      		
+           <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>        
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code(<i>open-source option</i>) </a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>
-        	</ul>
+         </ul>
         </td>
-        <td valign="top"> 
-        	<ul>
-          		<li>
-                <a href="/docs/security-testing-orchestration/sto-techref-category/checkmarx-scanner-reference">Checkmarx</a> 
+        <td valign="top">
+         <ul>
+            <li>
+                <a href="/docs/security-testing-orchestration/sto-techref-category/checkmarx-scanner-reference">Checkmarx</a>
                  — The following workflows are supported:
                 <ul>
                   <li>Ingestion workflows for all Checkmarx One services (including SAST and SCA) that can publish scan results in SARIF format</li>
                   <li>Orchestration, Extraction, and Ingestion workflows for Checkmarx SAST and Checkmarx SCA scans</li>
                 </ul>
               </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fortify Static Code Analyzer</a> Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fortify Static Code Analyzer</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fossa</a> Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Ingestion </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Ingestion  </li>
-        	</ul>
+         </ul>
      </td>
    </tr>
+</table>
+
+
+#### Artifact scanners
+
+An artifact scanner can detect one or more of the following types of issues in your container images and other artifacts. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+
+* **SCA (Software Composition Analysis)** Known vulnerabilities in open-source libraries and packages used by the code. 
+* **Container Scanning** identifies vulnerabilities in container images.
+
+<table>
     <tr>
-        <td valign="top">SCA</td> 
-        <td valign="top">
-         	<ul>
-             <li><a href="/docs/security-testing-orchestration/sto-techref-category/osv-scanner-reference">Open Source Vulnerabilities (OSV)</a> Orchestration, Ingestion </li>
-             <li><a href="/docs/security-testing-orchestration/sto-techref-category/owasp-scanner-reference">OWASP Dependency Check</a>  Orchestration, Ingestion</li>
-        	</ul>
-        </td>
-        <td valign="top">
-        	<ul>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/black-duck-hub-scanner-reference">Black Duck Hub</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/checkmarx-scanner-reference">Checkmarx</a> Orchestration, Extraction, Ingestion</li>
-           		<li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference">JFrog Xray</a> Ingestion </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Open Source</a>  Orchestration, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode SCA</a> Orchestration, Extraction, Ingestion </li>
-        	</ul>
-     </td>
-   </tr>
-          <tr>
-        <td valign="top">Secrets</td> 
+        <th>Open Source</th>
+        <th>Commercial</th>
+    </tr>
+    <tr>
         <td valign="top">
           <ul>
-            <li></li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/trivy/aqua-trivy-scanner-reference">Aqua Trivy (_Containers_)</a> Orchestration, Ingestion  </li>            
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks (_SAST_)</a>  Orchestration, Ingestion </li>
-          </ul>
-        </td>
-        <td valign="top"> 
-         	<ul>                      
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (_SAST_)</a> Orchestration, Extraction, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode (_SAST/SCA_) </a> Orchestration, Extraction, Ingestion </li>
-          </ul>
-     </td>
-   </tr>
-   <tr>
-        <td valign="top">DAST</td>
-        <td valign="top">
-         	<ul>
-        		<li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">OWASP ZAP</a> Orchestration, Ingestion </li>
-        	</ul>
-        </td>
-        <td valign="top"> 
-        	<ul>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a> Extraction, Ingestion</li> 
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HQL AppScan</a> Ingestion</li> 
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Pro</a> Orchestration, Ingestion </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus web app scan</a> Orchestration, Ingestion </li>
-        	</ul>
-     </td>
-   </tr>
-    <tr>
-        <td valign="top">Container Images</td> 
-        <td valign="top">
-         	<ul>
-         		<li><a href="/docs/security-testing-orchestration/sto-techref-category/grype/grype-scanner-reference">Grype</a>  Orchestration, Ingestion </li>
+           <li><a href="/docs/security-testing-orchestration/sto-techref-category/grype/grype-scanner-reference">Grype</a>  Orchestration, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/trivy/aqua-trivy-scanner-reference">Aqua Trivy</a> Orchestration, Ingestion  </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/clair-scanner-reference">Clair</a> Orchestration, Ingestion </li>
-        	</ul>
+         </ul>
         </td>
-        <td valign="top"> 
-        	<ul>
+        <td valign="top">
+         <ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/anchore-enterprise-scanner-reference">Anchore Enterprise</a> Orchestration, Extraction, Ingestion </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aquasec-scanner-reference">Aqua Security</a> Orchestration, Ingestion </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-ecr-scanner-reference">AWS ECR</a> Extraction </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/black-duck-hub-scanner-reference">Black Duck Hub</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/data-theorem-scanner-reference">Data Theorem</a> Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/docker-content-trust-dct-scanner-reference">Docker Content Trust (DCT)</a> Orchestration, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/data-theorem-scanner-reference">Data Theorem</a> Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/docker-content-trust-dct-scanner-reference">Docker Content Trust (DCT)</a> Orchestration, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/prisma-cloud-scanner-reference">Prisma Cloud (formerly Twistlock)</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/prisma-cloud-scanner-reference">Prisma Cloud (formerly Twistlock)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Container</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sysdig-scanner-reference">Sysdig</a> Ingestion</li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io</a> Orchestration, Extraction, Ingestion  </li>
-          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Orchestration, Ingestion  </li>
-        	</ul>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io</a> Orchestration, Extraction, Ingestion  </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Orchestration, Ingestion  </li>
+         </ul>
      </td>
    </tr>
+</table>
+
+#### Instance scanners
+
+A instance scanner scans a running application for vulnerabilties by simulating a malicious external actor exploiting known vulnerabilties. This is also known as a DAST (Dynamic Application Security Testing) scan. 
+
+For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation. 
+
+<table>
+    <tr>
+        <th>Open Source</th>
+        <th>Commercial</th>
+    </tr>
+   <tr>
+        <td valign="top">
+          <ul>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">OWASP ZAP</a> Orchestration, Ingestion </li>
+         </ul>
+        </td>
+        <td valign="top">
+         <ul>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a> Extraction, Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HQL AppScan</a> Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Pro</a> Orchestration, Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus web app scan</a> Orchestration, Ingestion </li>
+         </ul>
+     </td>
+   </tr>
+</table>
+
+#### Configuration scanners
+
+The following scanners detect misconfigurations in your cloud environment that can result in vulnerabilities. For information about the specific vulnerabilities detected by each scanner, go to the external scanner documentation.
+
+<table>
+    <tr>
+        <th>Open Source</th>
+        <th>Commercial</th>
+    </tr>
        <tr>
-        <td valign="top">Configurations</td>
         <td valign="top">
           <ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/scoutsuite-scanner-reference">ScoutSuite</a> Orchestration, Extraction, Ingestion</li>
           </ul>
         </td>
         <td valign="top">
-        	<ul>
+         <ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a>  Extraction </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/prowler-scanner-reference">Prowler</a> Orchestration, Ingestion</li>
-        	</ul>
+         </ul>
      </td>
    </tr>
 </table>
+
+
+#### Other scanners
+
+If you use a scanner that isn't listed above, you can still ingest your scan results into STO.
+
+- If your scanner can publish to SARIF format, go to [Ingest SARIF scan results into STO](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingest-sarif-data).
+
+- For other scanners, go to [Ingest results from unsupported scanners](/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/ingesting-issues-from-other-scanners.md).

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -30,7 +30,6 @@ A code scanner can detect one or more of the following types of issues in your s
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>        
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code(<i>open-source option</i>) </a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -28,7 +28,6 @@ A code scanner can detect one or more of the following types of issues in your s
           <ul>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/codeql-scanner-reference">CodeQL</a> Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a>  Orchestration, Ingestion </li>        
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
@@ -46,6 +45,7 @@ A code scanner can detect one or more of the following types of issues in your s
                   <li>Orchestration, Extraction, and Ingestion workflows for Checkmarx SAST and Checkmarx SCA scans</li>
                 </ul>
               </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/codeql-scanner-reference">CodeQL</a> Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fortify Static Code Analyzer</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fossa</a> Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -51,6 +51,7 @@ A code scanner can detect one or more of the following types of issues in your s
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fossa</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -94,7 +94,7 @@ An artifact scanner can detect one or more of the following types of issues in y
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/prisma-cloud-scanner-reference">Prisma Cloud (formerly Twistlock)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Container</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/sysdig-scanner-reference">Sysdig</a> Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/sysdig-scanner-reference">Sysdig</a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io</a> Orchestration, Extraction, Ingestion  </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Orchestration, Ingestion  </li>
          </ul>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -117,8 +117,9 @@ For information about the specific vulnerabilities detected by each scanner, go 
         <td valign="top">
           <ul>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>           
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
          </ul>
         </td>
         <td valign="top">
@@ -129,7 +130,6 @@ For information about the specific vulnerabilities detected by each scanner, go 
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HQL AppScan</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Pro</a> Orchestration, Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus web app scan</a> Orchestration, Ingestion </li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -11,7 +11,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
         <th>Commercial</th>
     </tr>
     <tr>
-        <td valign="top">SAST</td>
+        <td valign="top">SAST</td> 
         <td valign="top">
          	<ul>
         		<li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
@@ -24,7 +24,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>
         	</ul>
         </td>
-        <td valign="top">
+        <td valign="top"> 
         	<ul>
           		<li>
                 <a href="/docs/security-testing-orchestration/sto-techref-category/checkmarx-scanner-reference">Checkmarx</a> 
@@ -48,7 +48,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
      </td>
    </tr>
     <tr>
-        <td valign="top">SCA</td>
+        <td valign="top">SCA</td> 
         <td valign="top">
          	<ul>
              <li><a href="/docs/security-testing-orchestration/sto-techref-category/osv-scanner-reference">Open Source Vulnerabilities (OSV)</a> Orchestration, Ingestion </li>
@@ -67,16 +67,17 @@ If you use a scanner that isn't listed in the following table, you can still ing
      </td>
    </tr>
           <tr>
-        <td valign="top">Secrets</td>
+        <td valign="top">Secrets</td> 
         <td valign="top">
           <ul>
+            <li></li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/trivy/aqua-trivy-scanner-reference">Aqua Trivy (_Containers_)</a> Orchestration, Ingestion  </li>            
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks (_SAST_)</a>  Orchestration, Ingestion </li>
           </ul>
         </td>
-        <td valign="top">
+        <td valign="top"> 
          	<ul>                      
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (_DAST_)</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (_SAST_)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode (_SAST/SCA_) </a> Orchestration, Extraction, Ingestion </li>
           </ul>
      </td>
@@ -90,7 +91,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">OWASP ZAP</a> Orchestration, Ingestion </li>
         	</ul>
         </td>
-        <td valign="top">
+        <td valign="top"> 
         	<ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a> Extraction, Ingestion</li> 
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
@@ -106,7 +107,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
      </td>
    </tr>
     <tr>
-        <td valign="top">Container Images</td>
+        <td valign="top">Container Images</td> 
         <td valign="top">
          	<ul>
          		<li><a href="/docs/security-testing-orchestration/sto-techref-category/grype/grype-scanner-reference">Grype</a>  Orchestration, Ingestion </li>
@@ -114,7 +115,7 @@ If you use a scanner that isn't listed in the following table, you can still ing
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/clair-scanner-reference">Clair</a> Orchestration, Ingestion </li>
         	</ul>
         </td>
-        <td valign="top">
+        <td valign="top"> 
         	<ul>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/anchore-enterprise-scanner-reference">Anchore Enterprise</a> Orchestration, Extraction, Ingestion </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aquasec-scanner-reference">Aqua Security</a> Orchestration, Ingestion </li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -50,7 +50,7 @@ A code scanner can detect one or more of the following types of issues in your s
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fortify Static Code Analyzer</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fossa</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Ingestion </li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Orchestration, Extraction, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -118,7 +118,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Framework</a> Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion</li>           
-          <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
          </ul>
         </td>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -55,7 +55,7 @@ A code scanner can detect one or more of the following types of issues in your s
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Ingestion  </li>
          </ul>
      </td>

--- a/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference.md
@@ -10,6 +10,14 @@ import TabItem from '@theme/TabItem';
 
 import StoDinDNoIntro from '/docs/security-testing-orchestration/sto-techref-category/shared/dind-bg-step-setup.md';
 
+<DocsTag   text="Code repo scanners"  backgroundColor= "#cbe2f9" textColor="#0b5cad" link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners"  />
+<DocsTag   text="Artifact scanners" backgroundColor= "#cbe2f9" textColor="#0b5cad" link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#artifact-scanners"  />
+<DocsTag  text="Orchestration" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/run-an-orchestrated-scan-in-sto"  />
+<DocsTag  text="Ingestion" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/sto-workflows-overview#extraction-workflows-in-sto" />
+
+<br/>
+<br/>
+
 You can include [Wiz](https://www.wiz.io/) vulnerability scans in your Harness pipelines. Wiz is a cloud security platform that scans IaC templates, container images, and directories/repositories before deployment. Wiz can detect security misconfigurations, vulnerabilities, and exposed secrets.
 
 Harness currently supports the following: 

--- a/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference.md
@@ -10,13 +10,6 @@ import TabItem from '@theme/TabItem';
 
 import StoDinDNoIntro from '/docs/security-testing-orchestration/sto-techref-category/shared/dind-bg-step-setup.md';
 
-<DocsTag   text="Code repo scanners"  backgroundColor= "#cbe2f9" textColor="#0b5cad" link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners"  />
-<DocsTag   text="Artifact scanners" backgroundColor= "#cbe2f9" textColor="#0b5cad" link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#artifact-scanners"  />
-<DocsTag  text="Orchestration" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/run-an-orchestrated-scan-in-sto"  />
-<DocsTag  text="Ingestion" link="/docs/security-testing-orchestration/use-sto/orchestrate-and-ingest/sto-workflows-overview#extraction-workflows-in-sto" />
-
-<br/>
-<br/>
 
 You can include [Wiz](https://www.wiz.io/) vulnerability scans in your Harness pipelines. Wiz is a cloud security platform that scans IaC templates, container images, and directories/repositories before deployment. Wiz can detect security misconfigurations, vulnerabilities, and exposed secrets.
 


### PR DESCRIPTION
### Preview links
- [Scanners supported by STO](https://6632597edfce338a457d6cc3--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference/#scanners-supported-by-sto) Reorganized into sections by target type rather than scan type. Added intros that list the types of scans supported by each target type.
- [Ingestion formats supported by STO](https://6632597edfce338a457d6cc3--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference/#ingestion-formats-supported-by-sto) For all scanners that support both JSON and SARIF, added paren to note that JSON is recommended.

### WW review v2
- [Code repo scanners](https://6632597edfce338a457d6cc3--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#scanners-supported-by-sto) - remove Qwiet AI from open-source
- [Instance scanners](https://6632597edfce338a457d6cc3--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#instance-scanners) - OpenVAS (-orchestration), Metasploit Pro (commercial) > Metasploit Framework (open-source)
- [Metasploit Framework scanner reference](https://6632597edfce338a457d6cc3--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference) - updated to say Metasploit Framework rather than simply Metasploit

### Prepub requirements

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] SME review.
- [x] PM review
- [x] Editorial review.
- [x] No merge conflicts.
