### PR TITLE
[PL-39191] Adding note about user.email

### DIFF
--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -421,7 +421,7 @@ The Azure users that are added to your Azure app must have their email addresses
 To set this **User name** email address as the method for identifying users, in the Azure app **Single sign-on** section, the Azure app must use the **user.userprincipalname** as the **Unique User Identifier**, and **user.userprincipalname** must use **Email address** as the **name identifier format**.
 
 :::info note
-If user.userprincipalname can't use email address as name identifier format, then user.email should be used as the Unique User Identifier.
+If **user.userprincipalname** can't use an email address as the **Name ID format**, then **user.email** should be used as the unique identifier in the **Identifier (Entity ID)** field.
 :::
 
 To set this up in your Azure app, do the following:

--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -420,6 +420,10 @@ The Azure users that are added to your Azure app must have their email addresses
 
 To set this **User name** email address as the method for identifying users, in the Azure app **Single sign-on** section, the Azure app must use the **user.userprincipalname** as the **Unique User Identifier**, and **user.userprincipalname** must use **Email address** as the **name identifier format**.
 
+:::info note
+If user.userprincipalname can't use email address as name identifier format, then user.email should be used as the Unique User Identifier.
+:::
+
 To set this up in your Azure app, do the following:
 
 1. In your Azure app, in the **Single sign-on** blade, in **User Attributes & Claims**, click the edit icon (pencil). The **User Attributes & Claims** settings appear.


### PR DESCRIPTION
[PL-39191]

If user.userprincipalname can't use email address as name identifier format, then use user.email for should be used as the Unique User Identifier.

This needs to be added so that the customer knows that user.email is expected to process the request on Harness's end.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-39191]: https://harness.atlassian.net/browse/PL-39191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ