### PR TITLE
fix: [ML-1134]: Fix harness MCP server url

### DIFF
--- a/docs/platform/harness-aida/harness-mcp-server.md
+++ b/docs/platform/harness-aida/harness-mcp-server.md
@@ -175,8 +175,8 @@ HARNESS_DEFAULT_PROJECT_ID=your_project_id \
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/harness/harness-mcp.git  
-cd harness-mcp
+git clone https://github.com/harness/mcp-server  
+cd mcp-server
 ```
 
 2. Build the binary:


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Fix the MCP repo URL to https://github.com/harness/mcp-server
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/ML-1134
* Preview links/images (Internal contributors only): 
<img width="840" alt="image" src="https://github.com/user-attachments/assets/019b348a-16aa-44a5-820b-2919dec9c14a" />


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
