### PR TITLE
Add docs for 'Topology Spread Constraint' support in K8S build pods.

### DIFF
--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -605,7 +605,7 @@ This could happen when the PR/push trigger is configured with the 'Auto-abort Pr
 
 ### Can we add the config "topologySpreadConstraints" in the build pod which will help CI pod to spread across different AZs?
 
-Currently, we do not support adding "topologySpreadConstraints" to the build pod
+Harness CI now includes a new property, `podSpecOverlay`, in the Kubernetes infrastructure properties of the CI stage. This allows users to apply additional settings to the build pod. Currently, we support specifying `topologySpreadConstraint` in this field.
 
 ### Why the docker commands in the run step is failing with the error "Cannot connect to the Docker daemon at unix:///var/run/docker.sock?" even after the dind background step logs shows that the docker daemon has been initialized?
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: This PR adds docs for 'Topology Spread Constraint' support in K8S build pods.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/CI-14248
* Preview links/images (Internal contributors only): _to be added_

@nofarblue this PR adds to FAQ. How can I update this new field in the product documentation? i.e. a page like [this](https://developer.harness.io/docs/platform/connectors/cloud-providers/ref-cloud-providers/kubernetes-cluster-connector-settings-reference/)? 

## PR lifecycle

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
