### PR TITLE
[CDS-101882]: Document Update Release Repo/ Revert PR step concurrent execution lim…

### DIFF
--- a/docs/continuous-delivery/gitops/pr-pipelines/gitops-pipeline-steps.md
+++ b/docs/continuous-delivery/gitops/pr-pipelines/gitops-pipeline-steps.md
@@ -35,6 +35,13 @@ You don't have to edit anything in the **Update Release Repo**, **Merge PR** and
 
 ### Update Release Repo step
 
+:::note Limitation
+
+Only one Update Release Repo or Revert PR step can run per GitHub token reference at a time.
+This adheres to [GitHub's best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#avoid-concurrent-requests) to prevent [secondary rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) during pull request creation.
+
+:::
+
 This step fetches JSON or YAML files, updates them with your changes, performs a commit and push, and then creates the PR.
 
 You can also enter variables in this step to update key-value pairs in the config file you are deploying.
@@ -104,6 +111,13 @@ Found linked app: syncstep-automation-app-cluster11. Link - https://app.harness.
 ```
 
 ### Revert PR step
+
+:::note Limitation
+
+Only one Update Release Repo or Revert PR step can run per GitHub token reference at a time.
+This adheres to [GitHub's best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#avoid-concurrent-requests) to prevent [secondary rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) during pull request creation.
+
+:::
 
 This step reverts the commit passed and creates a new PR. Use this step if you want to run any tests or automation on the pipeline and then revert the commit done by the **Update Release Repo** step.
 


### PR DESCRIPTION
…itation

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

Document Update Release Repo/ Revert PR step concurrent execution limitation.
Context - Only a single UpdateReleaseRepo/Revert PR step can be executed at a time per github token reference. If there is another step, it will wait for the completion of the execution of the first step. 


<img width="1045" alt="image" src="https://github.com/user-attachments/assets/ab140264-cd61-407d-89f8-2e5b2da50e27">


* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
