### PR TITLE
fix:[CDS-104066]: K8s Canary step was failing after enabling CDS_K8S_…

### DIFF
--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -93,7 +93,7 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 
 #### Fixed issues
 
-- The customer encountered a pipeline failure when they enabled the CDS_K8S_CUSTOM_YAML_PARSER feature and used a YAML manifest with parameters supported by the 21.x.x version of the Kubernetes Java SDK. The issue arose due to a YAML parsing error. (CDS-104069)
+- The customer encountered a pipeline failure when they enabled the CDS_K8S_CUSTOM_YAML_PARSER feature and used a YAML manifest with parameters supported by the 21.x.x version of the Kubernetes Java SDK. The issue arose due to a YAML parsing error. (CDS-104066)
 
 ### Version 24.10.84205-ubi9-beta <!-- November 18, 2024 -->
 

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -89,6 +89,12 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 :::
 ## November 2024
 
+### Version 24.11.84307 <!-- November 19, 2024 -->
+
+#### Fixed issues
+
+- The customer encountered a pipeline failure when they enabled the CDS_K8S_CUSTOM_YAML_PARSER feature and used a YAML manifest with parameters supported by the 21.x.x version of the Kubernetes Java SDK. The issue arose due to a YAML parsing error. (CDS-104069)
+
 ### Version 24.10.84205-ubi9-beta <!-- November 18, 2024 -->
 
 #### Early release (Non-GA'ed release).


### PR DESCRIPTION


Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description
- During the Canary release, the setReplica step was invoked to return a k8sResource with correct parsing. However, it was not returning the expected k8sResource and instead fell back to the old flow, causing the parsing failure.
- 
* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
