### PR TITLE
Tile hover highlighting for Database DevOps and Secure Supply Chain

### DIFF
--- a/src/components/HomepageFeatures/styles.module.scss
+++ b/src/components/HomepageFeatures/styles.module.scss
@@ -98,6 +98,9 @@
       &.iacm:hover {
         border-color: var(--mod-iacm-200);
       }
+      &.dbdevops:hover {
+        border-color: var(--mod-dbdevops-200);
+      }
     }
     ul.docTypes {
       display: flex;

--- a/src/components/HomepageFeatures/styles.module.scss
+++ b/src/components/HomepageFeatures/styles.module.scss
@@ -74,6 +74,9 @@
       &.ff:hover {
         border-color: var(--mod-ff-200);
       }
+      &.ssca:hover {
+        border-color: var(--mod-ssca-200);
+      }
       &.sto:hover {
         border-color: var(--mod-sto-200);
       }

--- a/src/components/LandingPage/TutorialCard.module.scss
+++ b/src/components/LandingPage/TutorialCard.module.scss
@@ -163,6 +163,9 @@
 .gitness:hover {
   border-color: var(--mod-gitness-200) !important;
 }
+.dbdevops:hover {
+  border-color: var(--mod-dbdevops-200) !important;
+}
 .allTutorials {
   .tutorialCard {
     width: 28%;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -285,6 +285,11 @@
   --mod-iacm-200: #5fb34e;
   --mod-iacm-100: #f6fff2;
 
+  /* Module Colors/Database DevOps */
+  --mod-dbdevops-300: #30841f;
+  --mod-dbdevops-200: #5fb34e;
+  --mod-dbdevops-100: #f6fff2;
+
   /* Module Colors/Code  */
   --mod-code-300: #0672b6;
   --mod-code-200: #2bb1f2;


### PR DESCRIPTION
I was just making this change for new FME module docs, and it took me just a little more time to add hover-over highlighting to two modules (tiles) where it was missing...

## Description

* Please describe your changes: Add hover-over color highlighting (green and red) to the DB DevOps and SSC tiles on the HDH home page.
* Jira/GitHub Issue numbers (if any): ?
* Preview links/images (Internal contributors only):

<img width="712" alt="Screenshot 2024-12-04 at 8 27 15 AM" src="https://github.com/user-attachments/assets/31764445-2557-4cef-b277-fde6ee8b2626">

<img width="800" alt="Screenshot 2024-12-04 at 8 26 50 AM" src="https://github.com/user-attachments/assets/89c1e707-5bdb-4c74-974e-ddd1319f9bf1">

https://github.com/user-attachments/assets/2b7ead11-d3c3-4401-aaac-46f0f2a76992


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
