### PR TITLE
[PL-49092] Quartz Exp is valid, while Unix Exp is invalid for the Cron

### DIFF
--- a/docs/platform/authentication/single-sign-on-sso-with-ldap.md
+++ b/docs/platform/authentication/single-sign-on-sso-with-ldap.md
@@ -252,9 +252,9 @@ A sample of the Quartz expression is below:
 
 ```
 0 0 4 7 ? 2014  
-| | | |   | |  
-| | | |   | \------- YEAR (2014)  
-| | | |   \--------- DAY_OF_WEEK (NOT_SPECIFIED)  
+| | | | |  |  
+| | | | |  \-------- YEAR (2014)  
+| | | | \----------- DAY_OF_WEEK (NOT_SPECIFIED)  
 | | | \------------- MONTH (JULY)  
 | | \--------------- DAY_OF_MONTH (4th)  
 | \----------------- HOUR (0- MIDNIGHT LOCAL TIME)  

--- a/docs/platform/authentication/single-sign-on-sso-with-ldap.md
+++ b/docs/platform/authentication/single-sign-on-sso-with-ldap.md
@@ -245,6 +245,25 @@ To configure a synchronization schedule, in **Enter a custom cron expression**, 
 
 The page includes a tabular breakdown of the cron expression for ease of understanding and verification. The **Cron expression** field shows you whether or not the cron expression is valid.
 
+:::note
+The Cron(Quartz) Expression field will accept string consisting of six or seven subexpressions (fields) that describe individual details of the schedule. Unix Cron Expression consisting of five subexpressions is not supported.
+
+A sample of the the Quartz expression is below:
+QUARTZ Expression
+```
+0 0 4 7 ? 2014  
+| | | |   | |  
+| | | |   | \------- YEAR (2014)  
+| | | |   \--------- DAY_OF_WEEK (NOT_SPECIFIED)  
+| | | \------------- MONTH (JULY)  
+| | \--------------- DAY_OF_MONTH (4th)  
+| \----------------- HOUR (0- MIDNIGHT LOCAL TIME)  
+\------------------- MINUTE (0)
+```
+
+For more information please refer [Cron Expressions](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm) documentation.
+:::
+
 ### Add a Harness User Group with LDAP users
 
 Once you have configured an LDAP SSO Provider for Harness, you can create a Harness User Group and sync it to your LDAP directory.

--- a/docs/platform/authentication/single-sign-on-sso-with-ldap.md
+++ b/docs/platform/authentication/single-sign-on-sso-with-ldap.md
@@ -261,7 +261,7 @@ A sample of the Quartz expression is below:
 \------------------- MINUTE (0)
 ```
 
-For more information please refer [Cron Expressions](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm) documentation.
+For more information, please refer [Cron Expressions](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm) documentation.
 :::
 
 ### Add a Harness User Group with LDAP users

--- a/docs/platform/authentication/single-sign-on-sso-with-ldap.md
+++ b/docs/platform/authentication/single-sign-on-sso-with-ldap.md
@@ -246,9 +246,9 @@ To configure a synchronization schedule, in **Enter a custom cron expression**, 
 The page includes a tabular breakdown of the cron expression for ease of understanding and verification. The **Cron expression** field shows you whether or not the cron expression is valid.
 
 :::note
-The Cron(Quartz) Expression field will accept string consisting of six or seven subexpressions (fields) that describe individual details of the schedule. Unix Cron Expression consisting of five subexpressions is not supported.
+The **Cron Expression** field accepts a Quartz CronTrigger string consisting of six or seven subexpressions (fields) that describe individual details of the schedule. Unix cron expressions consisting of five subexpressions are not supported.
 
-A sample of the Quartz expression is below:
+Here's a sample Quartz expression:
 
 ```
 0 0 4 7 ? 2014  
@@ -261,7 +261,7 @@ A sample of the Quartz expression is below:
 \------------------- MINUTE (0)
 ```
 
-For more information, please refer [Cron Expressions](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm) documentation.
+For more information, go to [Cron Expressions](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm) in the Oracle documentation.
 :::
 
 ### Add a Harness User Group with LDAP users

--- a/docs/platform/authentication/single-sign-on-sso-with-ldap.md
+++ b/docs/platform/authentication/single-sign-on-sso-with-ldap.md
@@ -248,8 +248,8 @@ The page includes a tabular breakdown of the cron expression for ease of underst
 :::note
 The Cron(Quartz) Expression field will accept string consisting of six or seven subexpressions (fields) that describe individual details of the schedule. Unix Cron Expression consisting of five subexpressions is not supported.
 
-A sample of the the Quartz expression is below:
-QUARTZ Expression
+A sample of the Quartz expression is below:
+
 ```
 0 0 4 7 ? 2014  
 | | | |   | |  


### PR DESCRIPTION
[PL-49092](https://harness.atlassian.net/browse/PL-49092)

More info: https://harness.atlassian.net/browse/PL-48951

Adding a note to the Cron Expression section

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-49092]: https://harness.atlassian.net/browse/PL-49092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ