### PR TITLE
add brandon-harness as CODEOWNER to CCM KB

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,7 +182,7 @@ README.md @pratmit
 /kb/feature-flags/ @HarnessTheChaos @jenniferopal
 
 #CCM KB
-/kb/cloud-cost-management/ @rdsoze @navaneeth @Rohit-Kaliki @joeyouss @rssnyder
+/kb/cloud-cost-management/ @rdsoze @navaneeth @Rohit-Kaliki @joeyouss @rssnyder @brandon-harness
 
 #SRM KB
 /kb/service-reliability-management/ @sunilgupta-harness


### PR DESCRIPTION
Brandon is a new Principal Solutions Engineer for the CCM module and works to add and review documents to the CCM KB section. Adding him as codeowner so he has the ability to review documentation.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
