### PR TITLE
Fix log level indentation in gitleaks example

### DIFF
--- a/docs/security-testing-orchestration/custom-scanning/ingest-sarif-data.md
+++ b/docs/security-testing-orchestration/custom-scanning/ingest-sarif-data.md
@@ -60,7 +60,7 @@ Here's an example of how to configure a Gitleaks step to ingest a SARIF data fil
          variant: dev
       advanced:
          log:
-         level: debug
+           level: debug
       ingestion:
          file: /shared/scan_results/gitleaks.sarif
    description: gitleaks step


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: There was an issue with the log level indentation, which needed an additional 2 spaces. 
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
