### PR TITLE
CHAOS-7089 Command to enable workload identity in node pool

### DIFF
--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/gcp/gcp-iam-integration.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/gcp/gcp-iam-integration.md
@@ -53,11 +53,29 @@ Workload Identity can be enabled for an existing cluster as well as a new cluste
 
 * To enable Workload Identity on a new cluster, run the following command:
 
-```
-gcloud container clusters create CLUSTER_NAME \
---region=COMPUTE_REGION \
---workload-pool=PROJECT_ID.svc.id.goog
-```
+    ```
+    gcloud container clusters create CLUSTER_NAME \
+    --region=COMPUTE_REGION \
+    --workload-pool=PROJECT_ID.svc.id.goog
+    ```
+
+* To enable Workload Identity on a node pool when you have the node pool name:
+
+    ```
+    gcloud container node-pools update CLUSTER_NAME_NODE_POOL_NAME --cluster=CLUSTER_NAME --zone us-west1-a --workload-metadata-from-node=GKE_METADATA
+    ```
+    
+        - To list the node pools that would help identify the node pool name in the cluster,
+        
+            ```
+            gcloud container node-pools list --cluster=CLUSTER_NAME --zone us-west1-a --project <PROJECT_ID>
+            ```
+    
+        - To verify that Workload Identity is enabled on a node pool, 
+
+            ```
+            gcloud container node-pools describe CLUSTER_NAME_NODE_POOL_NAME --cluster=CLUSTER_NAME --zone us-west1-a
+            ```
 
 Replace the following:
 * **CLUSTER_NAME:** The name of your new cluster.


### PR DESCRIPTION
Command to enable workload identity in node pool

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
