### PR TITLE
Update fmeData.ts move "Monitoring tab: feature traffic insights" to released column

### DIFF
--- a/src/components/Roadmap/data/fmeData.ts
+++ b/src/components/Roadmap/data/fmeData.ts
@@ -15,11 +15,6 @@ export const FmeData: Horizon = {
         description: "New segment type enabling large-scale audience targeting up to 1M keys.",
       },
       {
-        tag: [{ value: "Measurement" }],
-        title: "Monitoring tab: feature traffic insights",
-        description: "Analyze flag traffic in real time to understand trends and ensure proper targeting configuration.",
-      },
-      {
         tag: [{ value: "Better Together" }],
         title: "Access Split from within Harness app",
         description: "Allow Harness customers to authenticate and access Split from the Harness application.",
@@ -77,6 +72,11 @@ export const FmeData: Horizon = {
   Released: {
     description: "What has been released",
     feature: [
+      {
+        tag: [{ value: "Measurement" }],
+        title: "Monitoring tab: feature traffic insights",
+        description: "Analyze flag traffic in real time to understand trends and ensure proper targeting configuration.",
+      },
       {
         tag: [{ value: "Alerting" }],
         title: "Significance alerting for guardrail metrics",


### PR DESCRIPTION
We have released Traffic Insights and renamed the Alerts tab to Monitoring tab.  This hit 100% before last week, but I didn't want to push the change amidst issues others were having with source control and the rush to get many new modules live for Unscripted Virtual.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \___Moving Traffic Insights to Released column_________
* Jira/GitHub Issue numbers (if any): \________n/a______________________
* Preview links/images (Internal contributors only): \_____n/a_____________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
