### PR TITLE
CD docs - Removed an old video reference related to Kubernetes manifest

### DIFF
--- a/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/cd-kubernetes-category/define-kubernetes-manifests.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/cd-kubernetes-category/define-kubernetes-manifests.md
@@ -24,14 +24,6 @@ This topics provides a quick overview or some options and steps when using Kuber
 
 You cannot use [Harness variables](/docs/platform/variables-and-expressions/harness-variables) in Kubernetes manifests. You can only use Harness variables in Values YAML files. Harness support Go templating, so you can use variables in Values YAML files and have the manifests reference those variables/values.
 
-## Visual summary on using Kubernetes manifests
-
-Here's a quick video that show how to add Kubernetes manifests and Values YAML files:
-
-<!-- Video:
-https://www.youtube.com/watch?v=dVk6-8tfwJc-->
-<DocVideo src="https://www.youtube.com/watch?v=dVk6-8tfwJc" />
-
 ## Artifacts and Kubernetes manifests in Harness
 
 If a public Docker image location is hardcoded in your Kubernetes manifest or values YAML file (for example, `image: nginx:1.14.2`) then you can simply add the manifest or values YAML to Harness and the Harness Delegate will pull the image during deployment.


### PR DESCRIPTION
Removed video referencing the v1 service with old FE experience thats no longer relevant to the new service experience.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
