### PR TITLE
Update kubernetes-autostopping-traefik.md kinds

### DIFF
--- a/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-traefik.md
+++ b/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-traefik.md
@@ -61,7 +61,7 @@ After applying the YAML, an AutoStopping Rule is created in your cluster for ser
 This header sends the AutoStoppingRule header to all the associated ingress routes.
 
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: test-rule-header
@@ -109,7 +109,7 @@ middlewares:
 Your ingressRoute should be similar to the following:
 
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   annotations:


### PR DESCRIPTION
For all the traefik examples we are using a legacy `kind`. When you follow the guide with newer versions you will get errors of kinds not found:

```
error: resource mapping not found for name: "whoami" namespace: "" from "middleware.yaml": no matches for kind "Middleware" in version "traefik.containo.us/v1alpha1"
```

When corrected to the new kind, things work as expected:

```
middleware.traefik.io/whoami created
```

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
