### PR TITLE
[CDS-97797] Added workload related warnings

### DIFF
--- a/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-blue-green-deployment.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-blue-green-deployment.md
@@ -24,6 +24,10 @@ Harness Canary and Blue Green strategies only support Kubernetes Deployment work
 
 See [What Can I Deploy in Kubernetes?](/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/cd-k8s-ref/what-can-i-deploy-in-kubernetes).
 
+:::warning
+In Blue Green deployment, only one deployment workload is supported. Having multiple workloads in service manifests will result in deployment failure.
+:::
+
 ## Harness Blue Green deployments
 
 Here's a quick summary of how Harness performs Blue Green deployments.

--- a/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-canary-deployment.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/kubernetes-executions/create-a-kubernetes-canary-deployment.md
@@ -28,6 +28,10 @@ The [Apply Step](/docs/continuous-delivery/deploy-srv-diff-platforms/kubernetes/
 
 In Harness, a workload is a Deployment, StatefulSet, or DaemonSet object deployed and managed to steady state.
 
+:::warning
+In Canary deployment, only one deployment workload is supported. Having multiple workloads in service manifests will result in deployment failure.
+:::
+
 ## Multiple managed workloads
 
 With the Rolling Deployment step, you can deploy multiple managed workloads.

--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -260,7 +260,7 @@ Refer to following doc for more details on new [repo listing](/docs/platform/git
 
 - Improved the error message that gets displayed when an incompatible Docker version causes the pipeline to fail. (CI-12612, ZD-63466)
 
-- Implemented a fix to ensure that all account-level secret references use the correct format (<+secrets.getValue("account.MY_SECRET_ID")>) in all build infrastructures. With this fix, pipelines will fail if account-level secrets are not referenced correctly. (CI-12595, ZD-63260)
+- Implemented a fix to ensure that all account-level secret references use the correct format `(<+secrets.getValue("account.MY_SECRET_ID")>)` in all build infrastructures. With this fix, pipelines will fail if account-level secrets are not referenced correctly. (CI-12595, ZD-63260)
 
 - Fixed an issue where the Docker LABEL set in a Build and Push step does not override the LABEL configured in the Dockerfile. With this fix, you can now use buildx rather than kaniko to build your container images. You must run buildx on k8s with Privileged mode enabled. This fix is behind the feature flag CI_USE_BUILDX_ON_K8. Contact Harness Support to enable this fix. (CI-12548, ZD-63222)
 


### PR DESCRIPTION
[CDS-97797] Added workload related warnings to Canary and Blue Green deployment methods

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[CDS-97797]: https://harness.atlassian.net/browse/CDS-97797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ