### PR TITLE
Fix broken FAQ link.

### DIFF
--- a/kb/continuous-integration/continuous-integration-faqs.md
+++ b/kb/continuous-integration/continuous-integration-faqs.md
@@ -2626,7 +2626,7 @@ If your builds time out with this error during stage initialization, and you're 
 
 ### Can I get logs for a service running on Harness Cloud when a specific Run step is executing?
 
-Yes. To do this, you can add a step that runs in parallel to the Run step, and have that parallel step get the service's logs while the build runs. For an example, go to [Use a parallel step to monitor failures](./articles/parallel-step-for-logging).
+Yes. To do this, you can add a step that runs in parallel to the Run step, and have that parallel step get the service's logs while the build runs. For an example, go to [Use a parallel step to monitor failures](/kb/continuous-integration/articles/parallel-step-for-logging).
 
 ### How to get the build ID of a pipeline execution?
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: On https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs/#can-i-get-logs-for-a-service-running-on-harness-cloud-when-a-specific-run-step-is-executing, there's a broken link https://developer.harness.io/kb/continuous-integration/continuous-integration-faqs/articles/parallel-step-for-logging which should actually point to https://developer.harness.io/kb/continuous-integration/articles/parallel-step-for-logging
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
