### PR TITLE
feature: Add InLine TOC and URL hash for deep linking

### DIFF
--- a/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.css
+++ b/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.css
@@ -65,6 +65,14 @@
     line-height: 1.6;
   }
   
+  /* Keep headings visible when navigated via hash links / TOC */
+  .dynamic-markdown-selector .markdown-content h2[id],
+  .dynamic-markdown-selector .markdown-content h3[id],
+  .dynamic-markdown-selector .markdown-content h4[id] {
+    /* Height of Docusaurus navbar (var fallback 70px) */
+    scroll-margin-top: var(--ifm-navbar-height, 70px);
+  }
+  
   .selector-divider {
     border: none;
     border-top: 1.5px solid #e0e0e0;

--- a/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.tsx
+++ b/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.tsx
@@ -20,18 +20,61 @@
  * />
  */
 
-import React, { useState, useEffect } from 'react';
-import ReactMarkdown from 'react-markdown';
-import './DynamicMarkdownSelector.css';
+import React, { useState, useEffect } from "react";
+import ReactMarkdown from "react-markdown";
+import "./DynamicMarkdownSelector.css";
 
 export interface DynamicMarkdownSelectorProps {
   options: Record<string, string>;
 }
 
-const DynamicMarkdownSelector: React.FC<DynamicMarkdownSelectorProps> = ({ options }) => {
+const DynamicMarkdownSelector: React.FC<DynamicMarkdownSelectorProps> = ({
+  options,
+}) => {
   const labels = Object.keys(options);
-  const [selected, setSelected] = useState(labels[0]);
-  const [markdown, setMarkdown] = useState('');
+
+  // Helper to normalize hash and label for comparison
+  const normalize = (str: string) => str.toLowerCase().replace(/\s+/g, "");
+
+  // Create slug from heading text (same algo used in TOC & rendered headings)
+  const slugify = (str: string) =>
+    str
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-");
+
+  // Get initial selection from hash, or default to first label
+  const getInitialSelected = () => {
+    const hash = window.location.hash.replace("#", "");
+    const match = labels.find((label) => normalize(label) === normalize(hash));
+    return match || labels[0];
+  };
+
+  const [selected, setSelected] = useState(getInitialSelected());
+  const [markdown, setMarkdown] = useState("");
+  const [toc, setToc] = useState<{ id: string; text: string; level: number }[]>([]);
+
+  // Update selection if hash changes
+  useEffect(() => {
+    const onHashChange = () => {
+      const hash = window.location.hash.replace("#", "");
+      const match = labels.find(
+        (label) => normalize(label) === normalize(hash)
+      );
+      if (match) setSelected(match);
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, [labels]);
+
+  // Update hash in URL when selection changes
+  useEffect(() => {
+    const normalized = normalize(selected);
+    if (normalized !== window.location.hash.replace("#", "")) {
+      window.location.hash = normalized;
+    }
+  }, [selected]);
 
   useEffect(() => {
     const fetchMarkdown = async () => {
@@ -41,20 +84,54 @@ const DynamicMarkdownSelector: React.FC<DynamicMarkdownSelectorProps> = ({ optio
         const text = await response.text();
         setMarkdown(text);
       } catch (e) {
-        setMarkdown('Error loading content.');
+        setMarkdown("Error loading content.");
       }
     };
     fetchMarkdown();
   }, [selected, options]);
 
+  useEffect(() => {
+    const scrollToHash = () => {
+      const hash = window.location.hash.replace("#", "");
+      if (hash) {
+        // Try scrolling after a tick, to ensure DOM is updated
+        setTimeout(() => {
+          const el = document.getElementById(hash);
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "start" });
+          }
+        }, 0);
+      }
+    };
+    window.addEventListener("hashchange", scrollToHash);
+    // Run once after new markdown loads
+    setTimeout(scrollToHash, 0);
+    return () => window.removeEventListener("hashchange", scrollToHash);
+  }, [markdown]);
+
+  // Build TOC whenever markdown string changes
+  useEffect(() => {
+    const headingRegex = /^(#{2,6})\s+(.*)$/gm; // capture headings ## and deeper
+    const newToc: { id: string; text: string; level: number }[] = [];
+
+    let match;
+    while ((match = headingRegex.exec(markdown)) !== null) {
+      const level = match[1].length; // number of # signs
+      const text = match[2].trim();
+      const id = slugify(text);
+      newToc.push({ id, text, level });
+    }
+    setToc(newToc);
+  }, [markdown]);
+
   return (
     <div className="dynamic-markdown-selector">
       <hr className="selector-divider" />
       <div className="selector-tiles">
-        {labels.map(label => (
+        {labels.map((label) => (
           <button
             key={label}
-            className={`selector-tile${selected === label ? ' selected' : ''}`}
+            className={`selector-tile${selected === label ? " selected" : ""}`}
             onClick={() => setSelected(label)}
             type="button"
           >
@@ -62,8 +139,52 @@ const DynamicMarkdownSelector: React.FC<DynamicMarkdownSelectorProps> = ({ optio
           </button>
         ))}
       </div>
+      {/* Right‑hand runtime TOC */}
+      {toc.length > 0 && (
+        <nav className="runtime-toc">
+          <ul>
+            {toc.map((h) => (
+              <li key={h.id} className={`level-${h.level}`}>
+                <a href={`#${h.id}`}>{h.text}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
       <div className="markdown-content">
-        <ReactMarkdown>{markdown}</ReactMarkdown>
+        <ReactMarkdown
+          components={{
+            h2: ({ node, children, ...props }) => {
+              const text = Array.isArray(children) ? children.join(" ") : String(children);
+              const id = slugify(text);
+              return (
+                <h2 id={id} {...props}>
+                  {children}
+                </h2>
+              );
+            },
+            h3: ({ node, children, ...props }) => {
+              const text = Array.isArray(children) ? children.join(" ") : String(children);
+              const id = slugify(text);
+              return (
+                <h3 id={id} {...props}>
+                  {children}
+                </h3>
+              );
+            },
+            h4: ({ node, children, ...props }) => {
+              const text = Array.isArray(children) ? children.join(" ") : String(children);
+              const id = slugify(text);
+              return (
+                <h4 id={id} {...props}>
+                  {children}
+                </h4>
+              );
+            },
+          }}
+        >
+          {markdown}
+        </ReactMarkdown>
       </div>
       <hr className="selector-divider" />
     </div>


### PR DESCRIPTION
## Description

* Updated the Dynamic Markdown select component to include inline TOC and apply selected tile URL hash for deep linking.
* Some scroll control was also added to ensure that the appropriate header is still visible when a TOC item is clicked.

### Screenshot / Preview
https://github.com/user-attachments/assets/f246ea9b-f81e-46df-8ce2-4f889867040e

PRs must meet these requirements to be merged:
- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.