### PR TITLE
[PL-50715] PL_HIDE_ACCOUNT_LEVEL_MANAGED_ROLE

### DIFF
--- a/docs/platform/role-based-access-control/add-manage-roles.md
+++ b/docs/platform/role-based-access-control/add-manage-roles.md
@@ -49,7 +49,7 @@ Harness includes several built-in roles. To examine the permissions assigned to 
 
 :::note
 
-Built-in roles can be hidden. This functionality is behind the feature flags `PL_HIDE_PROJECT_LEVEL_MANAGED_ROLE` and `PL_HIDE_ORGANIZATION_LEVEL_MANAGED_ROLE`. Contact [Harness Support](mailto:support@harness.io) to enable the features.
+Built-in roles can be hidden. This functionality is behind the feature flags `PL_HIDE_PROJECT_LEVEL_MANAGED_ROLE`, `PL_HIDE_ORGANIZATION_LEVEL_MANAGED_ROLE` and `PL_HIDE_ACCOUNT_LEVEL_MANAGED_ROLE`. Contact [Harness Support](mailto:support@harness.io) to enable the features.
 
 :::
 


### PR DESCRIPTION
[PL-50715](https://harness.atlassian.net/browse/PL-50715)

PL_HIDE_ACCOUNT_LEVEL_MANAGED_ROLE when enabled, restricts the visibility of account-level harness managed roles.

We have introduced a new feature flag, PL_HIDE_ACCOUNT_LEVEL_MANAGED_ROLE, which, when enabled, restricts the visibility of account-level harness managed roles. This flag is disabled by default

https://developer.harness.io/docs/platform/role-based-access-control/add-manage-roles/#built-in-roles 

https://harness.atlassian.net/browse/PL-43907

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
