### PR TITLE
docs: [IAC-3942]: Add approval resources uage admonition

### DIFF
--- a/docs/infra-as-code-management/get-started/get-started.md
+++ b/docs/infra-as-code-management/get-started/get-started.md
@@ -215,6 +215,10 @@ The Provision operation adds three Terraform plugin steps: `init`, `plan`, and `
 ### Add an Approval step (optional)
 You can add the Approval step to prompt a review of the previous pipeline before proceeding to the next. The most common use case would be to add the Approval step between the `plan` and `apply` steps to ensure you are happy with the infrastructure changes and estimated costs (if `cost estimation` is enabled on your Workspace) that come with them before applying them.
 
+:::warning Approval steps hold resources
+When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources. Plan accordingly to avoid resource locking or cost surprises.
+:::
+
 <Tabs>
 <TabItem value="Interactive guide">
 <DocVideo src="https://app.tango.us/app/embed/3efdb37e-0d97-4875-a0b2-91fd4442cbe9" title="Add an IaCM Approval step to your provision pipeline" />

--- a/docs/infra-as-code-management/get-started/get-started.md
+++ b/docs/infra-as-code-management/get-started/get-started.md
@@ -216,7 +216,7 @@ The Provision operation adds three Terraform plugin steps: `init`, `plan`, and `
 You can add the Approval step to prompt a review of the previous pipeline before proceeding to the next. The most common use case would be to add the Approval step between the `plan` and `apply` steps to ensure you are happy with the infrastructure changes and estimated costs (if `cost estimation` is enabled on your Workspace) that come with them before applying them.
 
 :::warning Approval steps hold resources
-When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources. Plan accordingly to avoid resource locking or cost surprises.
+When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources.
 :::
 
 <Tabs>

--- a/docs/infra-as-code-management/pipelines/operations/approval-step.md
+++ b/docs/infra-as-code-management/pipelines/operations/approval-step.md
@@ -10,7 +10,6 @@ import TabItem from '@theme/TabItem';
 If you want to see the result and impact of the Terraform plan before applying it against the resources, you can add an approval step to your flow. 
 
 The approval step provides the following information:
-
 *  The resources that were added (including Terraform outputs).
 *  The resources that were deleted.
 *  The resources that were changed.
@@ -18,6 +17,10 @@ The approval step provides the following information:
 *  OPA rules that were evaluated so far in the flow.
 
 Once you've reviewed the plan and are confident in the proposed changes, you can approve it. Approving the plan acknowledges that you understand the modifications that will be made to your infrastructure.
+
+:::warning Approval steps hold resources
+When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources. Plan accordingly to avoid resource locking or cost surprises.
+:::
 
 To use the approval plan step, perform the following steps:
 

--- a/docs/infra-as-code-management/pipelines/operations/approval-step.md
+++ b/docs/infra-as-code-management/pipelines/operations/approval-step.md
@@ -19,7 +19,7 @@ The approval step provides the following information:
 Once you've reviewed the plan and are confident in the proposed changes, you can approve it. Approving the plan acknowledges that you understand the modifications that will be made to your infrastructure.
 
 :::warning Approval steps hold resources
-When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources. Plan accordingly to avoid resource locking or cost surprises.
+When using an Approval step, the underlying machine running the pipeline remains active until the approval is resolved. This means it will continue consuming compute resources.
 :::
 
 To use the approval plan step, perform the following steps:


### PR DESCRIPTION
## Description

* Add 'warning' admonition to let users know that approval steps use resources until the step is resolved
* [JIRA](https://harness.atlassian.net/browse/IAC-3942)

### Screenshot / Preview
![CleanShot 2025-06-15 at 19 21 31](https://github.com/user-attachments/assets/2b9b12d7-64f4-42cd-a849-e5c025c4b4dc)


PRs must meet these requirements to be merged:
- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.