### PR TITLE
Update Github App documentation to prevent common error mode

### DIFF
--- a/docs/platform/connectors/code-repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
+++ b/docs/platform/connectors/code-repositories/ref-source-repo-provider/git-hub-connector-settings-reference.md
@@ -228,6 +228,12 @@ To use this authentication method, you need to create and install a GitHub App, 
    ![](../../static/git-hub-app-support-59.png)
 
 4. For **GitHub Private Key**, provide your GitHub App's PEM key file as a [Harness encrypted file secret](/docs/platform/secrets/add-file-secrets).
+:::tip
+Ensure your private key is in the correct format. For detailed steps, refer to [Generate a private key](/docs/platform/connectors/code-repositories/git-hub-app-support/#generate-a-private-key).
+
+Using an incorrect format will result in errors such as:  __Invalid request: Failed to generate token__
+
+:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
A common error mode for users is giving the wrong key, and the error message is not always clear that the format is the problem. This should be front and center in all concerned docs as this has been an issue in FG and NextGen that customers hit and don't realize the problem. 

![Screenshot 2024-08-07 at 8 22 47 AM](https://github.com/user-attachments/assets/cac6111b-5523-4df3-917e-230459f564af)

Please revise as necessary for clarity or consistency in format

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

Adding tip to section where one of my customers just hit this error mode and I had to spend 2 hours debugging with them. This is a common failure mode and I didn't realize what happened until I realized I was looking at the linked doc and he was looking at the doc with this proposed revision.

