### PR TITLE
[PL-50714] Publishes the total count for a user group

### DIFF
--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -36,6 +36,7 @@ All metrics reset when you restart the delegate.
 | `io_harness_custom_metric_task_rejected_total` * #| The number of tasks rejected because of a high load on the delegate. |
 | `io_harness_custom_metric_delegate_connected` | Indicates whether the delegate is connected. Values are 0 (disconnected) and 1 (connected). |
 | `io_harness_custom_metric_resource_consumption_above_threshold`* | Delegate CPU is above a threshold. Provide `DELEGATE_CPU_THRESHOLD` as the env variable in the delegate YAML to configure the CPU threshold. For more information, go to [Configure delegate resource threshold](#configure-delegate-resource-threshold). |
+| `ldap_sync_group_flush_total` | Publishes the total count for a user group when the LDAP group sync returned 0 users for that group. The metric publishes the `accountIdentifier` , `GroupDN` and the `count`. |
 
 :::info note
 Metrics with * above are only visible if you configure the resource threshold in your delegate YAML. Go to [Configure delegate resource threshold](#configure-delegate-resource-threshold) for more information.

--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -36,7 +36,7 @@ All metrics reset when you restart the delegate.
 | `io_harness_custom_metric_task_rejected_total` * #| The number of tasks rejected because of a high load on the delegate. |
 | `io_harness_custom_metric_delegate_connected` | Indicates whether the delegate is connected. Values are 0 (disconnected) and 1 (connected). |
 | `io_harness_custom_metric_resource_consumption_above_threshold`* | Delegate CPU is above a threshold. Provide `DELEGATE_CPU_THRESHOLD` as the env variable in the delegate YAML to configure the CPU threshold. For more information, go to [Configure delegate resource threshold](#configure-delegate-resource-threshold). |
-| `ldap_sync_group_flush_total` | Publishes the total count for a user group when the LDAP group sync returned 0 users for that group. The metric publishes the `accountIdentifier` , `GroupDN` and the `count`. |
+| `ldap_sync_group_flush_total` | Publishes the total count for a user group when the LDAP group sync returns 0 users for that group. The metric publishes the `accountIdentifier`, `GroupDN`, and the `count`. |
 
 :::info note
 Metrics with * above are only visible if you configure the resource threshold in your delegate YAML. Go to [Configure delegate resource threshold](#configure-delegate-resource-threshold) for more information.


### PR DESCRIPTION
[PL-50714](https://harness.atlassian.net/browse/PL-50714)

Changes will be reflected on this doc: https://developer.harness.io/docs/platform/delegates/manage-delegates/delegate-metrics/

Adding a new metric entry to the table:
| `ldap_sync_group_flush_total` | Publishes the total count for a user group when the LDAP group sync returned 0 users for that group. The metric publishes the `accountIdentifier` , `GroupDN` and the `count`. |

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-50714]: https://harness.atlassian.net/browse/PL-50714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ