### PR TITLE
feat:[PIPE-22546]: Documented the behavior where pipelines do not execute if the user lacks access to secrets referenced in ShellScript environment variables

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
@@ -132,6 +132,8 @@ This behavior applies to pipelines configured via direct YAML updates as well. I
 
 
 **When the feature flag is enabled**: The pipeline will be blocked from execution entirely if the user does not have access to the secret.
+
+
 **When the feature flag is disabled**: The pipeline will still start execution, but it will fail during the step that references the secret if the user lacks access.
 
 ### Different levels

--- a/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
@@ -129,6 +129,11 @@ Currently this behaviour is behind FF `PIE_SEND_SECRET_REF_FOR_SHELLSCRIPT_VARIA
 When a secret is referenced in ShellScript environment variables, the pipeline will not execute if the user does not have access to the referenced secret. This ensures that only users with the appropriate permissions can trigger pipelines that require access to specific secrets.
 
 This behavior applies to pipelines configured via direct YAML updates as well. In the UI, secret selection is filtered based on [RBAC](/docs/platform/role-based-access-control/rbac-in-harness.md), so users will only see the secrets they have access to.
+
+
+**When the feature flag is enabled**: The pipeline will be blocked from execution entirely if the user does not have access to the secret.
+**When the feature flag is disabled**: The pipeline will still start execution, but it will fail during the step that references the secret if the user lacks access.
+
 ### Different levels
 
 If there is a clash between selected errors in strategies on different levels, the step-level strategy is used and the stage-level strategy is ignored.

--- a/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
+++ b/docs/continuous-delivery/x-platform-cd-features/executions/step-failure-strategy-settings.md
@@ -120,6 +120,15 @@ Here is what will happen:
 * On an authentication failure, the stage is aborted.
 * On a connectivity error, the error is ignored.
 
+## Failure Strategy Behavior for Secrets in ShellScript Environment Variables
+
+:::info note
+Currently this behaviour is behind FF `PIE_SEND_SECRET_REF_FOR_SHELLSCRIPT_VARIABLES`. Please contact [Harness Support](mailto:support@harness.io) to enable this Feature Flag.
+:::
+
+When a secret is referenced in ShellScript environment variables, the pipeline will not execute if the user does not have access to the referenced secret. This ensures that only users with the appropriate permissions can trigger pipelines that require access to specific secrets.
+
+This behavior applies to pipelines configured via direct YAML updates as well. In the UI, secret selection is filtered based on [RBAC](/docs/platform/role-based-access-control/rbac-in-harness.md), so users will only see the secrets they have access to.
 ### Different levels
 
 If there is a clash between selected errors in strategies on different levels, the step-level strategy is used and the stage-level strategy is ignored.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: **Documented the behavior where pipelines do not execute if the user lacks access to secrets referenced in ShellScript environment variables**
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only):
<img width="928" alt="Screenshot 2024-10-15 at 3 00 01 PM" src="https://github.com/user-attachments/assets/7f7ff4aa-97d1-4876-8735-66cf71eb7634">


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
