### PR TITLE
fix:[CDS-103383]: Providing the dry run manifest as secret in output 

### DIFF
--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -90,9 +90,7 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 ## November 2024
 
 ### Version 24.11.84308 <!-- November 20, 2024 -->
-- In order to use this feature the customer must need to enable the request param named 
-"encryptYamlOutput" currently the UI is not ready for the same so customer have to enter the given input via yaml directly in 
-step param of k8s dry run node (CDS-103383)
+- The existing behaviour does not support returning the full, unredacted manifest in an encrypted format as the dry run output. With this fix, the full manifest is encrypted and returned as output, with no redactions. (CDS-103383)
 
 #### Fixed issues
 

--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -89,6 +89,15 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 :::
 ## November 2024
 
+### Version 24.11.84308 <!-- November 20, 2024 -->
+- In order to use this feature the customer must need to enable the request param named 
+"encryptYamlOutput" currently the UI is not ready for the same so customer have to enter the given input via yaml directly in 
+step param of k8s dry run node (CDS-103383)
+
+#### Fixed issues
+
+- The customer encountered a pipeline failure when they enabled the CDS_K8S_CUSTOM_YAML_PARSER feature and used a YAML manifest with parameters supported by the 21.x.x version of the Kubernetes Java SDK. The issue arose due to a YAML parsing error. (CDS-104066)
+
 ### Version 24.10.84205-ubi9-beta <!-- November 18, 2024 -->
 
 #### Early release (Beta release).


### PR DESCRIPTION

* Providing the dry run manifest as secret in output 
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
