### PR TITLE
CI 1.38 Release Notes

### DIFF
--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -37,41 +37,9 @@ Contact [Harness Support](mailto:support@harness.io) if you have any questions.
 
 ## July 2024
 
-### Version 1.39
-
-<!-- 2024-07-29 -->
-
-#### Fixed issues
-
-- Fixed an issue where the Harness Build URL could exceed 255 characters if the projectId, orgId, or PipelineId identifiers were too long. Changes have been made to remove stageExecId from the Build URL to reduce the URL length in the case of non-matrix stages. (CI-13402, ZD-66211)
-
-- Fixed an issue where SSH account-level Git connectors were failing during the connection test and status checks due to using an incorrect port. (CI-13578, ZD-67248,67266)
-
 ### Version 1.38
 
 <!-- 2024-07-22 -->
-
-#### Early Access feature
-
-This release introduces several highly requested features and improvements to enhance the Git clone operations within Harness, in both the Git Clone step and the native Clone Codebase functionality. With this release, we’re adding support for:
-
-- Git LFS - Allows users to clone repositories with large file storage (LFS) efficiently.
-
-- Fetch Tags - Enables fetching of tags during the clone operation.
-
-- Sparse Checkout - Enables cloning specific subdirectories.
-
-- Clone Submodules - Adds options for including and recursively cloning Git submodules.
-
-- Clone Path Customization - Exposes the clone path in the codebase section, allowing users to specify a custom clone directory.
-
-- Additional Pre-Fetch Command - Ability to specify any additional Git commands to run before fetching the code.
-
-- UI Changes - Have added additional configurations (LFS, fetch tags, clone directory, sparse checkout, submodule strategy, prefetch command) while cloning the codebase in the UI editor. These fields can be accessed in both the clone codebase dialog from the right navigation bar and in the Git clone step.
-
-For more information, please refer to the [documentation](../docs/continuous-integration/use-ci/codebase-configuration/git-clone-step). (CI-12952, CI-13239)
-
-This feature is behind the feature flag `CI_GIT_CLONE_ENHANCED`.
 
 #### Fixed issues
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -37,6 +37,52 @@ Contact [Harness Support](mailto:support@harness.io) if you have any questions.
 
 ## July 2024
 
+### Version 1.39
+
+<!-- 2024-07-29 -->
+
+#### Fixed issues
+
+- Fixed an issue where the Harness Build URL could exceed 255 characters if the projectId, orgId, or PipelineId identifiers were too long. Changes have been made to remove stageExecId from the Build URL to reduce the URL length in the case of non-matrix stages. (CI-13402, ZD-66211)
+
+- Fixed an issue where SSH account-level Git connectors were failing during the connection test and status checks due to using an incorrect port. (CI-13578, ZD-67248,67266)
+
+### Version 1.38
+
+<!-- 2024-07-22 -->
+
+#### Early Access feature
+
+This release introduces several highly requested features and improvements to enhance the Git clone operations within Harness, in both the Git Clone step and the native Clone Codebase functionality. With this release, we’re adding support for:
+
+- Git LFS - Allows users to clone repositories with large file storage (LFS) efficiently.
+
+- Fetch Tags - Enables fetching of tags during the clone operation.
+
+- Sparse Checkout - Enables cloning specific subdirectories.
+
+- Clone Submodules - Adds options for including and recursively cloning Git submodules.
+
+- Clone Path Customization - Exposes the clone path in the codebase section, allowing users to specify a custom clone directory.
+
+- Additional Pre-Fetch Command - Ability to specify any additional Git commands to run before fetching the code.
+
+- UI Changes - Have added additional configurations (LFS, fetch tags, clone directory, sparse checkout, submodule strategy, prefetch command) while cloning the codebase in the UI editor. These fields can be accessed in both the clone codebase dialog from the right navigation bar and in the Git clone step.
+
+For more information, please refer to the [documentation](../docs/continuous-integration/use-ci/codebase-configuration/git-clone-step). (CI-12952, CI-13239)
+
+This feature is behind the feature flag `CI_GIT_CLONE_ENHANCED`.
+
+#### Fixed issues
+
+- Fixed issues where the Git status update was not being sent to PRs and the PR link in the execution pipeline was incorrect, redirecting back to the same execution link. The PR link redirect was not working for the input expression `<+trigger.payload.pull_req.number>`, so support for this expression has been added. (CI-11759)
+
+- Fixed an issue where customers could not change the Build configuration from Runtime Input to an expression when setting up the CI Build stage. This fix allows customers to set an expression for the Build configuration of the CodeBase, enabling uniform build names across multiple child pipelines. Customers can now set the Build Type to a fixed value from Runtime Input and then set the branch/tag/pr as an expression, related to chained pipelines. (CI-13268, ZD-66080)
+
+- Fixed an issue where the plugin image path was incorrect when the registry endpoint had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13455, ZD-66772)
+
+- Fixed an issue where the **Docker build and push** steps using Docker Layer Caching (DLC) might fail while downloading the cache if the feature flag `CI_DLC_SIGNED_URL` is turned on. The bug was caused by the `getReader` utility returning a closed `io.ReadCloser`, leading to an error when the caller tried to read from it. The issue has been resolved by ensuring the `io.ReadCloser` is not closed prematurely in the new product-specific implementation of the interface for buildkit cache. (CI-13508, ZD-66950)
+
 ### Version 1.37
 
 <!-- 2024-07-16 -->

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -81,7 +81,7 @@ This feature is behind the feature flag `CI_GIT_CLONE_ENHANCED`.
 
 - Fixed an issue where the plugin image path was incorrect when the registry endpoint had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13455, ZD-66772)
 
-- Fixed an issue where the **Docker build and push** steps using Docker Layer Caching (DLC) might fail while downloading the cache if the feature flag `CI_DLC_SIGNED_URL` is turned on. The bug was caused by the `getReader` utility returning a closed `io.ReadCloser`, leading to an error when the caller tried to read from it. The issue has been resolved by ensuring the `io.ReadCloser` is not closed prematurely in the new product-specific implementation of the interface for buildkit cache. (CI-13508, ZD-66950)
+- Fixed an issue where the **Docker build and push** steps using Docker Layer Caching (DLC) might fail while downloading the cache if the feature flag `CI_DLC_SIGNED_URL` is turned on. (CI-13508, ZD-66950)
 
 ### Version 1.37
 


### PR DESCRIPTION
This PR adds CI 1.38 Release Notes.

## Checlist

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
