### PR TITLE
Add note about CDS_USE_EXECUTION_TRIGGER_PAYLOAD_TO_EVALUATE_BRANCH_EXPRESSION Feature Flag

### DIFF
--- a/docs/platform/triggers/triggers-reference.md
+++ b/docs/platform/triggers/triggers-reference.md
@@ -489,7 +489,7 @@ When Git Experience is enabled for your Pipeline, the **Pipeline Input** tab inc
 
 :::note
 
-In order to have the <+trigger.branch> expression working for an Issue Comment event trigger, the feature flag `CDS_USE_EXECUTION_TRIGGER_PAYLOAD_TO_EVALUATE_BRANCH_EXPRESSION` must be enabled.
+Currently, the `<+trigger.branch>` expression for Issue Comment event triggers is behind the feature flag `CDS_USE_EXECUTION_TRIGGER_PAYLOAD_TO_EVALUATE_BRANCH_EXPRESSION`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
 
 :::
 

--- a/docs/platform/triggers/triggers-reference.md
+++ b/docs/platform/triggers/triggers-reference.md
@@ -489,7 +489,7 @@ When Git Experience is enabled for your Pipeline, the **Pipeline Input** tab inc
 
 :::note
 
-The Issue Comment event trigger for Github does not support the `<+trigger.branch>` expression.
+In order to have the <+trigger.branch> expression working for an Issue Comment event trigger, the feature flag `CDS_USE_EXECUTION_TRIGGER_PAYLOAD_TO_EVALUATE_BRANCH_EXPRESSION` must be enabled.
 
 :::
 


### PR DESCRIPTION
Recently, we have made a fix for `<+trigger.branch>` expression resolution within Issue Comment git webhook triggers. 

In this PR, we add a note about the requirement of this Feature Flag enabled  for the `<+trigger.branch>` expression to work as expected for this kind of trigger.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
