### PR TITLE
Add redirect for broken CI FAQ page.

### DIFF
--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -4,6 +4,7 @@ description: Common questions and troubleshooting issues related to Harness CI.
 sidebar_position: 2
 redirect_from:
   - /docs/faqs/continuous-integration-ci-faqs
+  - /docs/frequently-asked-questions/harness-faqs/continuous-integration-ci-faqs
 ---
 
 ## Build infrastructure


### PR DESCRIPTION
This PR adds redirect for the broken https://developer.harness.io/docs/frequently-asked-questions/harness-faqs/continuous-integration-ci-faqs/ page. The correct page for CI FAQ is: https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs/

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
