### PR TITLE
CI 1.33 release notes v0 draft

### DIFF
--- a/docs/continuous-integration/ci-supported-platforms.md
+++ b/docs/continuous-integration/ci-supported-platforms.md
@@ -51,6 +51,7 @@ For more information about early access features, including early access feature
 | `CI_INDIRECT_LOG_UPLOAD` | Enables uploading of logs through log service for certain troubleshooting scenarios, for example, if [step logs disappear](https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs#step-logs-disappear). | Beta |
 | `CI_INCREASE_DEFAULT_RESOURCES` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag increases maximum CPU to 1000m and maximum memory to 3000Mi. | Beta |
 | `CI_CONSERVATIVE_K8_RESOURCE_LIMITS` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag sets lite engine resource limits to the default minimum (100m CPU and 100Mi memory). | Beta |
+| `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step uses buildx rather than kaniko. | Beta |
 
 <!-- In development: CI_YAML_VERSIONING, CI_ENABLE_TTY_LOGS, CIE_ENABLE_RUNTEST_V2, CI_ENABLE_INTELLIGENT_DEFAULTS  -->
 

--- a/docs/continuous-integration/ci-supported-platforms.md
+++ b/docs/continuous-integration/ci-supported-platforms.md
@@ -51,7 +51,7 @@ For more information about early access features, including early access feature
 | `CI_INDIRECT_LOG_UPLOAD` | Enables uploading of logs through log service for certain troubleshooting scenarios, for example, if [step logs disappear](https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs#step-logs-disappear). | Beta |
 | `CI_INCREASE_DEFAULT_RESOURCES` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag increases maximum CPU to 1000m and maximum memory to 3000Mi. | Beta |
 | `CI_CONSERVATIVE_K8_RESOURCE_LIMITS` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag sets lite engine resource limits to the default minimum (100m CPU and 100Mi memory). | Beta |
-| `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step uses buildx rather than kaniko. You must run buildx on k8s with Privileged mode enabled.  | Beta |
+| `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step, running on k8s, uses buildx rather than kaniko. You must run buildx on k8s with Privileged mode enabled.  | Beta |
 
 <!-- In development: CI_YAML_VERSIONING, CI_ENABLE_TTY_LOGS, CIE_ENABLE_RUNTEST_V2, CI_ENABLE_INTELLIGENT_DEFAULTS  -->
 

--- a/docs/continuous-integration/ci-supported-platforms.md
+++ b/docs/continuous-integration/ci-supported-platforms.md
@@ -51,7 +51,7 @@ For more information about early access features, including early access feature
 | `CI_INDIRECT_LOG_UPLOAD` | Enables uploading of logs through log service for certain troubleshooting scenarios, for example, if [step logs disappear](https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs#step-logs-disappear). | Beta |
 | `CI_INCREASE_DEFAULT_RESOURCES` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag increases maximum CPU to 1000m and maximum memory to 3000Mi. | Beta |
 | `CI_CONSERVATIVE_K8_RESOURCE_LIMITS` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag sets lite engine resource limits to the default minimum (100m CPU and 100Mi memory). | Beta |
-| `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step uses buildx rather than kaniko. | Beta |
+| `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step uses buildx rather than kaniko. You must run buildx on k8s with Privileged mode enabled.  | Beta |
 
 <!-- In development: CI_YAML_VERSIONING, CI_ENABLE_TTY_LOGS, CIE_ENABLE_RUNTEST_V2, CI_ENABLE_INTELLIGENT_DEFAULTS  -->
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -37,6 +37,20 @@ Contact [Harness Support](mailto:support@harness.io) if you have any questions.
 
 ## June 2024
 
+### Version 1.33
+
+#### New features
+
+- Added support for AWS connectors to assume external roles to STS (Security Token Service) credentials for cache plugins. (CI-12851)
+
+#### Fixed issues
+
+- Fixed an issue where default values were not populated when entering runtime inputs for environment variables in a Run step. (CI-12906, ZD-64897)
+- Fixed a UI issue where the Codebase icon (right menu) showed the status as not valid, even when the provider was chosen as Harness code repo and the repository was selected. (CI-12750)
+- Fixed an issue where the YAML editor allowed saving invalid environment variables in a Run step. (CI-12730)
+- Fixed an issue where certain keywords in a script could cause the step to fail with an "Invalid step" error. (CI-12708, ZD-63932)
+- Fixed an issue where the Docker LABEL set in a Build and Push step does not override the LABEL configured in the Dockerfile. With this fix, you can now use buildx rather than kaniko to build your container images. This fix is behind the feature flag CI_USE_BUILDX_ON_K8. Contact Harness Support to enable this fix. (CI-12548, ZD-63222)
+
 ### Version 1.30
 
 #### New features and enhancements

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -49,7 +49,7 @@ Contact [Harness Support](mailto:support@harness.io) if you have any questions.
 - Fixed a UI issue where the Codebase icon (right menu) showed the status as not valid, even when the provider was chosen as Harness code repo and the repository was selected. (CI-12750)
 - Fixed an issue where the YAML editor allowed saving invalid environment variables in a Run step. (CI-12730)
 - Fixed an issue where certain keywords in a script could cause the step to fail with an "Invalid step" error. (CI-12708, ZD-63932)
-- Fixed an issue where the Docker LABEL set in a Build and Push step does not override the LABEL configured in the Dockerfile. With this fix, you can now use buildx rather than kaniko to build your container images. This fix is behind the feature flag CI_USE_BUILDX_ON_K8. Contact Harness Support to enable this fix. (CI-12548, ZD-63222)
+- Fixed an issue where the Docker LABEL set in a Build and Push step does not override the LABEL configured in the Dockerfile. With this fix, you can now use buildx rather than kaniko to build your container images. You must run buildx on k8s with Privileged mode enabled. This fix is behind the feature flag CI_USE_BUILDX_ON_K8. Contact Harness Support to enable this fix. (CI-12548, ZD-63222)
 
 ### Version 1.30
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -2,7 +2,7 @@
 title: Continuous Integration release notes
 sidebar_label: Continuous Integration
 
-date: 2024-05-28T10:00
+date: 2024-06-24T10:00
 sidebar_position: 10
 ---
 


### PR DESCRIPTION
### Preview links
- CI release notes > [Version 1.33](https://667cac06b5a0a52c22faf6e8--harness-developer.netlify.app/release-notes/continuous-integration#version-133)
- [Harness CI early access features](https://667cac06b5a0a52c22faf6e8--harness-developer.netlify.app/docs/continuous-integration/ci-supported-platforms#harness-ci-early-access-features) last row in table

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
