### PR TITLE
Update fmeData.ts removed Gemini Code Assist

### DIFF
--- a/src/components/Roadmap/data/fmeData.ts
+++ b/src/components/Roadmap/data/fmeData.ts
@@ -63,12 +63,6 @@ export const FmeData: Horizon = {
         description:
           "Assign feature availability for user groups based on different conditions, with all the power of FME targeting.",
       },
-      {        
-        tag: [{value: "AI Agents"}],
-        title: "Gemini Code Assist",
-        description:
-          "View feature flags and definitions directly within your IDE through an integrated agent in the code assist interface.",
-      },
       {
         tag: [{ value: "SDK" }],
         title: "Remote evaluation client-side SDKs",

--- a/src/components/Roadmap/data/fmeData.ts
+++ b/src/components/Roadmap/data/fmeData.ts
@@ -31,11 +31,6 @@ export const FmeData: Horizon = {
         description: "See accumulation of sample population over time. Identify unexpected assignment or traffic level changes.",
       },
       {
-        tag: [{ value: "SDK" }],
-        title: "Elixir SDK",
-        description: "First of new SDKs to be added after joining Harness.",
-      },
-      {
         tag: [{ value: "Better Together" }],
         title: "Authn and authz on Harness platform",
         description: "Login, API scoping, and RBAC enhancements delivered by migration.",
@@ -98,6 +93,11 @@ export const FmeData: Horizon = {
   Released: {
     description: "What has been released",
     feature: [
+      {
+        tag: [{ value: "SDK" }],
+        title: "Elixir SDK",
+        description: "First of new SDKs to be added after joining Harness.",
+      },
       {        
         tag: [{value: "AI Agents"}],
         title: "AI results interpretation conversation",


### PR DESCRIPTION
Per announcement in #ask-split-fme-product 3/4/25:  Gemini Code Assist development is blocked and will be removed from the roadmap. It requires Harness to conform a specific google auth requirement that the platform does not currently support – and is not on the roadmap. When/if this changes, the roadmap will be updated accordingly.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
