### PR TITLE
Update key-concepts.md to clarify when projects and env level perms move

### DIFF
--- a/docs/feature-management-experimentation/10-getting-started/docs/key-concepts.md
+++ b/docs/feature-management-experimentation/10-getting-started/docs/key-concepts.md
@@ -71,7 +71,7 @@ import FMEArchitectureObjectsImage from '@site/docs/feature-management-experimen
 <FMEArchitectureObjectsImage />
 
 :::info[Note: Split Legacy settings locations]
-Post migration to app.harness.io, Split legacy Project permissions,  Change permissions and Data export permissions (marked in purple above) will move out of their current locations and into Harness RBAC management.
+Post migration to app.harness.io, Split legacy Project permissions,  Change permissions and Data export permissions (marked in purple above) will move out of their current locations and into Harness RBAC management. The first to move will be Project permissions in "part one" of the migration.  Environment-level change and data export permissions will move in "part two" of the migration.
 
 New Admin API Key creation and management will move to Harness Service Accounts.  Existing Split legacy Admin API Keys will continue to operate until revoked in the Split legacy location.
 :::


### PR DESCRIPTION
Project level permissions (aka "view restrictions") move to RBAC in Phase Two, Part One.  This is "day one" of being migrated to Harness.

Environment-level permissions move to RBAC in Phase Two, Part Two.  This part, often referred to as "granular permissions management" was originally scheduled for early Summer 2025 but will move into fall somewhere most likely.  Phase Two, Part Two also includes object-level permissions moving to RBAC in that same time frame.  Example: who can edit this flag in particular.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
