### PR TITLE
CI-13234 status checks points to another build with same commit

### DIFF
--- a/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
@@ -173,6 +173,9 @@ Go to the [Harness CI Knowledge Base](/kb/continuous-integration/continuous-inte
 * [Failed pipelines don't block PR merges.](/kb/continuous-integration/continuous-integration-faqs/#failed-pipelines-dont-block-pr-merges)
 * [Pipeline status updates aren't sent to PRs.](/kb/continuous-integration/continuous-integration-faqs/#pipeline-status-updates-arent-sent-to-prs)
 * [Build statuses don't show on my PRs, even though the code base connector's token has all repo permissions.](/kb/continuous-integration/continuous-integration-faqs/#build-statuses-dont-show-on-my-prs-even-though-the-code-base-connectors-token-has-all-repo-permissions)
-* [Why does the status check for my GitHub PR redirect to a different PR's build in Harness CI?](/kb/continuous-integration/continuous-integration-faqs/#why-does-the-status-check-for-my-gitHub-pr-redirect-to-a-different-prs-build-in-Harness-ci)
+* [Why does the status check for my GitHub PR redirect to a different PR's build in Harness CI?](/kb/continuous-integration/continuous-integration-faqs/#why-does-the-status-check-for-my-pr-redirect-to-a-different-prs-build-harness) 
+
+
+
 
 For troubleshooting information for Git event (webhook) triggers, go to [Troubleshoot Git event triggers](/docs/platform/triggers/triggering-pipelines/#troubleshoot-git-event-triggers).

--- a/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
+++ b/docs/continuous-integration/use-ci/codebase-configuration/scm-status-checks.md
@@ -173,5 +173,6 @@ Go to the [Harness CI Knowledge Base](/kb/continuous-integration/continuous-inte
 * [Failed pipelines don't block PR merges.](/kb/continuous-integration/continuous-integration-faqs/#failed-pipelines-dont-block-pr-merges)
 * [Pipeline status updates aren't sent to PRs.](/kb/continuous-integration/continuous-integration-faqs/#pipeline-status-updates-arent-sent-to-prs)
 * [Build statuses don't show on my PRs, even though the code base connector's token has all repo permissions.](/kb/continuous-integration/continuous-integration-faqs/#build-statuses-dont-show-on-my-prs-even-though-the-code-base-connectors-token-has-all-repo-permissions)
+* [Why does the status check for my GitHub PR redirect to a different PR's build in Harness CI?](/kb/continuous-integration/continuous-integration-faqs/#why-does-the-status-check-for-my-gitHub-pr-redirect-to-a-different-prs-build-in-Harness-ci)
 
 For troubleshooting information for Git event (webhook) triggers, go to [Troubleshoot Git event triggers](/docs/platform/triggers/triggering-pipelines/#troubleshoot-git-event-triggers).

--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -1152,8 +1152,8 @@ If the user account used to generate the token doesn't have repository write per
 For repos under organizations or projects, check the role/permissions assigned to the user in the target repository. For example, a user in a GitHub organization can have some permissions at the organization level, but they might not have those permissions at the individual repository level.
 
 
-### Why does the status check for my GitHub PR redirect to a different PR's build in Harness CI?
-This issue occurs when two PRs share the same commit ID. Harness CI associates builds with commits rather than specific PRs. If multiple PRs share the same commit, the latest build will replace the previous one, causing the build check on the earlier PR to redirect to the newer PR’s build.
+### Why does the status check for my PR redirect to a different PR's build Harness? 
+This issue occurs when two PRs are created for the same commit ID. Harness CI associates builds with commits rather than specific PRs. If multiple PRs share the same commit, the latest build will replace the previous one, causing the build check on the earlier PR to redirect to the newer PR’s build.
 To resolve this, push a new commit to the affected PR and rebuild it. This creates a unique commit, ensuring the build check redirects to the correct PR.
 
 ### Can I export a failed step's output to a pull request comment?

--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -1151,6 +1151,11 @@ If the user account used to generate the token doesn't have repository write per
 
 For repos under organizations or projects, check the role/permissions assigned to the user in the target repository. For example, a user in a GitHub organization can have some permissions at the organization level, but they might not have those permissions at the individual repository level.
 
+
+### Why does the build check for my GitHub PR redirect to a different PR's build in Harness CI?
+This issue occurs when two PRs share the same commit ID. Harness CI associates builds with commits rather than specific PRs. If multiple PRs share the same commit, the latest build will replace the previous one, causing the build check on the earlier PR to redirect to the newer PR’s build.
+To resolve this, push a new commit to the affected PR and rebuild it. This creates a unique commit, ensuring the build check redirects to the correct PR.
+
 ### Can I export a failed step's output to a pull request comment?
 
 To do this, you could:

--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -1152,7 +1152,7 @@ If the user account used to generate the token doesn't have repository write per
 For repos under organizations or projects, check the role/permissions assigned to the user in the target repository. For example, a user in a GitHub organization can have some permissions at the organization level, but they might not have those permissions at the individual repository level.
 
 
-### Why does the build check for my GitHub PR redirect to a different PR's build in Harness CI?
+### Why does the status check for my GitHub PR redirect to a different PR's build in Harness CI?
 This issue occurs when two PRs share the same commit ID. Harness CI associates builds with commits rather than specific PRs. If multiple PRs share the same commit, the latest build will replace the previous one, causing the build check on the earlier PR to redirect to the newer PR’s build.
 To resolve this, push a new commit to the affected PR and rebuild it. This creates a unique commit, ensuring the build check redirects to the correct PR.
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes:  addition to FAQ related to build status checks redirect url 
* Jira/GitHub Issue numbers (if any): \CI-13234
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
