### PR TITLE
[DBOPS-936]: minimum version required info for substitution property

### DIFF
--- a/docs/database-devops/concepts-and-features/subs-properties-in-changelogs.md
+++ b/docs/database-devops/concepts-and-features/subs-properties-in-changelogs.md
@@ -19,6 +19,16 @@ The tokens to replace in your changelog are described using the `${property-name
 The supported format includes alphanumeric characters, +, -, . , and _. Example `${property+name}`
 :::
 
+
+:::important 
+**Minimum versions required**
+- db-devops-service - 1.35.x
+- drone-liquibase - plugins/drone-liquibase:1.2.0-4.27
+- drone-liquibase-mongo - plugins/drone-liquibase:1.2.0-4.27-mongo
+- drone-liquibase-spanner - plugins/drone-liquibase:1.2.0-4.27-spanner 
+:::
+
+
 ## Uses
 1. Environment-specific Names
 2. Reusability

--- a/docs/database-devops/concepts-and-features/subs-properties-in-changelogs.md
+++ b/docs/database-devops/concepts-and-features/subs-properties-in-changelogs.md
@@ -14,19 +14,20 @@ flexibility in database migration scripts.
 It decouples your database migration logic from environment-specific values, making the whole process of versioning and 
 deploying database changes far more efficient and scalable.
 
+:::important
+**Minimum versions required**
+- db-devops-service - 1.35.x
+- drone-liquibase - plugins/drone-liquibase:1.2.0-4.27
+- drone-liquibase-mongo - plugins/drone-liquibase:1.2.0-4.27-mongo
+- drone-liquibase-spanner - plugins/drone-liquibase:1.2.0-4.27-spanner
+:::
+
+
 :::info
 The tokens to replace in your changelog are described using the `${property-name}` syntax.
 The supported format includes alphanumeric characters, +, -, . , and _. Example `${property+name}`
 :::
 
-
-:::important 
-**Minimum versions required**
-- db-devops-service - 1.35.x
-- drone-liquibase - plugins/drone-liquibase:1.2.0-4.27
-- drone-liquibase-mongo - plugins/drone-liquibase:1.2.0-4.27-mongo
-- drone-liquibase-spanner - plugins/drone-liquibase:1.2.0-4.27-spanner 
-:::
 
 
 ## Uses


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

[DBOPS-936]: minimum version required info for substitution property
<img width="1019" alt="Screenshot 2025-04-25 at 4 03 10 PM" src="https://github.com/user-attachments/assets/9613458b-0142-4a3c-8893-d6a21c7226ea" />

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.


[DBOPS-936]: https://harness.atlassian.net/browse/DBOPS-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ