### PR TITLE
Update kubernetes-autostopping-quick-start-guide.md

### DIFF
--- a/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-quick-start-guide.md
+++ b/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-quick-start-guide.md
@@ -95,7 +95,7 @@ Kubernetes AutoStopping support is fully available for the following ingress con
 
 ```yaml
 allow-snippet-annotations: true
-annotation-risk-level: Critical
+annotations-risk-level: Critical
 ```
 
 1. Expose your application by creating an ingress rule. Apply the following YAML to the cluster.

--- a/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-quick-start-guide.md
+++ b/docs/cloud-cost-management/4-use-ccm-cost-optimization/autostopping-guides/kubernetes-autostopping-quick-start-guide.md
@@ -91,6 +91,13 @@ Kubernetes AutoStopping support is fully available for the following ingress con
 <Tabs>
 <TabItem value="nginx" label="Kubernetes AutoStopping for Nginx" default>
 
+0. You will need the following options set on your NGINX Ingress Controller:
+
+```yaml
+allow-snippet-annotations: true
+annotation-risk-level: Critical
+```
+
 1. Expose your application by creating an ingress rule. Apply the following YAML to the cluster.
 
 ```yaml


### PR DESCRIPTION
Due to a recent k8s CVE, further configuration is needed on your nginx ingress controller for autostopping to work.

ref:
- https://github.com/kubernetes/kubernetes/issues/126811
- https://github.com/kubernetes/ingress-nginx/issues/12618
- 
## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
