### PR TITLE
Docs update for CI-16538

### DIFF
--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -107,8 +107,6 @@ pipeline:
             spec:
               connectorRef: k8
               namespace: harness-delegate-ng
-              automountServiceAccountToken: true
-              nodeSelector: {}
               os: Linux
           execution:
             steps:

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -59,10 +59,6 @@ You can also enable or disable Build Intelligence based on an expression directl
   <TabItem value="Cloud" label="Harness Cloud" default>
 
 
-:::info
-- If this feature is not yet enabled in your account, please reach out to [Harness Support](mailto:support@harness.io) to enable feature flags `CI_CACHE_ENABLED` and `CI_ENABLE_BUILD_CACHE_HOSTED_VM`. 
-:::
-
 The cache storage limit depends on your subscription plan type. Please visit [Subscriptions and licenses](/docs/continuous-integration/get-started/ci-subscription-mgmt.md#usage-limits) page to learn more about usage limits.
 
 Harness doesn't limit the number of caches you can store, but, once you reach your storage limit, Harness continues to save new caches by automatically evicting old caches.
@@ -77,9 +73,7 @@ The cache retention window is 15 days, which resets whenever a cache is updated.
   <TabItem value="Self Hosted" label="Self Hosted" default>
   :::info
     - Build Intelligence is only supported for Kubernetes on self-hosted build infrastructure. 
-  - To use Build Intelligence with self-hosted builds the following feature flags need to be enabled: 
-  `CI_CACHE_ENABLED` and `CI_ENABLE_BUILD_CACHE_K8` 
-  - To authenticate to your S3 bucket using OIDC, feature flags `PL_GCP_OIDC_AUTHENTICATION` for GCP or `CDS_AWS_OIDC_AUTHENTICATION` for AWS are required.
+    - To authenticate to your S3 bucket using OIDC, feature flags `PL_GCP_OIDC_AUTHENTICATION` for GCP or `CDS_AWS_OIDC_AUTHENTICATION` for AWS are required.
   
   Contact [Harness Support](mailto:support@harness.io) to enable the feature, if not already available in your account.
   :::

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -100,7 +100,6 @@ pipeline:
           cloneCodebase: true
           caching:
             enabled: false
-            paths: []
           buildIntelligence:
             enabled: true
           infrastructure:
@@ -122,12 +121,7 @@ pipeline:
                     image: gradle:8.1.1-jdk17
                     shell: Sh
                     command: |-
-                      #cat $GRADLE_HOME/init.d/init.gradle
                       ./gradlew build
-                    resources:
-                      limits:
-                        memory: 5000Mi
-                        cpu: 5000m
         variables:
           - name: MAVEN_URL
             type: String

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -73,9 +73,6 @@ The cache retention window is 15 days, which resets whenever a cache is updated.
   <TabItem value="Self Hosted" label="Self Hosted" default>
   :::info
     - Build Intelligence is only supported for Kubernetes on self-hosted build infrastructure. 
-    - To authenticate to your S3 bucket using OIDC, feature flags `PL_GCP_OIDC_AUTHENTICATION` for GCP or `CDS_AWS_OIDC_AUTHENTICATION` for AWS are required.
-  
-  Contact [Harness Support](mailto:support@harness.io) to enable the feature, if not already available in your account.
   :::
 
   - When using a Build Intelligence with self-hosted infrastructure, an S3-compatible bucket is required for cache storage. Please visit [configure default S3-compatible object storage](/docs/platform/settings/default-settings.md#continuous-integration) for more information.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

@nofarblue three questions:

1. I used port 8284 as an example of a custom port. The pipeline example in the ticket used the same 8082 port as an example.
2. Do you want me to add a YAML example for build intelligence on/off based on an expression?
3. I see the text "By default, the Build Intelligence plugin is downloaded from Maven Central...." in the ticket but no change regarding Maven central is mentioned in the ticket. Is there any required change there?

* Please describe your changes: Docs update for CI-16538
* Jira/GitHub Issue numbers (if any): CI-16538
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
