### PR TITLE
(Update) Add Leave blank to Relay State

### DIFF
--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -132,7 +132,7 @@ Sometimes users might have mixed case email addresses in Okta. In these situatio
 	3. Keep this page open. You will come back to it later in this process.
 
 5. In **Audience URI (SP Entity ID)**, enter `app.harness.io`. The SAML application identifier is always `app.harness.io`.
-6. In **Default RelayState**, enter a valid URL. This is the page where users land after a successful sign-in using SAML into the SP.
+6. In **Default RelayState**, leave **blank**.  Harness uses this to exchange addtiional info between IdP SAML provider (OKTA) and Service Provider (Harness), by sending Custom RelayState information.
 7. In **Name ID format**, enter the username format you are sending in the SAML Response. The default format is **Unspecified**.
 8. In **Application username**, enter the default username.
 9.  In **Attribute Statements (optional)**, enter name in the **Name** field, select **Name Format** as **Basic**, and select the **Value** as **user.email**.


### PR DESCRIPTION



Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \____________
As per discussion between @usheerfotedar and eng, It should be this
Default Relay State            triggerType=login

What is relaystate -
Just a way to exchange additonal info between IdP SAML provider(OKTA) and Service Provider (Harness) This info can have custom usage.
For example, we use it to determine whether the call is coming for actual login or just to test login. More details here: https://support.okta.com/help/s/article/How-to-send-a-custom-relaystate-to-application-through-idp-initiated-authentication-urls?language=en_US

* Jira/GitHub Issue numbers (if any): \________. https://harnesssupport.zendesk.com/agent/tickets/71057
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
