### PR TITLE
[fix]: [PL-58621]: Update documents for looker secrets for ArgoCD users.

### DIFF
--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -202,7 +202,7 @@ To fix this issue, follow these steps
   echo "<base64-encoded-lookerMasterKey>" | base64 --decode | base64 --decode
   ```
 
-  3. Do the same for secrets in and obtain the secrets for the following as well lookerClientId lookerClientSecret lookerEmbedSecret lookerSignupUrl
+  3. Copy the decrypted secrets for the following attributes lookerClientId lookerClientSecret lookerEmbedSecret lookerSignupUrl in harness-looker-secrets.
 
   4. After decoding, update your ArgoCD values override with the decoded key:
 

--- a/release-notes/self-managed-enterprise-edition.md
+++ b/release-notes/self-managed-enterprise-edition.md
@@ -192,22 +192,29 @@ To fix this issue, follow these steps
 
   ```bash
   kubectl get secrets looker-secrets -o yaml -n <namespace>
+  kubectl get secrets harness-looker-secrets -o yaml -n <namespace>
   ```
 
-  2. Copy the value of lookerMasterKey from the secret and decode it using the following command or any base64 decoder. You’ll need to decode it twice.
+  2. Copy the value of lookerMasterKey from the secret looker-secrets and decode it using the following command or any base64 decoder. You’ll need to decode it twice.
   It's required to decode the secret value twice because during creation, first it's encoded by the helm function in the charts and then Kubernetes encodes it again while creating the secret.
 
   ```bash
   echo "<base64-encoded-lookerMasterKey>" | base64 --decode | base64 --decode
   ```
 
-  3. After decoding, update your ArgoCD values override with the decoded key:
+  3. Do the same for secrets in and obtain the secrets for the following as well lookerClientId lookerClientSecret lookerEmbedSecret lookerSignupUrl
+
+  4. After decoding, update your ArgoCD values override with the decoded key:
 
   ```yaml
   platform:
   looker:
     secrets:
       lookerMasterKey: "<your-decoded-key>"
+      lookerClientId: "<your-decoded-key>"
+      lookerClientSecret: "<your-decoded-key>"
+      lookerEmbedSecret: "<your-decoded-key>"
+      lookerSignupUrl: "<your-decoded-key>"
   ```
 
 By doing this, you ensure that the same lookerMasterKey is used during upgrades, avoiding encryption issues.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Documentation to prevent looker internal secrets being updated randomly on upgraded when customer uses ArgoCD since it cannot do server lookup
* Jira/GitHub Issue numbers (if any): PL-58621 [PL-58087](https://harness.atlassian.net/browse/PL-58087)
* Preview links/images (Internal contributors only): [Reference](https://github.com/wings-software/looker-docker/blob/main/chart/values.yaml#L321-L330)

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [ ] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.


[PL-58087]: https://harness.atlassian.net/browse/PL-58087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ