### PR TITLE
Update Get Started > FME Tile in HDH Landing Page

### DIFF
--- a/src/components/HomepageFeatures/data/featureListData.tsx
+++ b/src/components/HomepageFeatures/data/featureListData.tsx
@@ -54,7 +54,7 @@ export const featureList: CardItem[] = [
     link: "docs/category/get-started-with-feature-flags",
   },
   {
-    title: "Feature Management & Experimentation",
+    title: "Release with Feature Management & Experimentation",
     module: MODULES.fme,
     icon: "img/icon_fme.svg",
     description: <>Switch on data-driven features and releases.</>,


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: The tile for FME states the product module, but to be consistent with the other tiles, so we are suggesting a verb + product module structure. Just noticed this while navigating through the HDH landing page.
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
