### PR TITLE
fix: [FFM-12188]: Support Webhook Format in FF Git Sync

### DIFF
--- a/docs/feature-flags/use-ff/webhook-for-ff.md
+++ b/docs/feature-flags/use-ff/webhook-for-ff.md
@@ -42,10 +42,11 @@ To set up webhook for Feature Flag implementation:
  post-event (10 attempts, 500ms apart). If unsuccessful, the system will fall back to the 5-minute poller intervals.
  3. **Enabling Webhook**: Once a webhook is set up at any level (account/project/org) it will be set up for any project that has Git sync enabled with the same GitHub 
  connector in the Feature Flags Module.
- 4. **Deleting Webhooks**: A webhook can be used by many entities so deleting the webhook in Harness will not cause it to be deleted in git.
- 5. **Disabling Webhook**: For Feature Flags disabling the webook in Harness is not enough to disable the functionality. You must either:
-   1. Disable/reset Git Sync in the Feature Flags module.
-   2. Delete the webhook in Github.
+ 4. **Webhook Events**: At present the webhook events page does not support yaml validation of FeatureFlag yamls
+ 5. **Deleting Webhooks**: A webhook can be used by many entities so deleting the webhook in Harness will not cause it to be deleted in git.
+ 6. **Disabling Webhook**: For Feature Flags disabling the webook in Harness is not enough to disable the functionality. You do one of the following:
+     - Disable/reset Git Sync in the Feature Flags module.
+     - Delete the webhook in Github.
   
 
 ## Best Practices

--- a/docs/feature-flags/use-ff/webhook-for-ff.md
+++ b/docs/feature-flags/use-ff/webhook-for-ff.md
@@ -44,7 +44,7 @@ To set up webhook for Feature Flag implementation:
  connector in the Feature Flags Module.
  4. **Webhook Events**: At present the webhook events page does not support yaml validation of FeatureFlag yamls
  5. **Deleting Webhooks**: A webhook can be used by many entities so deleting the webhook in Harness will not cause it to be deleted in git.
- 6. **Disabling Webhook**: For Feature Flags disabling the webook in Harness is not enough to disable the functionality. You do one of the following:
+ 6. **Disabling Webhook**: For Feature Flags disabling the webook in Harness is not enough to disable the functionality. You must do one of the following:
      - Disable/reset Git Sync in the Feature Flags module.
      - Delete the webhook in Github.
   


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Updates the webhook for FF docs to note that yaml validation for ff is not supported in the webhookn events tab
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
