### PR TITLE
Adding CI 1.32 release notes from backlog

### DIFF
--- a/docs/continuous-integration/ci-supported-platforms.md
+++ b/docs/continuous-integration/ci-supported-platforms.md
@@ -53,6 +53,7 @@ For more information about early access features, including early access feature
 | `CI_CONSERVATIVE_K8_RESOURCE_LIMITS` | Used to adjust [resource allocation limits](/docs/continuous-integration/use-ci/set-up-build-infrastructure/resource-limits/#override-resource-limits). This feature flag sets lite engine resource limits to the default minimum (100m CPU and 100Mi memory). | Beta |
 | `CI_USE_BUILDX_ON_K8` | With this flag enabled, a Build and Push step, running on k8s, uses buildx rather than kaniko. You must run buildx on k8s with Privileged mode enabled.  | Beta |
 | `CI_REMOVE_FQN_DEPENDENCY` | This flag is useful for steps that use a private Docker registry. With this flag enabled, the step uses the URI specified in the Docker connector. This means you don't need to specify the Fully Qualified Name in the Image field. This change applies to the following steps: **Plugin**, **Background**, **Run**, **Run Tests**, and **Test Intelligence**. | Beta |
+| `CI_EXTRA_ADDON_RESOURCE` | Used to speed up CI builds by adding more resources for running 'addon`. | Beta |
 
 <!-- In development: CI_YAML_VERSIONING, CI_ENABLE_TTY_LOGS, CIE_ENABLE_RUNTEST_V2, CI_ENABLE_INTELLIGENT_DEFAULTS  -->
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -152,6 +152,22 @@ This is behind the feature flag: `CI_ENGINE_LOG_UPLOAD_CONCURRENCY`.
 - Fixed an issue where certain keywords in a script could cause the step to fail with an "Invalid step" error. (CI-12708, ZD-63932)
 - Fixed an issue where the Docker LABEL set in a Build and Push step does not override the LABEL configured in the Dockerfile. With this fix, you can now use buildx rather than kaniko to build your container images. You must run buildx on k8s with Privileged mode enabled. This fix is behind the feature flag CI_USE_BUILDX_ON_K8. Contact Harness Support to enable this fix. (CI-12548, ZD-63222)
 
+### Version 1.32
+
+#### Fixed issues
+
+- CI builds were running slowly in some cases. This release includes the following fixes to address this issue. (CI-10042, ZD-52559)
+
+  - Added extra resources for running `addon`. This feature is behind the feature flag `CI_EXTRA_ADDON_RESOURCE`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.
+
+  - Updated LE to addon communication to retry every 300ms 30 times, for a total of 9 seconds.
+
+  - Disabled resource consumption logs for addon. 
+
+- Fixed an issue where pipelines failed intermittently due to delegate selection and task distribution problems when multiple delegates are configured with the same selector tag. (CI-12788, ZD-64246)
+- Running `unittest` in a Run step resulted in the error `sh: unittest not found in some cases`. With this fix, pipelines now run `python unittest -m` which supports more image types. (CI-12795)
+- In some cases, the **Image Pull Policy** setting didn't work as intended when running builds in Docker and VM build infrastructures. (CI-11703) 
+
 ### Version 1.30
 
 #### New features and enhancements


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

This PR brings this changes over as it was in the backlog 
https://github.com/harness/developer-hub/pull/7176/

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
