### PR TITLE
Fix link to Terraform how-tos page from terraform-provisioning-with-harness

### DIFF
--- a/docs/continuous-delivery/cd-infrastructure/terraform-infra/terraform-provisioning-with-harness.md
+++ b/docs/continuous-delivery/cd-infrastructure/terraform-infra/terraform-provisioning-with-harness.md
@@ -16,7 +16,7 @@ Harness can provision any resource that is supported by a Terraform [provider o
 
 :::note
 
-Looking for how-tos? See [Terraform how-tos](terraform-how-tos).
+Looking for how-tos? See [Terraform how-tos](/docs/continuous-delivery/cd-infrastructure/terraform-infra/terraform-how-to).
 
 :::
 


### PR DESCRIPTION
The link to the Terraform how-tos page points to the wrong place and thus results in a 404 - it currently links to [this route instead](https://developer.harness.io/docs/continuous-delivery/cd-infrastructure/terraform-infra/terraform-provisioning-with-harness/terraform-how-tos). Updated to link to terraform-how-tos.md

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: The link to the Terraform how-tos page points to the wrong place and thus results in a 404 - it currently links to [this route instead](https://developer.harness.io/docs/continuous-delivery/cd-infrastructure/terraform-infra/terraform-provisioning-with-harness/terraform-how-tos). Updated to link to terraform-how-tos.md
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
