### PR TITLE
docs: [IAC-2255]: Add dynamic IaCM supported framework versions

### DIFF
--- a/docs/infra-as-code-management/whats-supported.md
+++ b/docs/infra-as-code-management/whats-supported.md
@@ -5,6 +5,8 @@ sidebar_label: What's supported
 sidebar_position: 1
 ---
 
+import HarnessApiData from '../../src/components/HarnessApiData/index.tsx';
+
 This page describes supported platforms and technologies for Harness IaCM specifically.
 
 For information about what's supported for other Harness modules and the Harness Platform overall, go to [Supported platforms and technologies](https://developer.harness.io/docs/platform/platform-whats-supported/).
@@ -32,8 +34,18 @@ Harness IaCM supports the following source providers for seamless code managemen
 Git options include `Latest from Branch` (specifying a branch) and `Git Tag` fetch types. Users can set a configuration file path, such as a terraform (.tf) file.
 
 ## Supported IaC Frameworks
-Harness IaCM currently supports integration with **Terraform** and **OpenTofu** frameworks.
-
+Harness IaCM currently supports integration with **OpenTofu** <HarnessApiData
+    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/opentofu"
+    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
+    fallback=""
+    parse='.[-1] | "(up to v\(.))"'>
+</HarnessApiData> and **Terraform** <HarnessApiData
+    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/terraform"
+    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
+    fallback=""
+    parse='.[-1] | "(up to v\(.))"'>
+</HarnessApiData> frameworks.
+ 
 ## IaCM Feature Flags
 Some Harness IaCM features are released behind feature flags to get feedback from specific customers before releasing the features to the general audience.
 The following table describes each of the feature flags relevant to Harness IaCM.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,7 @@ async function config() {
     favicon: "img/hdh_fav_icon_grey.ico",
     customFields: {
       SEGMENT_API_KEY: process.env.SEGMENT_API_KEY,
+      HARNESS_GENERIC_READ_ONLY_KEY: process.env.HARNESS_GENERIC_READ_ONLY_KEY,
     },
 
     //Mermaid Diagram Functionality

--- a/src/components/HarnessApiData/index.tsx
+++ b/src/components/HarnessApiData/index.tsx
@@ -52,8 +52,8 @@ const HarnessApiData: React.FC<IHarnessApiData> = ({
               }
 
               const data = await fetchResponse.json();
-             
-              setResponse(JSON.stringify(data));
+              // Assuming data contains the version info, and we want to ensure it's not wrapped in quotes
+              setResponse(typeof data === 'string' ? data : JSON.stringify(data));
             } catch (error) {
               console.log(error);
               setResponse(fallback);


### PR DESCRIPTION
## Description

* Add dynamic content with HarnessAPIData component to render the latest supported framework versions of OpenTofu and Terraform.
* [JIRA](https://harness.atlassian.net/browse/IAC-2255)

### Screenshot / Preview
![IaCMSupported](https://github.com/user-attachments/assets/c1b535bc-83dd-4c53-89de-b0ff4a84d6ba)

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.