### PR TITLE
fix: [IDP]: Added information on techdocs not supported in harness code repo

### DIFF
--- a/docs/internal-developer-portal/get-started/enable-docs.md
+++ b/docs/internal-developer-portal/get-started/enable-docs.md
@@ -8,6 +8,14 @@ sidebar_position: 6
 
 Now that you have [added your Software Components](/docs/internal-developer-portal/get-started/register-a-new-software-component) in the Catalog, we need to add the documentation. By default, the **Docs** tab in your catalog does not include documentation for a new software component. However, you can quickly publish Markdown documentation to the **Docs** tab.
 
+
+:::info
+
+Techdocs is currently not supported with Harness Code Repo Integration
+
+:::
+
+
 ![](static/docs-empty.png)
 
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes:  Added information on techdocs not supported in harness code repo
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
