### PR TITLE
Reorganzied and simplified OPA section

### DIFF
--- a/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-connector.md
+++ b/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-connector.md
@@ -1,7 +1,7 @@
 ---
-title: Use Harness Policy As Code for connectors
-description: Describes steps to add policies to Connectors.
-sidebar_position: 5
+title: Policy as Code for connectors
+description: Learn how to use policies for connectors.
+sidebar_position: 70
 helpdocs_topic_id: 4kuokatvyw
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-pipeline.md
+++ b/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-pipeline.md
@@ -1,7 +1,7 @@
 ---
-title: Add a policy step to a pipeline
+title: Policy step
 description: Add a Policy step to your Stage.
-sidebar_position: 6
+sidebar_position: 4
 helpdocs_topic_id: xy8zsn8fa3
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-service-account.md
+++ b/docs/platform/governance/policy-as-code/add-a-governance-policy-step-to-a-service-account.md
@@ -1,7 +1,7 @@
 ---
-title: Use Harness Policy As Code for Service Account.
-description: Describes steps to add policies to Service Account.
-sidebar_position: 6
+title: Policy as Code for service accounts
+description: Learn how to use policy as code for a service account.
+sidebar_position: 80
 helpdocs_topic_id: 4kuokatvyw
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/add-a-policy-engine-step-to-a-secret.md
+++ b/docs/platform/governance/policy-as-code/add-a-policy-engine-step-to-a-secret.md
@@ -1,7 +1,7 @@
 ---
-title: Use Harness Policy as Code for secrets
-description: Add a Policy step to your Secret.
-sidebar_position: 4
+title: Policy as Code for secrets
+description: Learn how to use policy as code for secrets.
+sidebar_position: 60
 helpdocs_topic_id: ozw30qez44
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/aida-for-policies.md
+++ b/docs/platform/governance/policy-as-code/aida-for-policies.md
@@ -1,7 +1,7 @@
 ---
 title: Build policies using Harness AIDA
 description: Build Policies using Harness AIDA
-sidebar_position: 70
+sidebar_position: 120
 canonical_url: https://www.harness.io/blog/elevating-aida-harness-unveils-7-new-innovative-capabilities
 ---
 

--- a/docs/platform/governance/policy-as-code/configure-gitexperience-for-opa.md
+++ b/docs/platform/governance/policy-as-code/configure-gitexperience-for-opa.md
@@ -1,7 +1,7 @@
 ---
 title: Configure Git Experience for OPA
 description: Configure Git Experiemce for your policies.
-sidebar_position: 9
+sidebar_position: 110
 ---
 
 You can create policies and store them in your Git repository. These policies are called remote policies.

--- a/docs/platform/governance/policy-as-code/disable-a-policy-set.md
+++ b/docs/platform/governance/policy-as-code/disable-a-policy-set.md
@@ -1,5 +1,5 @@
 ---
-title: Enable or disable a policy set
+title: Enable/Disable a policy set
 description: Disable a Policy Set by locating the Policy Set and toggling the Enforced setting to off.
 sidebar_position: 3
 helpdocs_topic_id: 6lxxd5j8j5

--- a/docs/platform/governance/policy-as-code/harness-governance-overview.md
+++ b/docs/platform/governance/policy-as-code/harness-governance-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Harness Policy As Code overview
 description: Harness uses Open Policy Agent (OPA) to store and enforce policies for the Harness platform.
-sidebar_position: 2
+sidebar_position: 1
 helpdocs_topic_id: 1d3lmhv4jl
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/harness-governance-quickstart.md
+++ b/docs/platform/governance/policy-as-code/harness-governance-quickstart.md
@@ -1,7 +1,7 @@
 ---
-title: Harness Policy As Code quickstart
+title: Policy As Code quickstart
 description: Learn how to use OPA policies in Harness to enforce governance across your DevOps processes.
-sidebar_position: 8
+sidebar_position: 2
 helpdocs_topic_id: jws2znftay
 helpdocs_category_id: w6r9f17pk3
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/policy-as-code-faqs.md
+++ b/docs/platform/governance/policy-as-code/policy-as-code-faqs.md
@@ -1,7 +1,7 @@
 ---
 title: Policy as Code FAQs
 description: See sample policies and when to use them.
-sidebar_position: 80
+sidebar_position: 200
 ---
 
 This topic addresses some frequently asked questions about Policy as Code support in Harness.

--- a/docs/platform/governance/policy-as-code/sample-policy-use-case.md
+++ b/docs/platform/governance/policy-as-code/sample-policy-use-case.md
@@ -1,7 +1,7 @@
 ---
 title: Policy samples
 description: See sample policies and when to use them.
-sidebar_position: 6
+sidebar_position: 100
 canonical_url: https://www.harness.io/blog/feature-flags-best-practices
 ---
 

--- a/docs/platform/governance/policy-as-code/using-harness-policy-engine-for-feature-flags.md
+++ b/docs/platform/governance/policy-as-code/using-harness-policy-engine-for-feature-flags.md
@@ -1,7 +1,7 @@
 ---
-title: Use Harness Policy As Code for Feature Flags
+title: Policy As Code for Feature Flags
 description: This topic gives steps to create, update, and view policies and policy sets for Feature Flags.
-sidebar_position: 7
+sidebar_position: 90
 helpdocs_topic_id: vb6ilyz194
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false

--- a/docs/platform/governance/policy-as-code/using-policy-enforcement-on-pipeline-steps.md
+++ b/docs/platform/governance/policy-as-code/using-policy-enforcement-on-pipeline-steps.md
@@ -1,7 +1,7 @@
 ---
-title: Use Harness Policy As Code to enforce policies on steps
-description: Enforce policies on pipeline steps.
-sidebar_position: 8
+title: Enforce policies on steps
+description: Learn how to use policy as code to enforce policies on pipeline steps.
+sidebar_position: 5
 helpdocs_topic_id: vb6ilyz194
 helpdocs_category_id: zoc8fpiifm
 helpdocs_is_private: false


### PR DESCRIPTION
I changed the titles and sidebar ordering of policy as code section to hopefully make it easier to look through. 

## Before

![Screenshot 2025-04-28 at 1 42 26 PM](https://github.com/user-attachments/assets/2e8994a5-ecea-4931-a18c-dbff26462d1a)

## After

![Screenshot 2025-04-28 at 1 43 56 PM](https://github.com/user-attachments/assets/f500e2c0-6a23-44dc-a8b5-de62d5c74688)


