### PR TITLE
Adding KB article for dynamic inputset reference selection based on git push trigger

### DIFF
--- a/kb/platform/articles/pipeline-trigger-dynamic-inputsetref.md
+++ b/kb/platform/articles/pipeline-trigger-dynamic-inputsetref.md
@@ -1,5 +1,5 @@
 
-# Harness Dynamic Input Set Referencing on Git Event triggers
+# Dynamic Input Set Referencing on Git Event triggers
 
 ## Preface
 

--- a/kb/platform/articles/pipeline_trigger_dynamic_inputsetref.md
+++ b/kb/platform/articles/pipeline_trigger_dynamic_inputsetref.md
@@ -1,0 +1,88 @@
+
+# Harness Dynamic Input Set Referencing on Git Event triggers
+
+## Preface
+
+Before diving in, it’s important to reiterate that this is **not** Harness’s preferred method for selecting Input Sets based on the triggering branch. The recommended and most maintainable approach is to configure a dedicated trigger per watched branch, using explicit branch conditions. This approach is more declarative and aligns better with Harness's design philosophy.
+
+However, given certain edge cases and constraints presented by a customer group, the following outlines a best-effort solution for dynamically selecting an Input Set at runtime based on the triggering branch.
+
+## GitHub-Specific Considerations
+
+This approach requires some awareness of the structure of GitHub webhook payloads. In particular, Harness does **not** support using `trigger.targetBranch` or similar derived fields at the time of Input Set resolution. Instead, only `trigger.payload` fields are available when selecting an Input Set dynamically.
+
+You can reference any field from the payload using:
+
+```
+<+trigger.payload.<json-path>>
+```
+
+For example, with a typical GitHub push event payload:
+
+```json
+{
+  "ref": "refs/heads/main",
+  "before": "4937e6ceccd8ea253ab83564e92ce84603445a97",
+  "after": "7a35b6cc861f68c4ad0d0b07394912f889150389",
+  "repository": {}
+  ...
+}
+```
+
+The `ref` field would be accessed in Harness using:
+
+```
+<+trigger.payload.ref>
+```
+
+This is especially important because `ref` is typically the only field in the GitHub payload that contains the branch name. Despite its verbose format (`refs/heads/<branch>`), it is our key to dynamic selection.
+
+## Dynamic Input Set Selection Logic
+
+In your trigger YAML, you can parse the branch name and use it to dynamically reference an Input Set by ID:
+
+```yaml
+trigger:
+  name: test
+  identifier: test
+  enabled: true
+  description: "Example trigger for dynamic Input Set selection based on branch"
+  orgIdentifier: Demo
+  projectIdentifier: customer_demo
+  pipelineIdentifier: kubernetes_secret_cleanup
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.gitconnector
+          repoName: examples
+  inputSetRefs: <+[<+trigger.payload.ref>.split("/").get(2)]>
+```
+
+### Explanation of the Key Line
+
+```yaml
+inputSetRefs: <+[<+trigger.payload.ref>.split("/").get(2)]>
+```
+
+- `trigger.payload.ref` gives us the full reference string (`refs/heads/main`).
+- `.split("/")` splits it into `["refs", "heads", "main"]`.
+- `.get(2)` retrieves the branch name (`main`). (Lists in JEXL are 0 indexed, so the third item is always 2. You could have a second `<+trigger.payload.ref>.split("/").length -1` but that wasn’t necessary for this example.)
+- Wrapping it in `[ ... ]` returns it as a single-item list, which is required by the `inputSetRefs` field.
+
+This approach works **only** if your Input Set ID matches your branch name exactly (note: **ID**, not display name).
+
+## Final Notes
+
+This method can be a useful workaround in scenarios where:
+
+- You want to maintain a single trigger across many branches.
+- Your Input Sets are structured to mirror branch names.
+- You’re unable to manage a growing set of per-branch triggers.
+
+That said, it's worth reiterating: the **officially recommended strategy** is to use multiple explicitly defined triggers per branch for clarity, auditability, and long-term maintainability.
+
+This behavior will need to be adjusted for a different naming convention or if the Git provider varies (e.g., GitLab, Bitbucket).

--- a/kb/platform/pipeline-faq.md
+++ b/kb/platform/pipeline-faq.md
@@ -352,7 +352,7 @@ Yes, Harness NextGen supports both the QUARTZ and UNIX syntax formats for cron t
 
 ### Can i select an inputSetRef based on the branch that triggers a git event?
 
-Although not recommended, this is possible. see the writeup here: [Dynamically selecting an inputSetRef based on triggering branch](/kb/platform/articles/pipeline-trigger-inputsetref.md)
+Although not recommended, this is possible. see the writeup here: [Dynamically selecting an inputSetRef based on triggering branch](/kb/platform/articles/pipeline-trigger-dynamic-inputsetref.md)
 
 ## Stop pipelines
 

--- a/kb/platform/pipeline-faq.md
+++ b/kb/platform/pipeline-faq.md
@@ -350,6 +350,10 @@ There is no limit to the number of triggers for a pipeline.
 
 Yes, Harness NextGen supports both the QUARTZ and UNIX syntax formats for cron triggers. For more information, go to [Schedule Pipelines Using Cron Triggers](/docs/platform/triggers/schedule-pipelines-using-cron-triggers/#schedule-the-trigger).
 
+### Can i select an inputSet based on the branch that triggers a git event?
+
+Although not recommended, this is possible. see the writeup here: [Dynamically selecting an inputSetRef based on triggering branch] (./articles/pipeline-trigger-inputsetref.md)
+
 ## Stop pipelines
 
 ### What is expected when I abort a pipeline, and what actions are taken to ensure a clean state in the system?

--- a/kb/platform/pipeline-faq.md
+++ b/kb/platform/pipeline-faq.md
@@ -350,9 +350,9 @@ There is no limit to the number of triggers for a pipeline.
 
 Yes, Harness NextGen supports both the QUARTZ and UNIX syntax formats for cron triggers. For more information, go to [Schedule Pipelines Using Cron Triggers](/docs/platform/triggers/schedule-pipelines-using-cron-triggers/#schedule-the-trigger).
 
-### Can i select an inputSet based on the branch that triggers a git event?
+### Can i select an inputSetRef based on the branch that triggers a git event?
 
-Although not recommended, this is possible. see the writeup here: [Dynamically selecting an inputSetRef based on triggering branch] (./articles/pipeline-trigger-inputsetref.md)
+Although not recommended, this is possible. see the writeup here: [Dynamically selecting an inputSetRef based on triggering branch](/kb/platform/articles/pipeline-trigger-inputsetref.md)
 
 ## Stop pipelines
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: 
    Added a KB article to go over the basic workflow and considerations for having a git push event select an inputset based on the branch name of the triggering branch without needing to create a trigger per-branch. this was based on a customer ask and was an interesting use case. 

* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
