### PR TITLE
[PL-46758] Add info in docs regarding the SYSTEM updates

### DIFF
--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -21,7 +21,7 @@ To prevent the installation of the automatic upgrade feature, remove the `CronJo
 You can also change the time when the upgrade cron job runs by updating the `schedule`. For configuration details, go to [Configure the delegate upgrade schedule](#configure-the-delegate-upgrade-schedule).
 
 :::info
-User information is not propagated when a delegate is started from external sources. All delegate operations are recorded under the SYSTEM user in the audit trail. The **Action** column displays actions when a delegate is created, updated, or upserted and especially during the scale-up and scale-down process. For more information about the audit trail, go to [View audit trail](/docs/platform/governance/audit-trail/).
+User information is not propagated when a delegate is started from external sources. All delegate operations are recorded under the SYSTEM user in the audit trail, especially during the scale-up and scale-down processes. The **Action** column displays actions when a delegate is created, updated, or upserted. For more information about the audit trail, go to [View audit trail](/docs/platform/governance/audit-trail/).
 :::
 
 <details>

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -14,11 +14,15 @@ The automatic upgrade feature is enabled by default for the Kubernetes manifest 
 
 ## How automatic upgrade works in the Kubernetes manifest
 
-The Kubernetes manifest has a component called `upgrader`. The `upgrader` is a cron job that runs every hour by default. Every time it runs, it sends a request to Harness Manager to determine which delegate version is published for the account. The API returns a payload, such as `harness/delegate:yy.mm.verno`. If the delegate that was involved in this upgrade cron job does not have the same image as what the API returns, the `kubectl set image` command runs to perform a default rolling deployment of the delegate replicas with the newer image.
+The Kubernetes manifest has a component called `upgrader`. The `upgrader` is a cron job that runs every hour by default. Every time it runs, it sends a request to the Harness Manager to determine which delegate version is published for the account. The API returns a payload, such as `harness/delegate:yy.mm.verno`. If the delegate that was involved in this upgrade cron job does not have the same image as what the API returns, the `kubectl set image` command runs to perform a default rolling deployment of the delegate replicas with the newer image.
 
 To prevent the installation of the automatic upgrade feature, remove the `CronJob` section before you apply the manifest.
 
 You can also change the time when the upgrade cron job runs by updating the `schedule`. For configuration details, go to [Configure the delegate upgrade schedule](#configure-the-delegate-upgrade-schedule).
+
+:::info
+User information is not propagated when a delegate agent is started from external sources. As a result, all subsequent operations by the delegate agent will be recorded under the "SYSTEM" user. This includes the creation, deletion, and upsertion of delegates. This behaviour is expected during the platform's upgrade process.
+:::
 
 <details>
 <summary>Example Kubernetes manifest</summary>
@@ -132,7 +136,7 @@ spec:
 
 When a delegate is installed, it may take up to an hour by default to determine if the `upgrader` was removed during installation. During that time, the delegate shows a status of **DETECTING**.
 
-Harness updates the status when `upgrader` makes it's first API call to the Harness platform. The default schedule is one hour, but the schedule is configurable. If Harness doesn't detect the upgrader API call within 90 minutes, the upgrade status is updated from **DETECTING** to **AUTO UPGRADE: OFF**.
+Harness updates the status when `upgrader` makes its first API call to the Harness platform. The default schedule is one hour, but the schedule is configurable. If Harness doesn't detect the upgrader API call within 90 minutes, the upgrade status is updated from **DETECTING** to **AUTO UPGRADE: OFF**.
 
 Let's say the `upgrader` schedule is configured to two hours. The upgrade status would change from **AUTO UPGRADE: OFF** to **AUTO UPGRADE: ON** and back to **AUTO UPGRADE: OFF**. Every 90 minutes that Harness doesn't detect the API call, the status is set to **AUTO UPGRADE: OFF**. As soon as Harness detects it again, the status is set to **AUTO UPGRADE: ON**. Harness recommends a default schedule of 60 minutes. For more information, go to [Configure the delegate upgrade schedule](#configure-the-delegate-upgrade-schedule).
 

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -14,14 +14,14 @@ The automatic upgrade feature is enabled by default for the Kubernetes manifest 
 
 ## How automatic upgrade works in the Kubernetes manifest
 
-The Kubernetes manifest has a component called `upgrader`. The `upgrader` is a cron job that runs every hour by default. Every time it runs, it sends a request to the Harness Manager to determine which delegate version is published for the account. The API returns a payload, such as `harness/delegate:yy.mm.verno`. If the delegate that was involved in this upgrade cron job does not have the same image as what the API returns, the `kubectl set image` command runs to perform a default rolling deployment of the delegate replicas with the newer image.
+The Kubernetes manifest has a component called `upgrader`. The `upgrader` is a cron job that runs every hour by default. Every time it runs, it sends a request to Harness Manager to determine which delegate version is published for the account. The API returns a payload, such as `harness/delegate:yy.mm.verno`. If the delegate that was involved in this upgrade cron job does not have the same image as what the API returns, the `kubectl set image` command runs to perform a default rolling deployment of the delegate replicas with the newer image.
 
 To prevent the installation of the automatic upgrade feature, remove the `CronJob` section before you apply the manifest.
 
 You can also change the time when the upgrade cron job runs by updating the `schedule`. For configuration details, go to [Configure the delegate upgrade schedule](#configure-the-delegate-upgrade-schedule).
 
 :::info
-User information is not propagated when a delegate agent is started from external sources. As a result, all subsequent operations by the delegate agent will be recorded under the "SYSTEM" user. This includes the creation, deletion, and upsertion of delegates. This behaviour is expected during the platform's upgrade process.
+User information is not propagated when a delegate is started from external sources. All delegate operations are recorded under the SYSTEM user in the audit trail. The **Action** column displays actions when a delegate is created, updated, or upserted. For more information about the audit trail, go to [View audit trail](/docs/platform/governance/audit-trail/).
 :::
 
 <details>

--- a/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
+++ b/docs/platform/delegates/install-delegates/delegate-upgrades-and-expiration.md
@@ -21,7 +21,7 @@ To prevent the installation of the automatic upgrade feature, remove the `CronJo
 You can also change the time when the upgrade cron job runs by updating the `schedule`. For configuration details, go to [Configure the delegate upgrade schedule](#configure-the-delegate-upgrade-schedule).
 
 :::info
-User information is not propagated when a delegate is started from external sources. All delegate operations are recorded under the SYSTEM user in the audit trail. The **Action** column displays actions when a delegate is created, updated, or upserted. For more information about the audit trail, go to [View audit trail](/docs/platform/governance/audit-trail/).
+User information is not propagated when a delegate is started from external sources. All delegate operations are recorded under the SYSTEM user in the audit trail. The **Action** column displays actions when a delegate is created, updated, or upserted and especially during the scale-up and scale-down process. For more information about the audit trail, go to [View audit trail](/docs/platform/governance/audit-trail/).
 :::
 
 <details>


### PR DESCRIPTION
Add info in docs regarding the SYSTEM updates done on delegated displayed on audit logs.

"User information is not propagated when a Delegate agent is started from external sources. As a result, all subsequent operations by the Delegate agent will be recorded under the "SYSTEM" user. This includes the creation, deletion, and upsertion of delegates. This behavior is expected during the platform's upgrade process."

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): [PL-46758](https://harness.atlassian.net/browse/PL-46758)
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-46758]: https://harness.atlassian.net/browse/PL-46758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ