### PR TITLE
[PL-51420] Changing CLI ver from 0.24 to 0.25

### DIFF
--- a/docs/platform/shared/cli/amd.md
+++ b/docs/platform/shared/cli/amd.md
@@ -1,14 +1,14 @@
 ```bash
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-linux-amd64.tar.gz
-tar -xvf harness-v0.0.24-Preview-linux-amd64.tar.gz
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-linux-amd64.tar.gz
+tar -xvf harness-v0.0.25-Preview-linux-amd64.tar.gz
 ```
 
 <!---
 Non Scarf cURL
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-linux-amd64.tar.gz
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-linux-amd64.tar.gz
 -->
 
 <!---
 Scarf cURL
-curl -LO harness.gateway.scarf.sh/v0.0.24-Preview/harness-v0.0.24-Preview-linux-amd64.tar.gz
+curl -LO harness.gateway.scarf.sh/v0.0.25-Preview/harness-v0.0.25-Preview-linux-amd64.tar.gz
 -->

--- a/docs/platform/shared/cli/arm.md
+++ b/docs/platform/shared/cli/arm.md
@@ -1,14 +1,14 @@
 ```bash
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-linux-arm64.tar.gz
-tar -xvf harness-v0.0.24-Preview-linux-arm64.tar.gz
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-linux-arm64.tar.gz
+tar -xvf harness-v0.0.25-Preview-linux-arm64.tar.gz
 ```
 
 <!---
 Non Scarf cURL
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-linux-arm64.tar.gz
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-linux-arm64.tar.gz
 -->
 
 <!---
 Scarf cURL
-curl -LO harness.gateway.scarf.sh/v0.0.24-Preview/harness-v0.0.24-Preview-linux-arm64.tar.gz
+curl -LO harness.gateway.scarf.sh/v0.0.25-Preview/harness-v0.0.25-Preview-linux-arm64.tar.gz
 -->

--- a/docs/platform/shared/cli/mac.md
+++ b/docs/platform/shared/cli/mac.md
@@ -1,6 +1,6 @@
 ```bash
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-darwin-amd64.tar.gz
-tar -xvf harness-v0.0.24-Preview-darwin-amd64.tar.gz 
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-darwin-amd64.tar.gz
+tar -xvf harness-v0.0.25-Preview-darwin-amd64.tar.gz 
 export PATH="$(pwd):$PATH" 
 echo 'export PATH="'$(pwd)':$PATH"' >> ~/.bash_profile  
 source ~/.bash_profile 
@@ -9,10 +9,10 @@ harness --version
 
 <!---
 Non Scarf cURL
-curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-darwin-amd64.tar.gz 
+curl -LO https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-darwin-amd64.tar.gz 
 -->
 
 <!---
 Scarf cURL
-curl -LO harness.gateway.scarf.sh/v0.0.24-Preview/harness-v0.0.24-Preview-darwin-amd64.tar.gz
+curl -LO harness.gateway.scarf.sh/v0.0.25-Preview/harness-v0.0.25-Preview-darwin-amd64.tar.gz
 -->

--- a/docs/platform/shared/cli/windows.md
+++ b/docs/platform/shared/cli/windows.md
@@ -1,8 +1,8 @@
 ```
-Invoke-WebRequest -Uri https://github.com/harness/harness-cli/releases/download/v0.0.24-Preview/harness-v0.0.24-Preview-windows-amd64.zip -OutFile ./harness.zip
+Invoke-WebRequest -Uri https://github.com/harness/harness-cli/releases/download/v0.0.25-Preview/harness-v0.0.25-Preview-windows-amd64.zip -OutFile ./harness.zip
 ```
 
 <!---
 Potential Scarf cURL
-Invoke-WebRequest -Uri 'http://harness.gateway.scarf.sh/v0.0.24-Preview/harness-v0.0.24-Preview-linux-amd64.tar.gz' -MaximumRedirection 10 -OutFile './harness-v0.0.24-Preview-linux-amd64.tar.gz' -PassThru -ErrorAction SilentlyContinue
+Invoke-WebRequest -Uri 'http://harness.gateway.scarf.sh/v0.0.25-Preview/harness-v0.0.25-Preview-linux-amd64.tar.gz' -MaximumRedirection 10 -OutFile './harness-v0.0.25-Preview-linux-amd64.tar.gz' -PassThru -ErrorAction SilentlyContinue
 -->


### PR DESCRIPTION
[PL-51420
](https://harness.atlassian.net/browse/PL-51420)
We released v0.0.25-Preview version. This needs to be updated in the below document. 

https://developer.harness.io/docs/platform/automation/cli/install#install-harness-cli 

CFD reference: https://harness.atlassian.net/browse/PL-51125

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
