### PR TITLE
Add Khushi as a Code Owner for IDP Docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,10 +139,10 @@ static/  @rohanmaharjan100 @wei-harness
 /docs/platform/connectors/ @krishi0408 @vishal-av
 
 # IDP Docs
-/docs/internal-developer-portal/ @Debanitrkl @OrkoHunter @manishas
-/release-notes/internal-developer-portal.md @Debanitrkl @OrkoHunter @manishas
-/src/components/Roadmap/data/idpData.ts @Debanitrkl @OrkoHunter @manishas
-/src/components/Docs/data/internalDeveloperPortal.ts @Debanitrkl @OrkoHunter @manishas
+/docs/internal-developer-portal/ @Debanitrkl @OrkoHunter @manishas @khushisharmaharness
+/release-notes/internal-developer-portal.md @Debanitrkl @OrkoHunter @manishas @khushisharmaharness
+/src/components/Roadmap/data/idpData.ts @Debanitrkl @OrkoHunter @manishas @khushisharmaharness
+/src/components/Docs/data/internalDeveloperPortal.ts @Debanitrkl @OrkoHunter @manishas @khushisharmaharness
 
 # SCS Docs
 /docs/software-supply-chain-assurance/ @sunilgupta-harness @tejakummarikuntla @pranay-harness


### PR DESCRIPTION
Khushi Sharma is our new DevRel engineer in the team and primarily owns IDP docs. Adding her to IDP Docs code owners.

cc @manishas @khushisharmaharness @Debanitrkl

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
