### PR TITLE
Update CODEOWNERS: Add RA Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -210,11 +210,8 @@ static/  @rohanmaharjan100 @wei-harness
 #Armory KB
 /kb/armory @okosun-j @jimin-harness @deepanshuHarness @guna-harness
 
-#RA
-/kb/reference-architectures/ @rssnyder @suranc @jimin-harness @deepanshuHarness @guna-harness
-
 # DB DevOps
 /kb/database-devops/ @jenniferopal @stephenatwell @HarnessTheChaos @archit-harness @anshul-harness
 
 #Reference Architectures
-/kb/reference-architectures @RajiKoppala @rssnyder 
+/kb/reference-architectures @RajiKoppala @rssnyder @suranc @venkat65-harness @brandon-harness


### PR DESCRIPTION
There were duplicate entries for the RA section. Removing the one that had CXE members. Copy over @suranc as an owner.

Then add our Principal Engineers @brandon-harness and @venkat65-harness to codeowners.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
