### PR TITLE
Reverted the versions that are not there in docker hub

### DIFF
--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -95,20 +95,6 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 
 - Fixed the slot deployment timeout issue in azure deployments [CDS-108129]
 
-### Version 25.02.85304 <!--  March 13, 2025 -->
-
-#### Hotfix
-
-- Fixed the runtime input regex filtering for ECR artifacts [CDS-106566]
-
-
-### Version 25.02.85303 <!--  March 07, 2025 -->
-
-#### Hotfix
-
-- Fix the aws library upgrade issue for AWS serverless lambda deployment [CDS-107585]
-
-
 ## February 2025
 
 ### Version 24.08.83706 <!--  Feb 26, 2025 -->


### PR DESCRIPTION
Reverted the versions that are not there in docker hub

Version 25.02.85304 and 25.02.85303 does not exists in the docker hub, Hence, removing them from release notes

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
