### PR TITLE
FFM-11803 Add Target Forwarding Limitation to Relay Proxy Docs

### DIFF
--- a/docs/feature-flags/use-ff/relay-proxy/relay_proxy_v2.md
+++ b/docs/feature-flags/use-ff/relay-proxy/relay_proxy_v2.md
@@ -145,6 +145,7 @@ The below table outlines all of the configuration options that are available for
 | METRICS_STREAM_READ_CONCURRENCY | 10                          | Controls the number of threads running in the Primary that listen for metrics data being sent by replicas                                                                   | 10                                     |
 | AND_RULES              | true                                 | Enables AND rule support for Target Groups in the Proxy                                                                                                                     | false                                  |
 | PROMETHEUS_PORT        | 9091                                 | Port that the prometheus metrics are exposed on, defaults to 8000                                                                                                           | 8000                                   |
+| FORWARD_TARGETS        | false                                 | The Proxy will forward targets sent by Client SDKs to Harness Saas | false                                   |
 
 
 # The Proxy Key V2
@@ -388,4 +389,5 @@ If you decide to use the Relay Proxy, make sure it has a good place in your netw
 
 ## Are there any constraints to the Relay Proxy V2?
 
-At this current time and due to the way Harness implements the authentication tokens, users have a limit of 1000 environments per key. 
+- At this current time and due to the way Harness implements the authentication tokens, users have a limit of 1000 environments per key.
+- When running in HA mode Read replica's will not forward targets on to Harness Saas. This doesn't impact functionality as the Proxy will still add the Targets to the redis cache, it just means you won't see them in the Feature Flags UI.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: 
  - Documents limitations around target forwarding
  - Adds `FORWARD_TARGETS` env var which was missing from our docs

* Jira/GitHub Issue numbers (if any): FFM-11803
* Preview links/images (Internal contributors only):

![Screenshot 2024-07-23 at 11 04 42](https://github.com/user-attachments/assets/6c0c70ed-ae07-4828-8ddd-2fd6daa77125)
![Screenshot 2024-07-23 at 11 04 33](https://github.com/user-attachments/assets/df555c2d-1ed4-40df-b06a-87545309334a)



## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
