### PR TITLE
Add documentation for S3 support in Harness Open Source artifact registry

### DIFF
--- a/docs/code-repository/work-in-repos/clone-repos.md
+++ b/docs/code-repository/work-in-repos/clone-repos.md
@@ -24,3 +24,27 @@ After [creating a repository](../config-repos/create-repo.md), you can work dire
    When cloning the repository, you will be prompted for your Harness user name and the API token, which were shown when you generated clone credentials.
 
 4. Once cloned locally, you can work with your Harness Code repository as you would with other Git repositories, by creating commits, pushing to the remote, pulling changes, and more.
+
+## Partial and Shallow Clone Support (Filtering in git clone)
+
+Harness Code Repository supports filtering during git clone operations to improve performance, especially for large monorepos or multi-service repositories.
+
+When cloning large repositories, the default behavior of Git downloads the entire commit history and all associated blobs/trees, resulting in significant bandwidth usage and long clone times. To address this, you can use Git’s built-in partial clone and shallow clone features with Harness-hosted repositories.
+
+You can use the `--filter` flag with git clone against Harness Code Repositories:
+
+```
+git clone --filter=blob:none <REPO_URL>
+```
+
+This reduces the amount of data transferred during clone by excluding blobs initially. They are fetched lazily only when needed.
+
+You can also combine this with shallow clone options:
+
+```
+git clone --depth=1 --filter=blob:none <REPO_URL>
+```
+
+:::note
+Make sure your Git version is 2.19 or later to use filtering options.
+:::

--- a/docs/open-source/registries/artifacts.md
+++ b/docs/open-source/registries/artifacts.md
@@ -54,3 +54,17 @@ If you want to pull a specific version of an artifact, do the following.
 2. Choose your version. 
 3. Copy the **Download Command** for your artifact.
 4. Use the **Download Command** where you want to download your artifact. Make sure you are logged into the registry there first. 
+
+### Using S3 for Artifact Storage
+
+Harness Open Source supports storing artifacts on an S3-compatible storage backend. This is useful if you want to externalize artifact storage outside the local filesystem (e.g., for persistence across container restarts or for horizontal scaling).
+
+To configure S3 as your artifact storage backend, set the following environment variables during installation:
+
+```
+GITNESS_REGISTRY_S3_REGION_ENDPOINT=<your-S3-endpoint>
+GITNESS_REGISTRY_S3_ACCESS_KEY=<your-access-key>
+GITNESS_REGISTRY_S3_SECRET_KEY=<your-secret-key>
+GITNESS_REGISTRY_S3_REGION=<your-aws-region>
+GITNESS_REGISTRY_S3_BUCKET=<your-S3-bucket>
+```


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: This update adds a new section to the Artifact Registry documentation to outline support for using S3-compatible storage backends (AWS S3) for storing artifacts. The section includes the required environment variables (GITNESS_REGISTRY_S3_*) and usage notes. This helps users externalize and persist artifact storage beyond the local filesystem.
* Jira/GitHub Issue numbers (if any): CODE-3854
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
