### PR TITLE
Add tango to docvideo

### DIFF
--- a/docs/artifact-registry/platform-integrations/ci-ar-integrations.md
+++ b/docs/artifact-registry/platform-integrations/ci-ar-integrations.md
@@ -14,19 +14,6 @@ Harness CI offers a [Build and push to Docker](/docs/continuous-integration/use-
 
 <Tabs>
 <TabItem value="Interactive guide">
-<iframe
-    src="https://app.tango.us/app/embed/7892f010-0f5b-4acd-8ad3-9de5426ba386 "
-    title="Build and Push Docker Images with Harness Artifact Registry"
-    style={{ minHeight: '640px' }}
-    width="100%"
-    height="100%"
-    referrerpolicy="strict-origin-when-cross-origin"
-    frameborder="0"
-    webkitallowfullscreen="true"
-    mozallowfullscreen="true"
-    allowfullscreen="true">
-</iframe>
-
 <DocVideo src="https://app.tango.us/app/embed/7892f010-0f5b-4acd-8ad3-9de5426ba386" title="Build and Push Docker Images with Harness Artifact Registry" />
 </TabItem>
 <TabItem value="Step-by-step">

--- a/docs/artifact-registry/platform-integrations/ci-ar-integrations.md
+++ b/docs/artifact-registry/platform-integrations/ci-ar-integrations.md
@@ -26,6 +26,8 @@ Harness CI offers a [Build and push to Docker](/docs/continuous-integration/use-
     mozallowfullscreen="true"
     allowfullscreen="true">
 </iframe>
+
+<DocVideo src="https://app.tango.us/app/embed/7892f010-0f5b-4acd-8ad3-9de5426ba386" title="Build and Push Docker Images with Harness Artifact Registry" />
 </TabItem>
 <TabItem value="Step-by-step">
 To do so, follow these steps:

--- a/src/components/DocVideo/index.tsx
+++ b/src/components/DocVideo/index.tsx
@@ -15,6 +15,7 @@ const DocVideo = ({
   const isYoutubeShortenedURL = src.includes("youtu.be");
   const isWistiaVideo = /https?:\/\/(.+)?(wistia\.com|wi\.st)\/.*/.test(src);
   const isLoomVideo = /https?:\/\/(.+)?(loom\.com)\/.*/.test(src);
+  const isTangoVideo = src.includes("tango");
   if (isYoutubeShortenedURL) {
     //Strip out WWW incase WWW duplicate by user
     videoSrc = (src || "").replace("www.", "");
@@ -93,6 +94,20 @@ const DocVideo = ({
         height={height}
         title={title}
       />
+    );
+  } else if (isTangoVideo) {
+    return (
+      <iframe
+        src={videoSrc}
+        title={title}
+        width={width}
+        height={height}
+        referrerPolicy="strict-origin-when-cross-origin"
+        frameBorder="0"
+        webkitallowfullscreen="true"
+        mozallowfullscreen="true"
+        allowfullscreen="true">
+      </iframe>
     );
   }
   return (


### PR DESCRIPTION
I've added the tango guides to the DocVideo plugin that way you can embed a tango guide like so:

`<DocVideo src="https://app.tango.us/app/embed/7892f010-0f5b-4acd-8ad3-9de5426ba386" title="Build and Push Docker Images with Harness Artifact Registry" />`

vs the iframe method. Its consistent with how we embed other videos, and its nice. Let me know what you think

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
