### PR TITLE
SonarScanner remove pull-request config STO-7705

### DIFF
--- a/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
@@ -388,7 +388,7 @@ Here's what the Run step looks like in YAML:
 
 ### Can't generate SonarQube report due to shallow clone
 
-* Error message: `Shallow clone detected, no blame information will be provided. You can convert to non-shallow with 'git fetch --unshallow`
+* Error message: `Shallow clone detected, no blame information will be provided. You can convert to non-shallow with 'git fetch --unshallow'`
 * Cause: If the [depth setting](https://developer.harness.io/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase#depth) in your pipeline's codebase configuration is shallow, SonarQube can't generate a report. This is a [known SonarQube issue](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scm-integration/#known-issues).
 * Solution: Change the `depth` to `0`.
 

--- a/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
@@ -6,7 +6,7 @@ sidebar_label: SonarScanner scanner reference
 helpdocs_topic_id: 4qe4h3cl28
 helpdocs_category_id: m01pu2ubai
 helpdocs_is_private: false
-helpdocs_is_published: true
+helpdocs_is_published: truex
 ---
 
 <DocsTag  text="Code repo scanners"  backgroundColor= "#cbe2f9" textColor="#0b5cad" link="/docs/security-testing-orchestration/sto-techref-category/security-step-settings-reference#code-repo-scanners"  />
@@ -86,8 +86,7 @@ import StoSettingScanModeIngest from './shared/step_palette/scan/mode/_ingestion
 The predefined configuration to use for the scan. 
 
 - **Default**  
-- **Branch Scan**  
-- **Pull Request** 
+- **Branch Scan** With this option selected, the step scans the branch or pull request specified in the pipeline execution. 
 
 
 ### Target
@@ -297,6 +296,8 @@ import ScannerRefAdvancedSettings from './shared/_advanced-settings.md';
 
 <ScannerRefAdvancedSettings />
 
+<!-- 
+
 ## SonarQube pull-request scan configuration
 
 To implement a SonarQube pull-request scan, include the following arguments in [**Additional CLI flags**](#additional-cli-flags). Use trigger variables for the pull request ID and branch:
@@ -305,6 +306,8 @@ To implement a SonarQube pull-request scan, include the following arguments in [
     - `-Dsonar.pullrequest.base=YOUR_BASELINE_BRANCH`
 
       If the target branch in the PR is the baseline, you can use [`<+trigger.targetBranch>`](/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference/#codebasetargetbranch).
+
+
 
 <details>
 <summary>YAML configuration example</summary>
@@ -326,6 +329,8 @@ To implement a SonarQube pull-request scan, include the following arguments in [
 ```
 
 </details>
+
+<!-- -->
 
 
 ## SonarQube proxy settings

--- a/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
+++ b/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference.md
@@ -296,41 +296,7 @@ import ScannerRefAdvancedSettings from './shared/_advanced-settings.md';
 
 <ScannerRefAdvancedSettings />
 
-<!-- 
 
-## SonarQube pull-request scan configuration
-
-To implement a SonarQube pull-request scan, include the following arguments in [**Additional CLI flags**](#additional-cli-flags). Use trigger variables for the pull request ID and branch:
-    - `-Dsonar.pullrequest.key=`[`<+codebase.prNumber>`](/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference/#codebaseprnumber)
-    - `-Dsonar.pullrequest.branch=`[`<+codebase.sourceBranch>`](/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference/#codebasesourcebranch)
-    - `-Dsonar.pullrequest.base=YOUR_BASELINE_BRANCH`
-
-      If the target branch in the PR is the baseline, you can use [`<+trigger.targetBranch>`](/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference/#codebasetargetbranch).
-
-
-
-<details>
-<summary>YAML configuration example</summary>
-
-```yaml
-              - step:
-                  type: Sonarqube
-                  # ...
-                  spec:
-                    mode: orchestration
-                    config: default
-                    # ...
-                    advanced:
-                      log:
-                        level: debug
-                      args:
-                        cli: "-Dsonar.pullrequest.key=<+trigger.prNumber> -Dsonar.pullrequest.branch=<+trigger.sourceBranch> -Dsonar.pullrequest.base=<+trigger.targetBranch> "
-                    # ...
-```
-
-</details>
-
-<!-- -->
 
 
 ## SonarQube proxy settings
@@ -434,11 +400,10 @@ In your SonarQube step, declare `-Dsonar.projectVersion` under [Additional CLI F
 
 :::info 
 
-Harness introduced a fix in [STO release 1.83.1](/release-notes/security-testing-orchestration#version-1882) to provide better support for orchestrated branch and pull-request scanning with SonarQube Enterprise.
+Harness introduced a fix in [STO release 1.83.1](/release-notes/security-testing-orchestration#version-1831) to provide better support for orchestrated branch and pull-request scanning with SonarQube Enterprise.
 
 - With this fix, the orchestration step always downloads results for the scanned branch or pull request.
-- Branch scans require no additional configuration.
-- To configure pull-request scans, go to [SonarQube pull-request scan configuration](#sonarqube-pull-request-scan-configuration).
+- To scan a branch or pull request, select **Branch Scan** in [Scan Configuration](#scan-configuration). With this option selected, the step scans the branch or pull request specified in the pipeline execution.
 
 :::
 

--- a/kb/security-testing-orchestration/security-testing-orchestration-faqs.md
+++ b/kb/security-testing-orchestration/security-testing-orchestration-faqs.md
@@ -125,10 +125,7 @@ This error ocurrs if there's no scan target in the Scanner configuration. To fix
 
 #### How does the SonarQube integration work when attempting to perform a branch scan with SonarQube Enterprise?
 
-An enhancement has been made to ensure the orchestration step always downloads results for the branch specified in the step, instead of downloading results only for main or master branches. For more information, go to:
-
-- [SonarQube pull-request scan configuration](/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference#sonarqube-pull-request-scan-configuration)
-- STO release notes > [Version 1.83.1](https://developer.harness.io/release-notes/security-testing-orchestration#version-1831)
+An enhancement has been made to ensure the orchestration step always downloads results for the branch specified in the step, instead of downloading results only for main or master branches. For more information, go to the [STO 1.83.1 release notes](https://developer.harness.io/release-notes/security-testing-orchestration#version-1831).
 
 
 

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -453,11 +453,15 @@ You can scan your code repositories using [Open Source Vulnerabilities (OSV)](ht
 
 - Fixed a UI issue where the Exemptions page would show the incorrect severity of an issue if that severity was overridden after the original scan. (STO-7069)
 
+
 - The SonarQube integration includes better support for orchestrated branch and pull-request scanning with SonarQube Enterprise. (STO-7122, STO-6840, STO-6857, ZD-58021, ZD-55282, ZD-55592)
   - Previously, the orchestration scan step downloaded results for the main or master branch regardless of the branch specified in the runtime input or the pull request.
   - With this enhancement, the orchestration step always downloads results for the scanned branch or pull request.
-  - Branch scans require no additional configuration.
+
+  <!-- 
   - To configure pull-request scans, go to [SonarQube pull-request scan configuration](/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference#sonarqube-pull-request-scan-configuration).
+
+<!-- -->
 
 ## January 2024 
 

--- a/release-notes/security-testing-orchestration.md
+++ b/release-notes/security-testing-orchestration.md
@@ -457,6 +457,7 @@ You can scan your code repositories using [Open Source Vulnerabilities (OSV)](ht
 - The SonarQube integration includes better support for orchestrated branch and pull-request scanning with SonarQube Enterprise. (STO-7122, STO-6840, STO-6857, ZD-58021, ZD-55282, ZD-55592)
   - Previously, the orchestration scan step downloaded results for the main or master branch regardless of the branch specified in the runtime input or the pull request.
   - With this enhancement, the orchestration step always downloads results for the scanned branch or pull request.
+  - When **Branch Scan** is selected in the [Scan Configuration](/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference#scan-configuration), the step scans the branch or pull request specified in the pipeline execution.
 
   <!-- 
   - To configure pull-request scans, go to [SonarQube pull-request scan configuration](/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference#sonarqube-pull-request-scan-configuration).


### PR DESCRIPTION
### Preview links
- [SonarScanner scanner reference](https://6669ec77a49b3318aa1a76ee--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference)
  - Removed [SonarQube pull-request scan configuration](https://developer.harness.io/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference/#sonarqube-pull-request-scan-configuration) (this link points to the public doc, not the draft)
  - [Scan configuration](https://6669ec77a49b3318aa1a76ee--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference/#scan-configuration) Remove **Pull Request**, add description to **Branch Scan**  
  - [SonarQube doesn't scan the main branch and pull request branches in the same pipeline](https://6669ec77a49b3318aa1a76ee--harness-developer.netlify.app/docs/security-testing-orchestration/sto-techref-category/sonarqube-sonar-scanner-reference/#sonarqube-doesnt-scan-the-main-branch-and-pull-request-branches-in-the-same-pipeline) 
     - Updated second bullet point
     - Removed last bullet point: To configure pull-request scans, go to **SonarQube pull-request scan configuration**

- STO release notes > [1.83 fixed issues](https://6669ec77a49b3318aa1a76ee--harness-developer.netlify.app/release-notes/security-testing-orchestration#fixed-issues-11) - Deleted last bullet point about pull-request config, update **Branch Scan** bullet point

- KB > STO FAQs > [How does the SonarQube integration work when attempting to perform a branch scan with SonarQube Enterprise?](https://6669ec77a49b3318aa1a76ee--harness-developer.netlify.app/kb/security-testing-orchestration/security-testing-orchestration-faqs/#how-does-the-sonarqube-integration-work-when-attempting-to-perform-a-branch-scan-with-sonarqube-enterprise) Removed link to pull-request section

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] SME review - see Jira ticket.
- [x] No merge conflicts.
