### PR TITLE
Clarify ECR authentication for private repositories in Docker connector setup

### DIFF
--- a/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
+++ b/docs/platform/connectors/artifact-repositories/connect-to-harness-container-image-registry-using-docker-connector.md
@@ -181,6 +181,10 @@ Create a [Docker connector](/docs/platform/connectors/cloud-providers/ref-cloud-
 
    ![](../static/connect-to-harness-container-image-registry-using-docker-connector-49.png)
 
+### Authentication Considerations for Amazon ECR Private Repositories
+
+You can configure a Docker connector in Harness to authenticate and pull images from your private registry. You can either create your own Docker connector or use the built-in account-level Harness Docker connector (`harnessImage`). When configuring a Docker connector to access an Amazon ECR private repository, you must provide a username and password for authentication. According to [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token), the authentication token obtained via the `aws ecr get-login-password` command is valid for 12 hours. Therefore, to maintain uninterrupted access, you need to update the connector with a new token every 12 hours. This requirement applies only to private ECR repositories. For public ECR repositories, you can configure the connector to use anonymous access, which does not require token-based authentication.
+
 ## Connector selection hierarchy
 
 <!-- CDS-82080/CI-11611 -->


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: This update clarifies the behavior when connecting to private Amazon ECR repositories using a Docker connector in Harness. Specifically, it notes that authentication tokens for private ECR repositories expire every 12 hours (per AWS documentation), requiring periodic updates to the connector credentials. The update also specifies that the built-in harnessImage connector is an account-level Docker connector, and distinguishes between authentication requirements for private and public ECR repositories. 

The reviewer to check if the doc update was made to the right section in addition to regular review.

* Jira/GitHub Issue numbers (if any): CI-17171
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
