### PR TITLE
[feat]: [DBOPS-1173]: Update includeAll path reference expectation

### DIFF
--- a/docs/database-devops/concepts-and-features/understanding-changelog-directories/changelog-directories-structure.md
+++ b/docs/database-devops/concepts-and-features/understanding-changelog-directories/changelog-directories-structure.md
@@ -29,8 +29,11 @@ databaseChangeLog:
   - includeAll:
       path: db/changelog/releases/
       errorIfMissingOrEmpty: true
-      relativeToChangelogFile: true
 ```
+
+:::note
+The path specified in includeAll should be relative to the location of the changelog file that contains this statement.
+:::
 
 :::tip
 Use a consistent naming convention for your changelog files (e.g., `001-feature-name.yaml`, `002-feature-name.yaml`) to ensure they are processed in the intended order when using `includeAll` as the files are processed in **alphabetical order**.


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description
We are always pointing to changelog file location with folder structure added in search-path command argument.
So we already expect path relative to changelog file by default. Hence removing this `relativeToChangelogFile` property input.

<img width="1003" alt="Screenshot 2025-04-25 at 10 50 19 AM" src="https://github.com/user-attachments/assets/d41f3cc3-0e80-4255-865f-8cb58ddc2920" />


* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
