### PR TITLE
Add IPs and CIDR to allowlist.

### DIFF
--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -198,7 +198,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
               size: xlarge # optional 
 ```
 
-### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
+### Allowlisting for accessing resources in your private network
 
 If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-resources-in-your-private-network).
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -200,7 +200,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 ### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
 
-If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#Harness-Cloud-Allowlisting-for-accessing-self-hosted-(On-Prem)-services).
+If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-self-hosted-services).
 
 ### Harness Cloud best practices
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -202,7 +202,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 When running pipeline stages on Harness Cloud, you may need to connect to internal resources that are not publicly accessible — such as artifact repositories, source code management systems (SCMs), or internal APIs.
 
-To enable secure communication between Harness Cloud infrastructure and your private network, your networking or security team can allowlist the relevant IP ranges used by Harness Cloud. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
+To enable secure communication between Harness Cloud infrastructure and your private network, your networking or security team can allowlist the relevant IP ranges used by Harness Cloud. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your environment.
 
 For more information about allowlisting, please review the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-resources-in-your-private-network).
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -200,7 +200,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 ### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
 
-If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#add-harness-platform-ips-to-the-allowlist).
+If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#Harness-Cloud-Allowlisting-for-accessing-self-hosted-(On-Prem)-services).
 
 ### Harness Cloud best practices
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -200,7 +200,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 ### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
 
-If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-self-hosted-services).
+If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-resources-in-your-private-network).
 
 ### Harness Cloud best practices
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -198,37 +198,9 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
               size: xlarge # optional 
 ```
 
-### Allowlisting for Access to On-Prem Services (Mac Platform)
+### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
 
-If you're running builds on Harness Cloud macOS machines, and require access to on-premises resources, please allowlist the following CIDR block:  `207.254.53.128/25`
-
-This will enable seamless communication between Harness Mac-based CI infrastructure and your on-prem services.
-
-Alternatively, you can also use [Secure connector](/docs/continuous-integration/secure-ci/secure-connect) for accessing your on-premises resources.
-
-### Allowlisting for Access to On-Prem Services (Linux Platform)
-
-Harness Cloud users utilizing hosted Linux infrastructure, who rely on allowlisting for on-premises resource access, are requested to update their configuration.
-
-:::warning
-To ensure uninterrupted connectivity and functionality for your CI builds, please allowlist the following IP range in your network settings by **March 15th, 2025**:
-:::
-CIDR Blocks:
-
-```
-15.204.17.0/24, 15.204.19.0/24, 15.204.23.0/24, 15.204.69.0/24, 15.204.70.0/24, 15.204.71.0/24, 51.81.128.0/24, 51.81.189.0/24
-```
-
-**Additional IPs to add to allowlist:**
-```
-34.94.194.45, 34.133.164.105, 35.184.10.123, 34.171.8.178, 34.172.44.211, 34.28.94.170, 34.75.255.154, 34.139.54.93, 35.231.172.154,  
-35.227.126.5, 35.231.234.224, 34.139.103.193, 34.139.148.112, 35.196.119.169, 34.73.226.43, 35.237.185.165, 34.162.90.200, 34.162.31.112,  
-34.162.177.5, 34.162.189.244, 34.162.184.1, 34.125.74.8, 34.125.80.89, 34.16.190.122, 34.125.82.12, 34.125.11.217, 35.197.35.30,  
-35.233.237.208, 34.83.94.29, 34.168.158.33, 34.168.20.8, 34.82.156.127, 34.83.1.152, 34.168.60.254, 34.82.65.138, 34.82.140.146,  
-34.127.6.209, 35.185.226.205, 35.247.24.71, 34.168.30.50, 35.233.132.196, 34.168.214.255, 34.102.103.7, 34.102.40.149, 34.102.16.205,  
-34.127.65.210, 35.233.172.173
-```
-If you have any questions or need assistance with the allowlisting process, please [contact Harness Support](https://support.harness.io/).
+If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#allowlisting-for-access-to-on-prem-services-mac-platform).
 
 ### Harness Cloud best practices
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -200,7 +200,7 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 ### Allowlisting for Access to On-Prem Services (Mac and Linux Platforms)
 
-If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#allowlisting-for-access-to-on-prem-services-mac-platform).
+If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#add-harness-platform-ips-to-the-allowlist).
 
 ### Harness Cloud best practices
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure.md
@@ -200,7 +200,11 @@ To enable this feature, set the `nestedVirtualization` property to `true` as sho
 
 ### Allowlisting for accessing resources in your private network
 
-If you're running builds on Harness Cloud machines, and require access to on-premises resources, check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-resources-in-your-private-network).
+When running pipeline stages on Harness Cloud, you may need to connect to internal resources that are not publicly accessible — such as artifact repositories, source code management systems (SCMs), or internal APIs.
+
+To enable secure communication between Harness Cloud infrastructure and your private network, your networking or security team can allowlist the relevant IP ranges used by Harness Cloud. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
+
+For more information about allowlisting, please review the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-resources-in-your-private-network).
 
 ### Harness Cloud best practices
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -95,7 +95,7 @@ All the IPs are cloud NAT gateways and need to enable specific IPs instead of ra
 35.189.94.200/32
 34.141.112.174/32
 ```
-### Harness Cloud Allowlisting for accessing self-hosted (On-Prem) services
+### Harness Cloud Allowlisting for accessing self-hosted services
 
 When using Harness Cloud to run pipeline stages, you may need to connect to resources hosted in your private network — such as artifact repositories, internal APIs, or Git repositories (SCM). To enable this secure communication, your networking team can allowlist the IP ranges used by Harness Cloud infrastructure.
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -95,6 +95,34 @@ All the IPs are cloud NAT gateways and need to enable specific IPs instead of ra
 35.189.94.200/32
 34.141.112.174/32
 ```
+### Allowlisting for Access to On-Prem Services (Mac Platform)
+
+If you're running builds on Harness Cloud macOS machines, and require access to on-premises resources, please allowlist the following CIDR block:  `207.254.53.128/25`
+
+This will enable seamless communication between Harness Mac-based CI infrastructure and your on-prem services.
+
+Alternatively, you can also use [Secure connector](/docs/continuous-integration/secure-ci/secure-connect) for accessing your on-premises resources.
+
+### Allowlisting for Access to On-Prem Services (Linux Platform)
+
+Harness Cloud users utilizing hosted Linux infrastructure, who rely on allowlisting for on-premises resource access, are requested to update their configuration.
+
+CIDR Blocks:
+
+```
+15.204.17.0/24, 15.204.19.0/24, 15.204.23.0/24, 15.204.69.0/24, 15.204.70.0/24, 15.204.71.0/24, 51.81.128.0/24, 51.81.189.0/24
+```
+
+**Additional IPs to add to allowlist:**
+```
+34.94.194.45, 34.133.164.105, 35.184.10.123, 34.171.8.178, 34.172.44.211, 34.28.94.170, 34.75.255.154, 34.139.54.93, 35.231.172.154,  
+35.227.126.5, 35.231.234.224, 34.139.103.193, 34.139.148.112, 35.196.119.169, 34.73.226.43, 35.237.185.165, 34.162.90.200, 34.162.31.112,  
+34.162.177.5, 34.162.189.244, 34.162.184.1, 34.125.74.8, 34.125.80.89, 34.16.190.122, 34.125.82.12, 34.125.11.217, 35.197.35.30,  
+35.233.237.208, 34.83.94.29, 34.168.158.33, 34.168.20.8, 34.82.156.127, 34.83.1.152, 34.168.60.254, 34.82.65.138, 34.82.140.146,  
+34.127.6.209, 35.185.226.205, 35.247.24.71, 34.168.30.50, 35.233.132.196, 34.168.214.255, 34.102.103.7, 34.102.40.149, 34.102.16.205,  
+34.127.65.210, 35.233.172.173
+```
+If you have any questions or need assistance with the allowlisting process, please [contact Harness Support](https://support.harness.io/).
 
 ### Harness hosted Feature Flags IPs
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -95,11 +95,11 @@ All the IPs are cloud NAT gateways and need to enable specific IPs instead of ra
 35.189.94.200/32
 34.141.112.174/32
 ```
-### Harness Cloud Allowlisting for accessing self-hosted services
+### Harness Cloud Allowlisting for accessing resources in your private network
 
-When using Harness Cloud to run pipeline stages, you may need to connect to resources hosted in your private network — such as artifact repositories, internal APIs, or Git repositories (SCM). To enable this secure communication, your networking team can allowlist the IP ranges used by Harness Cloud infrastructure.
+When running pipeline stages on Harness Cloud, you may need to connect to internal resources that are not publicly accessible — such as artifact repositories, source code management systems (SCMs), or internal APIs. To enable secure communication between Harness Cloud infrastructure and your private network, your networking or security team can allowlist the relevant IP ranges used by Harness Cloud. 
 
-This page provides the list of IP ranges to allowlist for both macOS and Linux hosted platforms. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
+This page provides the list of IP ranges to allowlist for both macOS and Linux hosted platforms. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your environment.
 
 #### Harness Cloud Allowlisting for Mac Platform
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -26,7 +26,7 @@ Users of the Harness Manager browser client need access to **app.harness.io** an
 
 If you are using a Harness vanity URL, like **mycompany.harness.io**, you can allowlist it also.
 
-## Allowlist Harness Platform IPs
+## Allowlist Harness SaaS IPs
 
 The following list is optional. You can allowlist these IPs if needed.
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -95,15 +95,20 @@ All the IPs are cloud NAT gateways and need to enable specific IPs instead of ra
 35.189.94.200/32
 34.141.112.174/32
 ```
-### Allowlisting for Access to On-Prem Services (Mac Platform)
+### Harness Cloud Allowlisting for accessing self-hosted (On-Prem) services
 
-If you're running builds on Harness Cloud macOS machines, and require access to on-premises resources, please allowlist the following CIDR block:  `207.254.53.128/25`
+When using Harness Cloud to run pipeline stages, you may need to connect to resources hosted in your private network — such as artifact repositories, internal APIs, or Git repositories (SCM). To enable this secure communication, your networking team can allowlist the IP ranges used by Harness Cloud infrastructure.
+
+This page provides the list of IP ranges to allowlist for both macOS and Linux hosted platforms. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure connector](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
+
+#### Harness Cloud Allowlisting for Mac Platform
+
+If you're running pipeline stages (e.g. for CI) on Harness Cloud macOS machines, and require access to on-premises resources, please allowlist the following CIDR block:  `207.254.53.128/25`
 
 This will enable seamless communication between Harness Mac-based CI infrastructure and your on-prem services.
 
-Alternatively, you can also use [Secure connector](/docs/continuous-integration/secure-ci/secure-connect) for accessing your on-premises resources.
 
-### Allowlisting for Access to On-Prem Services (Linux Platform)
+#### Harness Cloud Allowlisting for Linux Platform
 
 Harness Cloud users utilizing hosted Linux infrastructure, who rely on allowlisting for on-premises resource access, are requested to update their configuration.
 
@@ -113,7 +118,8 @@ CIDR Blocks:
 15.204.17.0/24, 15.204.19.0/24, 15.204.23.0/24, 15.204.69.0/24, 15.204.70.0/24, 15.204.71.0/24, 51.81.128.0/24, 51.81.189.0/24
 ```
 
-**Additional IPs to add to allowlist:**
+##### Additional IPs to add to allowlist:
+
 ```
 34.94.194.45, 34.133.164.105, 35.184.10.123, 34.171.8.178, 34.172.44.211, 34.28.94.170, 34.75.255.154, 34.139.54.93, 35.231.172.154,  
 35.227.126.5, 35.231.234.224, 34.139.103.193, 34.139.148.112, 35.196.119.169, 34.73.226.43, 35.237.185.165, 34.162.90.200, 34.162.31.112,  

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -1,5 +1,5 @@
 ---
-title: Allowlist Harness domains and IPs
+title: Allowlist Harness Platform IPs and CIDR
 description: Harness SaaS Delegates only need outbound access to the Harness domain name (most commonly, app.harness.io) and, optionally, to logging.googleapis.com.
 sidebar_position: 1
 helpdocs_topic_id: ooelo06uy5
@@ -26,7 +26,7 @@ Users of the Harness Manager browser client need access to **app.harness.io** an
 
 If you are using a Harness vanity URL, like **mycompany.harness.io**, you can allowlist it also.
 
-## Allowlist Harness SaaS IPs
+## Allowlist Harness Platform IPs
 
 The following list is optional. You can allowlist these IPs if needed.
 
@@ -44,11 +44,11 @@ The following list is optional. You can allowlist these IPs if needed.
 Harness will not change IPs without 30 days notice to all customers. If a security emergency requires a change, all customers are notified.
 :::
 
-## Add Harness hosted IPs to the allowlist
+## Add Harness Platform IPs to the allowlist
 
 Access to Kubernetes clusters that are behind strict firewalls and are not accessible from the public internet is controlled through authorized IP addresses. To allow access to these clusters, Harness provides a list of IP addresses that need to be configured on the clusters.
 
-### Harness hosted GitOps IPs
+### Harness Platform GitOps IPs
 
 If you are using hosted GitOps agents to deploy on managed clusters, you must configure these clusters with a specific set of IP addresses to authorize access.
 
@@ -124,7 +124,7 @@ CIDR Blocks:
 ```
 If you have any questions or need assistance with the allowlisting process, please [contact Harness Support](https://support.harness.io/).
 
-### Harness hosted Feature Flags IPs
+### Harness Platform Feature Flags IPs
 
 With Feature Flags, the following IP can be added to the allowlist as needed.
 

--- a/docs/platform/references/allowlist-harness-domains-and-ips.md
+++ b/docs/platform/references/allowlist-harness-domains-and-ips.md
@@ -99,18 +99,16 @@ All the IPs are cloud NAT gateways and need to enable specific IPs instead of ra
 
 When using Harness Cloud to run pipeline stages, you may need to connect to resources hosted in your private network — such as artifact repositories, internal APIs, or Git repositories (SCM). To enable this secure communication, your networking team can allowlist the IP ranges used by Harness Cloud infrastructure.
 
-This page provides the list of IP ranges to allowlist for both macOS and Linux hosted platforms. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure connector](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
+This page provides the list of IP ranges to allowlist for both macOS and Linux hosted platforms. Alternatively, if allowlisting is not feasible or permitted by your security team, you can use [Secure Connect](/docs/continuous-integration/secure-ci/secure-connect) to establish a secure tunnel to your on-premises environment.
 
 #### Harness Cloud Allowlisting for Mac Platform
 
-If you're running pipeline stages (e.g. for CI) on Harness Cloud macOS machines, and require access to on-premises resources, please allowlist the following CIDR block:  `207.254.53.128/25`
-
-This will enable seamless communication between Harness Mac-based CI infrastructure and your on-prem services.
+Harness Cloud users utilizing hosted **macOS** infrastructure, who rely on allowlisting for on-premises resource access, are requested to allowlist the following CIDR block:  `207.254.53.128/25`
 
 
 #### Harness Cloud Allowlisting for Linux Platform
 
-Harness Cloud users utilizing hosted Linux infrastructure, who rely on allowlisting for on-premises resource access, are requested to update their configuration.
+Harness Cloud users utilizing hosted **Linux** infrastructure, who rely on allowlisting for on-premises resource access, are requested to update their configuration.
 
 CIDR Blocks:
 

--- a/docs/platform/security/add-manage-ip-allowlist.md
+++ b/docs/platform/security/add-manage-ip-allowlist.md
@@ -30,6 +30,7 @@ This topic explains how to set up an IP allowlist in Harness.
   - Calls corresponding to Identity providers.
   - API calls corresponding to Harness admin.
 - Harness uses an in-memory cache. All caches expire after 5 minutes. Every update takes 5 minutes because there are no manual cache updates.
+- Check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#allowlisting-for-access-to-on-prem-services-mac-platform).
 
 ## Add an allowlist
 

--- a/docs/platform/security/add-manage-ip-allowlist.md
+++ b/docs/platform/security/add-manage-ip-allowlist.md
@@ -30,7 +30,7 @@ This topic explains how to set up an IP allowlist in Harness.
   - Calls corresponding to Identity providers.
   - API calls corresponding to Harness admin.
 - Harness uses an in-memory cache. All caches expire after 5 minutes. Every update takes 5 minutes because there are no manual cache updates.
-- Check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#allowlisting-for-access-to-on-prem-services-mac-platform).
+- Check out the [full allowlist for IP addresses and CIDR block](/docs/platform/references/allowlist-harness-domains-and-ips#harness-cloud-allowlisting-for-accessing-self-hosted-services).
 
 ## Add an allowlist
 


### PR DESCRIPTION
Duplicate information exists on https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/use-harness-cloud-build-infrastructure/#allowlisting-for-access-to-on-prem-services-linux-platform. Shall we keep this? Per [this thread](https://harness.slack.com/archives/C08E50LNUEA/p1743781913097729), there should be a single place to get the list of all IPs and CIDRs.

## Description

* Please describe your changes: This PR adds IPs and CIDR per [this thread](https://harness.slack.com/archives/C08E50LNUEA/p1743781913097729)
* Jira/GitHub Issue numbers (if any): CI-17041
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
