### PR TITLE
Add notes for PR_MERGE_STRATEGY_BRANCH stage variable.

### DIFF
--- a/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
@@ -235,6 +235,10 @@ Set maximum resource limits for the containers that clone the codebase at runtim
 
 Go to the [Harness CI Knowledge Base](/kb/continuous-integration/continuous-integration-faqs) for common questions and issues related to codebases, such as:
 
+:::tip
+If you're using the GitHub API, use the stage variable `PR_MERGE_STRATEGY_BRANCH` along with the `CI_PR_MERGE_STRATEGY_BRANCH` flag to enable the **Merge Commit Strategy** for codebase cloning.
+:::
+
 * [How do I improve codebase clone time?](/kb/continuous-integration/continuous-integration-faqs/#how-can-i-reduce-clone-codebase-time)
 * [The same Git commit is not used in all stages.](/kb/continuous-integration/continuous-integration-faqs/#the-same-git-commit-is-not-used-in-all-stages)
 * [Git fetch fails with invalid index-pack output when cloning large repos.](/kb/continuous-integration/continuous-integration-faqs/#git-fetch-fails-with-invalid-index-pack-output-when-cloning-large-repos)

--- a/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase.md
@@ -235,10 +235,6 @@ Set maximum resource limits for the containers that clone the codebase at runtim
 
 Go to the [Harness CI Knowledge Base](/kb/continuous-integration/continuous-integration-faqs) for common questions and issues related to codebases, such as:
 
-:::tip
-If you're using the GitHub API, use the stage variable `PR_MERGE_STRATEGY_BRANCH` along with the `CI_PR_MERGE_STRATEGY_BRANCH` flag to enable the **Merge Commit Strategy** for codebase cloning.
-:::
-
 * [How do I improve codebase clone time?](/kb/continuous-integration/continuous-integration-faqs/#how-can-i-reduce-clone-codebase-time)
 * [The same Git commit is not used in all stages.](/kb/continuous-integration/continuous-integration-faqs/#the-same-git-commit-is-not-used-in-all-stages)
 * [Git fetch fails with invalid index-pack output when cloning large repos.](/kb/continuous-integration/continuous-integration-faqs/#git-fetch-fails-with-invalid-index-pack-output-when-cloning-large-repos)

--- a/docs/continuous-integration/use-ci/codebase-configuration/git-clone-step.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/git-clone-step.md
@@ -191,5 +191,6 @@ Set the timeout limit for the step. Once the timeout limit is reached, the step 
 ## Troubleshooting 
 * **SSH-keyscan timeout:** - If your [connector](#connector) uses SSH authentication, you can add a `PLUGIN_SSH_KEYSCAN_TIMEOUT` [stage variable](/docs/platform/pipelines/add-a-stage/#stage-variables) to override the `ssh-keyscan` command's timeout limit (the default is `5s`).
 Stage variables are configured in stage settings, not step settings.
+* If you're using the GitHub API and facing issues with **Merge Commit Strategy** for codebase cloning, use the stage variable `PR_MERGE_STRATEGY_BRANCH` along with the `CI_PR_MERGE_STRATEGY_BRANCH` flag.
 
 

--- a/docs/continuous-integration/use-ci/codebase-configuration/git-clone-step.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/git-clone-step.md
@@ -4,10 +4,8 @@ description: Clone a repository into the CI stage's workspace.
 sidebar_position: 10
 ---
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
 
 This topic describes how to use the **Git Clone** step included in Harness Continuous Integration (CI) pipelines. The **Git Clone** step clones a repository into the CI stage's workspace. In addition to the pipeline's default [clone codebase](./create-and-configure-a-codebase.md), you can use **Git Clone**, **Run**, and **Plugin** steps to clone additional code repos into the pipeline's workspace.
 
@@ -132,6 +130,10 @@ If this is set to **Merge Commit** (which is the default setting), the pipeline 
 If this is set to **Source Branch**, the pipeline builds the artifact from the latest commit in the pull request branch. This can be faster and less likely to result in build failures; however, it might not include some commits in the target branch.
 
 ![](./static/create-and-configure-a-codebase-05.png)
+
+:::tip
+If you're using the GitHub API, use the stage variable `PR_MERGE_STRATEGY_BRANCH` along with the `CI_PR_MERGE_STRATEGY_BRANCH` flag to enable the **Merge Commit Strategy** for codebase cloning.
+:::
 
 ### Download LFS Files
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -39,10 +39,8 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 - Fixed an issue where external endpoints were used for internal communication with logs service, causing token authentication failures and 401 errors. The issue was resolved by ensuring internal communication for the services. (CI-13686)
 
-<!-- The following item will be added back in when the current discussion is resolved. 
+- The stage variable `PR_MERGE_STRATEGY_BRANCH` has been added, along with the `CI_PR_MERGE_STRATEGY_BRANCH` flag, to enable the **Merge Commit Strategy** for codebase clone, resolving previous issues with the GitHub API. (CI-13625, ZD-67476)
 
-- Validated the `CI_PR_MERGE_STRATEGY_BRANCH` flag to enable the **Merge Commit Strategy** for codebase clone, addressing previous issues with the GitHub API. Additionally, a stage variable `PR_MERGE_STRATEGY_BRANCH` has been validated. Both the **Merge Commit** and **Source Branch** strategies now function as expected. (CI-13625, ZD-67476)
--->
 - Improved error message for anonymous base image connector option in the 'Build and Push' steps. (CI-13562)
 
 - Fixed an issue where pipelines were getting queued when running concurrently. The fix ensures that the flush API log lines are sanitized to be less than 4MB, avoiding grpc `ResourceExhausted` failures. (CI-12879, ZD-64595)


### PR DESCRIPTION
This PR
- Adds a note to 1.41 release notes that was previously commented out pending discussion
- Adds the same note to CI docs on using `PR_MERGE_STRATEGY_BRANCH` variable and `CI_PR_MERGE_STRATEGY_BRANCH` flag when using GitHub API in git clone step or configure codebase step.