### PR TITLE
[CDS-105745] Added note related to undefined variables in expressions…

### DIFF
--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -219,7 +219,7 @@ Additionally, variable values (after evaluation) are limited to 256 KB. Expressi
 
 :::note
 
-In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error, unlike FirstGen pipelines, where undefined variables default to `null`. NG pipelines requires explicit handling of undefined variables.
+In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error, unlike FirstGen pipelines, where undefined variables default to `null`. NG pipelines require explicit handling of undefined variables.
 
 :::
 

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -219,7 +219,9 @@ Additionally, variable values (after evaluation) are limited to 256 KB. Expressi
 
 :::note
 
-In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error, unlike FirstGen pipelines, where undefined variables default to `null`. NG pipelines require explicit handling of undefined variables.
+In Harness NG pipelines, undefined variables in expressions cause pipeline execution errors. This behavior differs from FirstGen (FG) pipelines, where undefined variables default to null. NG pipelines require explicit handling of undefined variables to avoid failures.
+
+For example, if the expression `<+pipeline.variables.test>` is used and the pipeline variable `test` is not defined, the expression resolution will fail, causing the step or stage to fail.
 
 :::
 

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -217,6 +217,12 @@ Additionally, variable values (after evaluation) are limited to 256 KB. Expressi
 
 :::
 
+:::note
+
+In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error. Unlike FirstGen pipelines, where undefined variables default to `null`, NG requires explicit handling of undefined variables.
+
+:::
+
 ## Expression manipulation
 
 In addition to standard evaluation, expressions can be evaluated and manipulated with Java string methods, JSON parsing, JEXL, interpolation, concatenation, and more.

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -219,7 +219,7 @@ Additionally, variable values (after evaluation) are limited to 256 KB. Expressi
 
 :::note
 
-In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error. Unlike FirstGen pipelines, where undefined variables default to `null`, NG requires explicit handling of undefined variables.
+In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error, unlike FirstGen pipelines, where undefined variables default to `null`. NG pipelines requires explicit handling of undefined variables.
 
 :::
 


### PR DESCRIPTION
… in NG pipeline

In Harness NG pipelines, undefined variables in expressions will cause a pipeline execution error. Unlike FirstGen pipelines, where undefined variables default to `null`, NG requires explicit handling of undefined variables.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
