### PR TITLE
Fixed broken STO tutorials link

### DIFF
--- a/docs/security-testing-orchestration/get-started/onboarding-guide.md
+++ b/docs/security-testing-orchestration/get-started/onboarding-guide.md
@@ -285,7 +285,7 @@ Now that you've set up Harness, you're ready to start using STO.
 
 A good next step is to go through [Your first STO pipeline](/docs/security-testing-orchestration/get-started/your-first-sto-pipeline). This tutorial covers the basic concepts of STO. You'll set up a standalone pipeline with one scanner, run scans, analyze the results, and learn how to investigate and fix detected vulnerabilities.
 
-The [STO tutorials](./tutorials) also include a set of quickstarts and end-to-end workflows that show you how to create pipelines that you can apply to a wide variety of security-related use cases. 
+The [STO tutorials](/docs/security-testing-orchestration/get-started/tutorials) also include a set of quickstarts and end-to-end workflows that show you how to create pipelines that you can apply to a wide variety of security-related use cases. 
 
 Happy scanning! 
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: The STO tutorial link at the end seems to be broken. I have replaced the link to use the full path to the correct doc. 
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): 

<img width="989" alt="image" src="https://github.com/user-attachments/assets/48b1382f-c389-4979-93c0-2bd10575d368" />

leads to 

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/64858e37-b89f-4d1e-8bff-f95d1150e407" />

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
