### PR TITLE
[PL-43422] note to use vanity URL instead of app.harness

### DIFF
--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -750,7 +750,7 @@ With JIT, you add users to Keycloak, and they will automatically be added to Har
 	| **Master SAML Processing URL** | `https://app.harness.io/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`                                                               |
 
 :::info note
-If the account uses vanity URL, then use the same in SAML setup. eg: https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>
+If the account uses vanity URL, then use the same in SAML setup. eg: `https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`
 :::
 
 4. Select **Save**.

--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -750,7 +750,7 @@ With JIT, you add users to Keycloak, and they will automatically be added to Har
 	| **Master SAML Processing URL** | `https://app.harness.io/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`                                                               |
 
 :::info note
-If the account uses vanity URL, then use the same in SAML setup. eg: `https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`
+If the account uses a vanity URL, then use the vanity URL in your SAML setup. For example, `https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`.
 :::
 
 4. Select **Save**.

--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -749,6 +749,10 @@ With JIT, you add users to Keycloak, and they will automatically be added to Har
 	| **Valid post logout redirect URIs** | `https://app.harness.io/ng/account/<YOUR ACCOUNT ID>/main-dashboard`                                                                       |
 	| **Master SAML Processing URL** | `https://app.harness.io/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>`                                                               |
 
+:::info note
+If the account uses vanity URL, then use the same in SAML setup. eg: https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>
+:::
+
 4. Select **Save**.
 5. In the newly-created client's configuration, enter the following values.
 


### PR DESCRIPTION
[PL-43422](https://harness.atlassian.net/browse/PL-43422)

Changes will be reflected on: https://developer.harness.io/docs/platform/authentication/single-sign-on-saml/#saml-sso-with-keycloak

Change: Adding a note - If the account uses vanity URL, then use the same in SAML setup. eg: https://<yourvanityurl>/gateway/api/users/saml-login?accountId=<YOUR ACCOUNT ID>

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-43422]: https://harness.atlassian.net/browse/PL-43422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ