### PR TITLE
FMEPRD-151 Add April 16 Release Note

### DIFF
--- a/release-notes/feature-management-experimentation.md
+++ b/release-notes/feature-management-experimentation.md
@@ -13,7 +13,7 @@ import HarnessApiData from '../src/components/HarnessApiData/index.tsx';
 
 These release notes describe recent changes to Harness Feature Management & Experimentation (FME).
 
-#### Last updated: May 20, 2025
+#### Last updated: May 23, 2025
 
 
 ## April 2025

--- a/release-notes/feature-management-experimentation.md
+++ b/release-notes/feature-management-experimentation.md
@@ -49,7 +49,7 @@ This release makes it easier for teams to run experiments without requiring deep
 
 You can now configure how your React application responds to SDK lifecycle events using new props on the `<SplitFactoryProvider>` component. This allows you to set default reactivity behavior for all components in the application, reducing the need to configure each hook individually. 
 
-This is especially useful for use cases like suppressing UI updates during onboarding flows or session transactions. For example, setting `updateOnSdkUpdate={false}` at the root level disables re-renders triggered by flag changes until re-enabled.
+This is especially useful for use cases like suppressing UI updates during onboarding flows or session transactions. For example, setting `updateOnSdkUpdate={false}` at the root level (i.e., the `<SplitFactoryProvider>` component) disables updates of the `useSplitTreatments` hook triggered by flag changes until re-enabled.
 
 The following options are supported:
 

--- a/release-notes/feature-management-experimentation.md
+++ b/release-notes/feature-management-experimentation.md
@@ -13,7 +13,7 @@ import HarnessApiData from '../src/components/HarnessApiData/index.tsx';
 
 These release notes describe recent changes to Harness Feature Management & Experimentation (FME).
 
-#### Last updated: April 30, 2025
+#### Last updated: May 20, 2025
 
 
 ## April 2025
@@ -42,6 +42,39 @@ This release makes it easier for teams to run experiments without requiring deep
 #### Related documentation
 - [Experiments](https://help.split.io/hc/en-us/articles/35511708088077-Experiments)
 - [Experiment health check](https://help.split.io/hc/en-us/articles/35928892585741-Experiment-health-check)
+
+### [New Feature] Centralized control for React SDK flag update behavior
+----
+#### 2025-04-16
+
+You can now configure how your React application responds to SDK lifecycle events using new props on the `<SplitFactoryProvider>` component. This allows you to set default reactivity behavior for all components in the application, reducing the need to configure each hook individually. 
+
+This is especially useful for use cases like suppressing UI updates during onboarding flows or session transactions. For example, setting `updateOnSdkUpdate={false}` at the root level disables re-renders triggered by flag changes until re-enabled.
+
+The following options are supported:
+
+- `updateOnSdkReady`
+- `updateOnSdkReadyFromCache`
+- `updateOnSdkTimedout`
+- `updateOnSdkUpdate`
+
+These settings apply to all nested hooks and components unless explicitly overridden.
+
+For example:
+
+```javascript
+const App = () => (
+  <SplitFactoryProvider 
+    config={sdkConfig} 
+    updateOnSdkUpdate={false} // Disables SDK_UPDATE-triggered re-renders for all child components
+  >
+    <MyApp />
+  </SplitFactoryProvider>
+);
+```
+
+#### Related documentation
+- [React SDK](https://help.split.io/hc/en-us/articles/360038825091-React-SDK#subscribe-to-events)
 
 ### [New Feature] Append impression properties
 ----


### PR DESCRIPTION
## Description

* Please describe your changes: Adds a release note from April that documents the ability to centralize control for flag update behavior in the React SDK.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/FMEPRD-151
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
