### PR TITLE
feature: DynamicMarkdownSelector redirects

### DIFF
--- a/_server-redirects
+++ b/_server-redirects
@@ -132,9 +132,4 @@ docs/self-managed-enterprise-edition/monitor-harness-on-prem#view-metrics-on-the
 
 /docs/self-managed-enterprise-edition/advanced-configurations/external-db/use-an-external-redis-database /docs/self-managed-enterprise-edition/advanced-configurations/external-db/redis/use-an-external-redis-database
 
-#Dynamic content redirects
-# Artifact Registry
-# Supported Formats redirect to dynamic selector tile
-/artifact-registry/content/supported-formats/nuget-quickstart /artifact-registry/supported-formats#nuget
-
 # Redirects generated from Front Matter [sytem generated goes below here]:

--- a/_server-redirects
+++ b/_server-redirects
@@ -132,9 +132,9 @@ docs/self-managed-enterprise-edition/monitor-harness-on-prem#view-metrics-on-the
 
 /docs/self-managed-enterprise-edition/advanced-configurations/external-db/use-an-external-redis-database /docs/self-managed-enterprise-edition/advanced-configurations/external-db/redis/use-an-external-redis-database
 
-# Redirects generated from Front Matter [sytem generated goes below here]:
-
 #Dynamic content redirects
 # Artifact Registry
 # NuGet redirect to dynamic selector tile
 /docs/artifact-registry/content/supported-formats/nuget-quickstart /docs/artifact-registry/supported-formats#nuget
+
+# Redirects generated from Front Matter [sytem generated goes below here]:

--- a/_server-redirects
+++ b/_server-redirects
@@ -133,3 +133,8 @@ docs/self-managed-enterprise-edition/monitor-harness-on-prem#view-metrics-on-the
 /docs/self-managed-enterprise-edition/advanced-configurations/external-db/use-an-external-redis-database /docs/self-managed-enterprise-edition/advanced-configurations/external-db/redis/use-an-external-redis-database
 
 # Redirects generated from Front Matter [sytem generated goes below here]:
+
+#Dynamic content redirects
+# Artifact Registry
+# NuGet redirect to dynamic selector tile
+/docs/artifact-registry/content/supported-formats/nuget-quickstart /docs/artifact-registry/supported-formats#nuget

--- a/_server-redirects
+++ b/_server-redirects
@@ -134,7 +134,7 @@ docs/self-managed-enterprise-edition/monitor-harness-on-prem#view-metrics-on-the
 
 #Dynamic content redirects
 # Artifact Registry
-# NuGet redirect to dynamic selector tile
-/docs/artifact-registry/content/supported-formats/nuget-quickstart /docs/artifact-registry/supported-formats#nuget
+# Supported Formats redirect to dynamic selector tile
+/artifact-registry/content/supported-formats/nuget-quickstart /artifact-registry/supported-formats#nuget
 
 # Redirects generated from Front Matter [sytem generated goes below here]:

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,5 +1,7 @@
 ---
-redirect_to: /docs/artifact-registry/supported-formats/#nuget
+redirect_to:
+  - /docs/artifact-registry/supported-formats#nuget
+hide_table_of_contents: true
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,8 +1,9 @@
+---
+redirect_to: /artifact-registry/supported-formats#nuget
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import RedirectIfStandalone from '@site/src/components/DynamicMarkdownSelector/RedirectIfStandalone';
-
-<RedirectIfStandalone label="NuGet" targetPage="/docs/artifact-registry/supported-formats" />
 
 Learn how to **create a NuGet Artifact Registry**, **configure an upstream proxy**, and **publish or install NuGet packages** using the CLI.
 

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,6 +1,6 @@
 ---
-redirect_to:
-  - /docs/artifact-registry/supported-formats#nuget
+redirect_from:
+- /docs/artifact-registry/content/supported-formats/nuget-quickstart /docs/artifact-registry/supported-formats#nuget
 hide_table_of_contents: true
 ---
 

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: /artifact-registry/supported-formats#nuget
+redirect_from: /artifact-registry/supported-formats#nuget
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,9 +1,3 @@
----
-redirect_from:
-- /docs/artifact-registry/content/supported-formats/nuget-quickstart /docs/artifact-registry/supported-formats#nuget
-hide_table_of_contents: true
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
+++ b/docs/artifact-registry/content/supported-formats/nuget-quickstart.md
@@ -1,5 +1,5 @@
 ---
-redirect_from: /artifact-registry/supported-formats#nuget
+redirect_to: /docs/artifact-registry/supported-formats/#nuget
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/artifact-registry/supported-formats.md
+++ b/docs/artifact-registry/supported-formats.md
@@ -2,8 +2,6 @@
 title: Supported Formats
 description: Learn about supported formats in your workspace tabs. 
 sidebar_position: 10
-redirect_from:
-  - /docs/artifact-registry/content/supported-formats/nuget-quickstart
 ---
 
 import DynamicMarkdownSelector from '@site/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector';

--- a/docs/artifact-registry/supported-formats.md
+++ b/docs/artifact-registry/supported-formats.md
@@ -2,6 +2,8 @@
 title: Supported Formats
 description: Learn about supported formats in your workspace tabs. 
 sidebar_position: 10
+redirect_from:
+  - /docs/artifact-registry/content/supported-formats/nuget-quickstart
 ---
 
 import DynamicMarkdownSelector from '@site/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector';

--- a/docs/artifact-registry/supported-formats.md
+++ b/docs/artifact-registry/supported-formats.md
@@ -2,6 +2,15 @@
 title: Supported Formats
 description: Learn about supported formats in your workspace tabs. 
 sidebar_position: 10
+redirect_from: 
+  - /docs/artifact-registry/content/supported-formats/nuget-quickstart
+  - /docs/artifact-registry/content/supported-formats/python-quickstart
+  - /docs/artifact-registry/content/supported-formats/rpm-quickstart
+  - /docs/artifact-registry/content/supported-formats/helm-quickstart
+  - /docs/artifact-registry/content/supported-formats/generic-quickstart
+  - /docs/artifact-registry/content/supported-formats/npm-quickstart
+  - /docs/artifact-registry/content/supported-formats/maven-quickstart
+  - /docs/artifact-registry/content/supported-formats/docker-quickstart
 ---
 
 import DynamicMarkdownSelector from '@site/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector';


### PR DESCRIPTION
## Description
* Add `redirect_to` to child markdown file to test redirects as the Redirect component only works locally due to Docusaurus static page load.

### Screenshot / Preview
#### Current behaviour
https://github.com/user-attachments/assets/29b936d8-54ca-41a3-85ad-a18acf4c3b47

#### Desired behaviour
https://github.com/user-attachments/assets/5f863494-fbce-43a3-a473-184f7cb64bcd

PRs must meet these requirements to be merged:
- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.