### PR TITLE
Update docker-registry-connector-settings-reference.md

### DIFF
--- a/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference.md
+++ b/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference.md
@@ -72,7 +72,7 @@ If you select **Other**, the registry must be Docker V2 compliant.
 The URL of the Docker registry. This is usually the URL used for your [docker login](https://docs.docker.com/engine/reference/commandline/login/) credentials.
 
 * To connect to a public Docker Hub registry, use `https://index.docker.io/v2/`.
-* To connect to a private Docker Hub registry, use `https://registry.hub.docker.com/v2/`.
+* To connect to a private Docker Hub registry, use `https://index.docker.io/v1/`.
 * For other Docker registries, provide the relevant URL for your container registry provider. For example:
    * For GitHub Container Registry, provide the GHCR hostname and namespace, such as `https://ghcr.io/NAMESPACE`. The namespace is the name of a GitHub personal account or organization.
    * For JFrog Artifactory Docker registries, provide your JFrog instance URL, such as `https://mycompany.jfrog.io`. You can get this URL from the `docker-login` command on your repo's **Set Me Up** page.


### PR DESCRIPTION
Update docker url to use when pulling from private registries  [CI-13015]

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Dockerhub doesn't allow using v2 api when pulling from private docker registries. updated the docker url accordingly. 
* Jira/GitHub Issue numbers (if any): CI-13015
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[CI-13015]: https://harness.atlassian.net/browse/CI-13015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ