### PR TITLE
Secrets aren't supported for Tanzu Command Steps

### DIFF
--- a/docs/continuous-delivery/deploy-srv-diff-platforms/tanzu/tanzu-command-step.md
+++ b/docs/continuous-delivery/deploy-srv-diff-platforms/tanzu/tanzu-command-step.md
@@ -14,9 +14,14 @@ Harness performs the `cf login` using the credentials in the stage Infrastructur
 ## Important notes
 
 - You can use the CF Command to run any [CF CLI command](https://cli.cloudfoundry.org/en-US/v6/) or script at any point in your Harness Tanzu Command step.
-- Secret variable types are not supported for **Input Variables** and **Output Variables** at this time. String and Number are supported.
 - The Tanzu Command step can be added to a Deploy stage only.
 - Output variables have a maximum size of 512KB.
+
+:::important
+
+Secret expressions are not supported for the Tanzu Command Step at this time.
+
+:::
 
 ## Add the Tanzu Command step
 
@@ -62,19 +67,9 @@ While you can simply declare a variable in your script using a Harness expressio
 
 These variables are set as environment variables and can be accessed in the script using `$variable_name`.
 
-The following variable types are supported:
-
-- String
-- Number
-
 ### Output variables
 
 To export variables from the script to other steps in the stage, you use the **Output Variables** option.
-
-The following variable types are supported:
-
-- String
-- Secret
 
 Output variables are passed from the the script output to the Harness pipeline and can be referenced in subsequent steps and settings using expressions.
 
@@ -116,16 +111,6 @@ To find the expression to reference your output variables, you can begin typing 
 If you exit from the script (`exit 0`), Harness does not populate the output variables because the step has exited.
 
 :::
-
-You can access a secret configured in the **Secrets Manager** using an expression. For example, `<+secrets.getValue('SECRET_NAME')>`.
-
-You can also configure variables of type Secret as output variables. When an output variable is configured as a secret, its value is encrypted. 
-
-![](static/tanzu-secrets-output-variable.png)
-
-The encrypted secret is decrypted and made available for use in the script. However, the script's output will not display the secret, even if the secret is explicitly passed to the output stream.
-
-![](static/output-variable-logs.png)
 
 ### Using manifests in your scripts
 


### PR DESCRIPTION
This seems to undo the changes by this PR: https://github.com/harness/developer-hub/pull/9027

Did something change in the last two months that caused the functionality to differ? Adding the **DO NOT MERGE** label to this PR until I can confirm this should be removed as written. 

https://harness.atlassian.net/browse/CDS-100500

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
