### PR TITLE
fix: [CHAOS-7334]: adds tip for using unique byteman port per java process

### DIFF
--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-cpu-stress.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-cpu-stress.md
@@ -77,7 +77,7 @@ Linux JVM CPU stress:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Pid

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-cpu-stress.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-cpu-stress.md
@@ -76,6 +76,10 @@ Linux JVM CPU stress:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Pid
 
 The process ID used by Byteman to target the services of the JVM. This is mutually exclusive with the `startupCommand` input variable.

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-memory-stress.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-memory-stress.md
@@ -76,6 +76,10 @@ Linux JVM memory stress:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Pid
 
 The process ID used by Byteman to target the services of the JVM. This is mutually exclusive with the `startupCommand` input variable.

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-memory-stress.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-memory-stress.md
@@ -77,7 +77,7 @@ Linux JVM memory stress:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Pid

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-exception.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-exception.md
@@ -60,7 +60,7 @@ JVM method exception:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Optional tunables

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-exception.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-exception.md
@@ -59,6 +59,10 @@ JVM method exception:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Optional tunables
 <table>
   <tr>

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-latency.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-latency.md
@@ -87,7 +87,7 @@ Linux JVM method latency:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Class name

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-latency.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-method-latency.md
@@ -86,6 +86,10 @@ Linux JVM method latency:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Class name
 
 The `class` input variable targets the class name where the exception is present. Specify it in the format `packageName.className`.

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-modify-return.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-modify-return.md
@@ -84,6 +84,10 @@ Linux JVM modify return:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Class name
 
 The `class` input variable targets the class name where the exception is present. Specify it in the format `packageName.className`.

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-modify-return.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-modify-return.md
@@ -85,7 +85,7 @@ Linux JVM modify return:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Class name

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-trigger-gc.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-trigger-gc.md
@@ -69,7 +69,7 @@ Linux JVM trigger gc:
 </table>
 
 :::tip
-If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+If multiple Java processes on the same machine are subject to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
 :::
 
 ### Startup command

--- a/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-trigger-gc.md
+++ b/docs/chaos-engineering/use-harness-ce/chaos-faults/linux/linux-jvm-trigger-gc.md
@@ -68,6 +68,10 @@ Linux JVM trigger gc:
   </tr>
 </table>
 
+:::tip
+If multiple Java processes on the same machine are subjected to JVM chaos, whether simultaneously or not, each process must use a unique Byteman port.
+:::
+
 ### Startup command
 
 The `startupCommand` input variable is used to start the Java process. A substring match is used with the given command for all processes. This is mutually exclusive with the `pid` input variable.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Adds tip for using unique byteman port per java process
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
