### PR TITLE
docs: [IAC-2490]: Update what's supported details

### DIFF
--- a/docs/infra-as-code-management/whats-supported.md
+++ b/docs/infra-as-code-management/whats-supported.md
@@ -16,6 +16,21 @@ To configure an IaCM workspace and create pipelines, you must have the following
 - An active cloud provider account
 - A Git repository
 
+## Supported IaC Frameworks
+:::info opentofu / terraform
+Harness IaCM currently supports integration with **OpenTofu** <HarnessApiData
+    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/opentofu"
+    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
+    fallback=""
+    parse='.[-1] | "(up to v\(.))"'>
+</HarnessApiData> and **Terraform** <HarnessApiData
+    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/terraform"
+    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
+    fallback=""
+    parse='.[-1] | "(up to v\(.))"'>
+</HarnessApiData> frameworks.
+:::
+
 ## Supported Workspace Connectors
 ### Cloud Providers
 - **AWS**: Connect via your AWS account to leverage extensive IaCM features.
@@ -32,19 +47,6 @@ Harness IaCM supports the following source providers for seamless code managemen
 - **Azure Repos**: Supports Azure Repos for direct access to Microsoft’s DevOps tools.
 
 Git options include `Latest from Branch` (specifying a branch) and `Git Tag` fetch types. Users can set a configuration file path, such as a terraform (.tf) file.
-
-## Supported IaC Frameworks
-Harness IaCM currently supports integration with **OpenTofu** <HarnessApiData
-    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/opentofu"
-    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
-    fallback=""
-    parse='.[-1] | "(up to v\(.))"'>
-</HarnessApiData> and **Terraform** <HarnessApiData
-    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/terraform"
-    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
-    fallback=""
-    parse='.[-1] | "(up to v\(.))"'>
-</HarnessApiData> frameworks.
  
 ## IaCM Feature Flags
 Some Harness IaCM features are released behind feature flags to get feedback from specific customers before releasing the features to the general audience.

--- a/docs/infra-as-code-management/whats-supported.md
+++ b/docs/infra-as-code-management/whats-supported.md
@@ -18,17 +18,13 @@ To configure an IaCM workspace and create pipelines, you must have the following
 
 ## Supported IaC Frameworks
 :::info opentofu / terraform
-Harness IaCM currently supports integration with **OpenTofu** <HarnessApiData
+Harness IaCM currently supports integration with all **OpenTofu** versions<HarnessApiData
     query="https://app.harness.io/gateway/iacm/api/provisioners/supported/opentofu"
     token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
     fallback=""
-    parse='.[-1] | "(up to v\(.))"'>
-</HarnessApiData> and **Terraform** <HarnessApiData
-    query="https://app.harness.io/gateway/iacm/api/provisioners/supported/terraform"
-    token="process.env.HARNESS_GENERIC_READ_ONLY_KEY"
-    fallback=""
-    parse='.[-1] | "(up to v\(.))"'>
-</HarnessApiData> frameworks.
+    parse='.[-1] | " (latest: v\(.))"'></HarnessApiData>.
+    
+ For **Terraform**, we support all MPL versions up to **1.5.x**, any BSL versions (from 1.6.0) are not supported.
 :::
 
 ## Supported Workspace Connectors

--- a/src/components/Docs/data/iacmData.ts
+++ b/src/components/Docs/data/iacmData.ts
@@ -10,6 +10,12 @@ export const docsCards: CardSections = [
     description: "",
     list: [
       {
+        title: "What's supported",
+        module: MODULES.iacm,
+        description: "Find details on supported Infrastructure as Code tools, providers and frameworks like OpenTofu and Terraform.",
+        link: "/docs/infra-as-code-management/whats-supported",
+      },
+      {
         title: "Onboarding",
         module: MODULES.iacm,
         description: "Get onboarded with Harness Infrastructure as Code Management.",


### PR DESCRIPTION
## Description

* Update Whats supported doc to move supported framework details (re OpenTofu and Terraform) to the top and also added a new navigation tile to the IaCM landing page.
* [JIRA](https://harness.atlassian.net/browse/IAC-2490)

### Screenshot / Preview
![CleanShot 2024-09-19 at 10 45 15](https://github.com/user-attachments/assets/86417a21-8fb3-4a14-96fe-c143682917a3)
![CleanShot 2024-09-12 at 14 39 37](https://github.com/user-attachments/assets/34ddc5da-a09f-4205-b211-de236dc0dfb4)

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.