### PR TITLE
Adding the 1.44 Release Notes

### DIFF
--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -33,11 +33,9 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 #### Fixed issues
 
-- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` must be enabled whenever a base image connector is used. (CI-13924, ZD-68737)
+- For SMP customers, the 'getting started' flow for CI has been removed from the side navigation. (CI-13821)
 
-- For SMP customers, the 'getting started' purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
-
-- Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after the first : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
+- Fixed an issue with 'Build and Push' step where a faiure occured when the registry URL in the Doceker connector had a port configured. This issue occurred because everything after the first ':' was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
 
 
 ### Version 1.43

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -29,7 +29,7 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 #### New features and enhancements
 
-- Added new setting in the account default settings under CI named ‘Upload Logs Via Harness’, allowing customers to route CI step execution logs through Harness’ log service instead uploading them directly from the build environment. This was previously behind a feature flag, but is now available for all users. (CI-13647)
+- Added a new setting in the account default settings under CI named ‘Upload Logs Via Harness’, allowing customers to route CI step execution logs through Harness’ log service instead uploading them directly from the build environment. This was previously behind a feature flag, but is now available for all users. (CI-13647)
 
 #### Fixed issues
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -33,7 +33,7 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 #### Fixed issues
 
-- Due to Docker rate limiting, CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR must be enabled whenever a base image connector is used (CI-13924, ZD-68737)
+- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` must be enabled whenever a base image connector is used (CI-13924, ZD-68737)
 
 - For SMP customers the getting started purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -23,6 +23,23 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 ## August 2024
 
+### Version 1.44
+
+<!-- 2024-08-26 -->
+
+#### New features and enhancements
+
+- Added new setting in the account default settings under CI named ‘Upload Logs Via Harness’, allowing customers to route CI step execution logs through Harness’ log service instead uploading them directly from the build environment. This was previously behind a feature flag, but is now available for all users. (CI-13647)
+
+#### Fixed issues
+
+- Due to Docker rate limiting, CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR must be enabled whenever a base image connector is used (CI-13924, ZD-68737)
+
+- For SMP customers the getting started purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
+
+- Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
+
+
 ### Version 1.43
 
 <!-- 2024-08-19 -->

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -35,7 +35,7 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 - Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` must be enabled whenever a base image connector is used (CI-13924, ZD-68737)
 
-- For SMP customers the getting started purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
+- For SMP customers, the 'getting started' purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
 
 - Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -33,11 +33,11 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 #### Fixed issues
 
-- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` must be enabled whenever a base image connector is used (CI-13924, ZD-68737)
+- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` must be enabled whenever a base image connector is used. (CI-13924, ZD-68737)
 
 - For SMP customers, the 'getting started' purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)
 
-- Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
+- Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after the first : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)
 
 
 ### Version 1.43


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

### Version 1.44

<!-- 2024-08-26 -->

#### New features and enhancements

- Added new setting in the account default settings under CI named ‘Upload Logs Via Harness’, allowing customers to route CI step execution logs through Harness’ log service instead uploading them directly from the build environment. This was previously behind a feature flag, but is now available for all users. (CI-13647)

#### Fixed issues

- Due to Docker rate limiting, CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR must be enabled whenever a base image connector is used (CI-13924, ZD-68737)

- For SMP customers the getting started purchase flow for CI has been removed from the side navigation as it is not relevant for SMP customers. (CI-13821)

- Fixed an issue where the plugin image url was incorrect when the registry url had a port configured. This issue occurred because everything after : was being considered as the tag of the image, leading to an invalid Fully Qualified Name (FQN) and causing the Initialize step to fail in the Kubernetes flow. The fix ensures that the FQN is properly considered when the registry endpoint includes a port number. (CI-13770, ZD-66772)

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
