### PR TITLE
Ensure consistent FF

### DIFF
--- a/release-notes/continuous-integration.md
+++ b/release-notes/continuous-integration.md
@@ -69,7 +69,7 @@ This update is currently being rolled out to customers, and we expect the rollou
 
 - Previously, CI stage timeouts for Kubernetes infrastructure were limited to a maximum of 24 hours. Some stages, however, require longer timeouts. Harness CI now supports stage timeouts of up to 35 days for Kubernetes-based CI stages. To enable this functionality, set the desired timeout value (greater than 24 hours) in the **Overview** section of the CI stage. (CI-15102, ZD-72737)
 
-  This feature is behind the feature flag `CI_ENABLE_MAX_TIMEOUT_K8`. 
+  This feature is behind the feature flag `CI_ENABLE_LONG_TIMEOUTS`. 
 
 #### Fixed issues
 


### PR DESCRIPTION
Ensure consistent FF which is CI_ENABLE_LONG_TIMEOUTS instead of CI_ENABLE_MAX_TIMEOUT_K8.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Ensure consistent FF which is CI_ENABLE_LONG_TIMEOUTS instead of CI_ENABLE_MAX_TIMEOUT_K8.
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
