### PR TITLE
correct <+greeting> reference in idp branding docs

### DIFF
--- a/docs/internal-developer-portal/layout-and-appearance/home-page-customization.md
+++ b/docs/internal-developer-portal/layout-and-appearance/home-page-customization.md
@@ -23,7 +23,7 @@ The **Platform Admins** can customize the homepage under Layouts for 3 different
 - You can leave the header text static such as - `Welcome to Harness IDP!`
     - You can make it personalized such as - Welcome `<+first_name>!`
     - If your users have names of the format "last name, first name", then you can use Welcome `<+last_name>`, `<+first_name>`! Or you can name the portal a unique product name such as - `Welcome to MyPortal!` (maybe, a bit more creative than MyPortal).
-    - There is a special variable called `<+greetings>` which resolves to Good Morning, Good Evening, etc. depending upon the timezone of the user. e.g. `<+greetings> <+first_name>`
+    - There is a special variable called `<+greeting>` which resolves to Good Morning, Good Evening, etc. depending upon the timezone of the user. e.g. `<+greeting> <+first_name>`
 
 - For Quick links you can upload a Custom Icon **(Recommended Size: 128x128px and file size: 200KB)** along with a name and a link. You can also drag and re-arrange the order of the links. It's ideal to add a few links to some central documents that you want your users to go to when they come to your Developer Portal. e.g. Onboarding Docs, Link to Slack, etc.
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

We were referencing `<+greetings>` in the branding docs, when the correct usage is `<+greeting>`

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
