### PR TITLE
Update maven-settings-xml.md

### DIFF
--- a/kb/continuous-integration/articles/maven-settings-xml.md
+++ b/kb/continuous-integration/articles/maven-settings-xml.md
@@ -24,7 +24,9 @@ There are several options for handling `settings.xml` in Harness CI:
 You can use expressions to reference secrets in step commands, such as:
 
 ```
-echo '<+secrets.getValue("account.[settingsXMLSecretID]")>' > settings.xml
+cat > settings.xml <<- EOM
+<+secrets.getValue("account.[settingsXMLSecretID]")>
+EOM
 ```
 
 If you need to share `settings.xml` with multiple steps in the same stage, declare it in **Shared Paths**. For more information, go to [Share data between steps in a stage](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/share-ci-data-across-steps-and-stages/).
@@ -61,7 +63,9 @@ import TabItem from '@theme/TabItem';
 If your Maven tests run in a **Run** or **Test** step, add the following to the **Command**:
 
 ```
-echo '<+secrets.getValue("account.settingsXML")>' > settings.xml
+cat > settings.xml <<- EOM
+<+secrets.getValue("account.settingsXML")>
+EOM
 ```
 
 </TabItem>
@@ -70,7 +74,9 @@ echo '<+secrets.getValue("account.settingsXML")>' > settings.xml
 If your Maven tests run in a **Run Tests** step, add the following to the **Pre-Command**:
 
 ```
-echo '<+secrets.getValue("account.settingsXML")>' > settings.xml
+cat > settings.xml <<- EOM
+<+secrets.getValue("account.settingsXML")>
+EOM
 ```
 
 </TabItem>
@@ -91,7 +97,9 @@ If your `settings.xml` file is in the `~/.m2/` directory, Maven can read the sec
 For example, if you can use the following command to transcribe the [settings.xml text secret](#transcribe-the-text-secret-into-settingsxml) to `~/.m2/`:
 
 ```
-echo '<+secrets.getValue("account.settingsXML")>' > ~/.m2/settings.xml
+cat > ~/.m2/settings.xml <<- EOM
+<+secrets.getValue("account.settingsXML")>
+EOM
 ```
 
 And then you only need `mvn test` to run the test.


### PR DESCRIPTION
The existing docs used an echo command with the secret value wrapped in single quotes. This syntax will not work if the secret file contains single quotes. I updated the command to use a HEREDOC format which will never cause issues with special characters in the settings file.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
