### PR TITLE
Resolve Docusaurus Trailing Slashes for CI docs.

### DIFF
--- a/docs/continuous-integration/get-started/harness-ci-intelligence.md
+++ b/docs/continuous-integration/get-started/harness-ci-intelligence.md
@@ -8,7 +8,7 @@ Harness Continuous Integration (CI) Intelligence features are designed to smartl
 
 ## Build Intelligence
 
-[Build Intelligence](../use-ci/build-and-upload-artifacts/build-intelligence.md) is part of the suite of intelligent features in Harness CI designed to improve build times. It saves time by reusing outputs from previous builds. Build Intelligence works by storing these outputs locally or remotely and retrieving them when inputs haven't changed. This process avoids the need to regenerate outputs, significantly speeding up the build process and enhancing efficiency. 
+[Build Intelligence](/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md) is part of the suite of intelligent features in Harness CI designed to improve build times. It saves time by reusing outputs from previous builds. Build Intelligence works by storing these outputs locally or remotely and retrieving them when inputs haven't changed. This process avoids the need to regenerate outputs, significantly speeding up the build process and enhancing efficiency. 
 
 Build Intelligence in Harness CI is currently available for **Gradle** and **Bazel** with **Maven** support coming soon.
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Build Intelligence is part of [Harness CI Intelligence](../../get-started/harness-ci-intelligence), a suite of features in Harness CI designed to improve build times. It saves time by reusing outputs from previous builds. BI works by storing these outputs locally or remotely and retrieving them when inputs haven't changed. This process avoids the need to regenerate outputs, significantly speeding up the build process and enhancing efficiency.
+Build Intelligence is part of [Harness CI Intelligence](/docs/continuous-integration/get-started/harness-ci-intelligence), a suite of features in Harness CI designed to improve build times. It saves time by reusing outputs from previous builds. BI works by storing these outputs locally or remotely and retrieving them when inputs haven't changed. This process avoids the need to regenerate outputs, significantly speeding up the build process and enhancing efficiency.
 
 :::note
 Build Intelligence is currently only offered to Harness Cloud, with support for self hosted coming soon. This feature is behind the feature flag `CI_CACHE_ENABLED`. Contact [Harness Support](mailto:support@harness.io) to enable the feature.


### PR DESCRIPTION
This PR resolves the broken link on CI docs caused by trailing slashes.

Both links have been updated with full path. 