### PR TITLE
update scanners table STO-7544

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -132,6 +132,7 @@ For information about the specific vulnerabilities detected by each scanner, go 
         <td valign="top">
          <ul>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HCL AppScan</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>

--- a/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
+++ b/docs/security-testing-orchestration/sto-techref-category/shared/_sto-supported-scanners.md
@@ -29,7 +29,9 @@ A code scanner can detect one or more of the following issue types in your sourc
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/bandit-scanner-reference">Bandit</a>  Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/brakeman-scanner-reference">Brakeman</a> Orchestration, Ingestion </li>
            <li><a href="/docs/security-testing-orchestration/sto-techref-category/coverity-scanner-reference">Coverity</a> Ingestion </li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a> Orchestration, Ingestion </li>        
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/gitleaks-scanner-reference">Gitleaks</a> Orchestration, Ingestion </li> 
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/osv-scanner-reference">Open Source Vulnerabilities (OSV)</a> Orchestration, Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/owasp-scanner-reference">OWASP Dependency Check</a> Orchestration, Ingestion</li>       
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/reapsaw-scanner-reference">Reapsaw</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code (<i>open-source option</i>) </a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud (<i>free option</i>) </a> Orchestration, Extraction, Ingestion</li>
@@ -37,6 +39,7 @@ A code scanner can detect one or more of the following issue types in your sourc
         </td>
         <td valign="top">
          <ul>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/black-duck-hub-scanner-reference">Black Duck Hub</a> Orchestration, Extraction, Ingestion</li>
             <li>
                 <a href="/docs/security-testing-orchestration/sto-techref-category/checkmarx-scanner-reference">Checkmarx</a>
                  — The following workflows are supported:
@@ -46,17 +49,20 @@ A code scanner can detect one or more of the following issue types in your sourc
                 </ul>
               </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/codeql-scanner-reference">CodeQL</a> Ingestion </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/data-theorem-scanner-reference">Data Theorem</a> Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fortify Static Code Analyzer</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-scanner-reference">Fossa</a> Ingestion</li>
+              <li><a href="/docs/security-testing-orchestration/sto-techref-category/fossa-scanner-reference">Fossa</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/nexus-scanner-reference">Nexus IQ</a> Orchestration, Extraction, Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qwiet-scanner-reference">Qwiet AI (formerly ShiftLeft)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/semgrep/semgrep-scanner-reference">Semgrep Code (<i>paid option</i>) </a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Code</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Infrastructure as Code</a> Ingestion _(beta)_</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Open Source</a> Orchestration, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference">SonarQube/SonarCloud</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/veracode-scanner-reference">Veracode</a> Orchestration, Extraction, Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Ingestion  </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Ingestion  </li>
          </ul>
      </td>
    </tr>
@@ -89,14 +95,14 @@ An artifact scanner can detect one or more of the following issue types in your 
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aquasec-scanner-reference">Aqua Security</a> Orchestration, Ingestion </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-ecr-scanner-reference">AWS ECR</a> Extraction </li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/black-duck-hub-scanner-reference">Black Duck Hub</a> Orchestration, Extraction, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/data-theorem-scanner-reference">Data Theorem</a> Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/docker-content-trust-dct-scanner-reference">Docker Content Trust (DCT)</a> Orchestration, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/prisma-cloud-scanner-reference">Prisma Cloud (formerly Twistlock)</a> Orchestration, Extraction, Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/snyk/snyk-scanner-reference">Snyk Container</a> Ingestion</li>
               <li><a href="/docs/security-testing-orchestration/sto-techref-category/sysdig-scanner-reference">Sysdig</a> Orchestration, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io</a> Orchestration, Extraction, Ingestion  </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io</a> Orchestration, Ingestion  </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/wiz-scanner-reference">Wiz</a> Orchestration, Ingestion  </li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/xray-scanner-reference">JFrog Xray</a> Ingestion </li>
          </ul>
      </td>
    </tr>
@@ -119,17 +125,14 @@ For information about the specific vulnerabilities detected by each scanner, go 
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/metasploit-scanner-reference">Metasploit Framework</a> Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nikto-scanner-reference">Nikto</a>  Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/nmap-scanner-reference">Nmap ("Network Mapper")</a> Orchestration, Ingestion </li>           
-          <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Ingestion </li>
+          <li><a href="/docs/security-testing-orchestration/sto-techref-category/openvas-scanner-reference">OpenVAS</a> Orchestration, Ingestion </li>
           <li><a href="/docs/security-testing-orchestration/sto-techref-category/zap/zap-scanner-reference">ZAP</a> Orchestration, Ingestion </li>
          </ul>
         </td>
         <td valign="top">
          <ul>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/aws-security-hub-scanner-reference">AWS Security Hub</a> Extraction, Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
-            <li><a href="/docs/security-testing-orchestration/sto-techref-category/fortify-on-demand-scanner-reference">Fortify on Demand</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HQL AppScan</a> Ingestion</li>
-              <li><a href="/docs/security-testing-orchestration/sto-techref-category/mend-scanner-reference">Mend (formerly WhiteSource)</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/burp-scanner-reference">Burp Enterprise</a> Orchestration, Extraction, Ingestion</li>
+            <li><a href="/docs/security-testing-orchestration/sto-techref-category/hql-appscan-scanner-reference">HCL AppScan</a> Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/qualys-web-app-scanner-reference">Qualys Web Application Scanning (WAS)</a>  Ingestion </li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus vulnerability scan</a> Orchestration, Ingestion</li>
             <li><a href="/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference">Tenable.io Nessus web app scan</a> Orchestration, Ingestion </li>


### PR DESCRIPTION
### Updates to Supported Scanners table

This [Supported scanners table (v2)](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference/#scanners-supported-by-sto) has the following updates to the [Supported scanners table (v1)](https://developer.harness.io/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#scanners-supported-by-sto) currently on HDH

#### [Code repo scanners](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners)

- [Data Theorem](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/data-theorem-scanner-reference) -- moved from **Artifact scanners** to **Code repo scanners (commercial)**
- [Open Source Vulnerabilities (OSV)](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/osv-scanner-reference), [OWASP Dependency Check](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/owasp-scanner-reference) -- Missed these when I refactored. Added them to **Code Repos (open source)**.

#### [Artifact scanners](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#artifact-scanners)

- Removed **Extraction** as a supported mode for **Tenable**. [Tenable.io](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference) scanner reference and [Instance scanners](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#instance-scanners) table say we support Orchestration and Ingestion only.
   - Have we tested `dataLoad` workflows for Tenable? Didn't see anything in QA so I removed Extraction from this entry in the table.
   - **Artifact scanners** lists  **Tenable**
   - **Instance scanners** lists **Tenable Nessus**
   - I'm not real clear about the difference. Perhaps we need some clarification in the [Tenable.io](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/tenable-scanner-reference) scanner reference?

#### [Instance scanners](https://663bce0d6c9f9e248aa69f5e--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#instance-scanners)

- **Mend (formerly WhiteSource)** Removed.. Checked a Mend step and the **Target Type** menu only has **Repo** and **Container Image**
- **JFrog Xray** Missed this when I refactored. Added it to **Artifact scanners (commercial)**.
- **Fortify on Demand** Removed from **Instance scanners**
PRs must meet these requirements to be merged:

### Prepub checks

- [x] Successful preview build.
- [x] Peer review
- [x] SME review (reviewed with WW over zoom)
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
