### PR TITLE
Fixed the Input set RBAC permissions

### DIFF
--- a/docs/platform/automation/api/api-permissions-reference.md
+++ b/docs/platform/automation/api/api-permissions-reference.md
@@ -259,9 +259,9 @@ The following permissions allow an API key to interact with IDP Admin resources.
 
 The following permissions allow an API key to manage Input Sets. They are available at any [scope](../../role-based-access-control/rbac-in-harness.md#permissions-hierarchy-scopes).
 
-* View input sets: `core_inputsets_view`
-* Create/edit input sets: `core_inputsets_edit`
-* Delete input sets: `core_inputsets_delete`
+* View input sets: `core_inputset_view`
+* Create/edit input sets: `core_inputset_edit`
+* Delete input sets: `core_inputset_delete`
 
 ## Organizations
 


### PR DESCRIPTION
## Description

Fixed the Input set RBAC permissions. The permissions was wrongly mentioned as core_inputsets_* where it should be core_inputset_*


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
