### PR TITLE
RN - Added support for an alternative method to fetch Jenkins job details when the queueItem API returns null

### DIFF
--- a/release-notes/delegate.md
+++ b/release-notes/delegate.md
@@ -88,6 +88,12 @@ For more information, go to [Delegate expiration support policy](/docs/platform/
 
 ## June 2025
 
+### Version 25.06.86102 <!-- June 26, 2025 -->
+
+#### Fixed issues
+
+- Added support for an alternative method to fetch Jenkins job details when the queueItem API returns null. [CDS-109699]
+
 ### Version 25.06.86101 <!-- June 19, 2025 -->
 
 #### Fixed issues


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Added support for an alternative method to fetch Jenkins job details when the queueItem API returns null
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/CDS-109699
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
