### PR TITLE
Updating default cache key behavior

### DIFF
--- a/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
@@ -177,9 +177,9 @@ Harness generates a cache key from a hash of the build lock file (such as `pom.x
 You can define custom cache keys if you don't want to use the default cache key naming behavior or you have a use case that requires defining custom cache keys, such as [caching in parallel stages](#cache-intelligence-in-parallel-stages).
 
 :::note
-When **Cache Intelligence** is enabled, the cache plugin automatically detects build tools and determines cache paths. If no cache key is provided, a default key (`default`) is used, and cache paths are stored under `<account_id>/default/path/to/directory`.  
+When **Cache Intelligence** is enabled, the cache plugin automatically detects build tools and determines cache paths. Cache paths are stored under `<account_id>/default/path/to/directory`.  
 
-By default, you can specify only a cache path without a key, but this may cause issues during cache restoration in CI stages. To avoid unnecessary cache downloads, we recommend enabling the `CI_CACHE_SKIP_IF_KEY_EMPTY` feature flag. When enabled, **Cache Intelligence** will skip cache restoration and saving if cache paths are provided without a cache key.
+If a cache path is specified without a key, **Cache Intelligence** will be disabled skipping cache restoration and saving thus ensuring caching behavior is intentional.
 :::
 
 <Tabs>

--- a/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
+++ b/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence.md
@@ -105,6 +105,10 @@ Cache Intelligence stores the data to be cached in the `/harness` directory by d
 - You have customized cache locations, such as with `yarn config set cache-folder`.
 - You're using a Windows platform.
 
+:::warning
+When using custom paths, you must also provide a cache key. **If a cache path is specified without a key, Cache Intelligence will be disabled**, skipping cache operations.
+:::
+
 <Tabs>
 <TabItem value="Visual" label="Visual editor">
 
@@ -177,9 +181,7 @@ Harness generates a cache key from a hash of the build lock file (such as `pom.x
 You can define custom cache keys if you don't want to use the default cache key naming behavior or you have a use case that requires defining custom cache keys, such as [caching in parallel stages](#cache-intelligence-in-parallel-stages).
 
 :::note
-When **Cache Intelligence** is enabled, the cache plugin automatically detects build tools and determines cache paths. Cache paths are stored under `<account_id>/default/path/to/directory`.  
-
-If a cache path is specified without a key, **Cache Intelligence** will be disabled skipping cache restoration and saving thus ensuring caching behavior is intentional.
+When **Cache Intelligence** is enabled, the cache plugin automatically detects build tools and determines cache paths, unless custom paths are specified. Cache paths are stored under `<account_id>/default/path/to/directory`.  
 :::
 
 <Tabs>


### PR DESCRIPTION
If paths are specified without a corresponding key, Cache Intelligence will be disabled for that step.

No caching or restoration will occur in such cases.​

This change ensures that caching behavior is intentional

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Documenting changes to default cache key generation behavior when a path is provided without a key
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
