### PR TITLE
Add note on required delegate version.

### DIFF
--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-acr.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-acr.md
@@ -118,7 +118,7 @@ When using base image connector, pushing to or pulling from multiple Docker regi
 This limitation does not apply to following build and push steps only on K8 - ACR, GAR, ECR.
 :::
 
-This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`. 
+This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`. When enabling this flag, the delegate version must be higher than `24.07.83503`.
 
 ### Optimize
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
@@ -121,7 +121,7 @@ When using base image connector, pushing to or pulling from multiple Docker regi
 This limitation does not apply to following build and push steps only on K8 - ACR, GAR, ECR.
 :::
 
-This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`.
+This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`. When enabling this flag, the delegate version must be higher than `24.07.83503`.
 
 ### Optimize
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ecr-step-settings.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-ecr-step-settings.md
@@ -151,7 +151,7 @@ When using base image connector, pushing to or pulling from multiple Docker regi
 This limitation does not apply to following build and push steps only on K8 - ACR, GAR, ECR.
 :::
 
-This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`.
+This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`. When enabling this flag, the delegate version must be higher than `24.07.83503`.
 
 ### Optimize
 

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gar.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-gar.md
@@ -121,7 +121,7 @@ When using base image connector, pushing to or pulling from multiple Docker regi
 This limitation does not apply to following build and push steps only on K8 - ACR, GAR, ECR.
 :::
 
-This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`.
+This setting is enabled by the feature flag `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR`. When enabling this flag, the delegate version must be higher than `24.07.83503`.
 
 ### Optimize
 

--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -48,7 +48,7 @@ These release notes describe recent changes to Harness Continuous Integration.
 
 - Fixed an issue where time savings due to Harness CI intelligence feature, didn't populate properly when used in the parallel CI stages. (CI-13993)
 
-- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` feature flag must be enabled whenever a base image connector is used (CI-13924)
+- Due to Docker rate limiting, `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` feature flag must be enabled whenever a base image connector is used (CI-13924). When enabling this flag, the delegate version must be higher than `24.07.83503`.
 
 - Bitbucket has an issue in their API; it does not support the slash character ( / ) [https://jira.atlassian.com/browse/BCLOUD-20223](https://jira.atlassian.com/browse/BCLOUD-20223)
 This can be worked around by using query parameters in the Bitbucket api `https://api.bitbucket.org/2.0/repositories/smjth/originalrepo/?at=qq/ww` (CI-13826)


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: When enabling `CI_ENABLE_BASE_IMAGE_DOCKER_CONNECTOR` flag, the delegate version must be higher than `24.07.83503`. This PR adds this required note to relevant pages.
* Jira/GitHub Issue numbers (if any): CI-14381
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
