### PR TITLE
Add GitHub App Token Plugin Doc and Cross-Link from Existing PAT Article

### DIFF
--- a/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
+++ b/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
@@ -1,6 +1,6 @@
 ---
 title: Using GitHub App Tokens Securely in Harness CI Pipelines
-description: Learn how to securely authenticate GitHub API calls in Harness CI pipelines using GitHub App tokens and the community plugin for ephemeral token generation.
+description: Learn how to securely authenticate GitHub API calls in Harness CI pipelines using GitHub App tokens and the Drone plugin for ephemeral token generation.
 sidebar_position: 20
 ---
 
@@ -69,7 +69,6 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
 <+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_INSTALLATION_ID>
 <+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_SLUG>
 ```
-* The JWT is used to authenticate as the GitHub App and generate the installation token. The JWT expires after 10 minutes by design, but the installation token — which grants actual repo access — lasts for 60 minutes.
 :::
 
 ## Best Practices

--- a/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
+++ b/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
@@ -15,8 +15,6 @@ When interacting with GitHub from CI pipelines, authentication is required for a
 
 This guide walks through a modern, flexible solution that uses a GitHub App to generate short-lived tokens at runtime, powered by a [Harness-compatible plugin](https://github.com/harness-community/drone-github-app-token).
 
----
-
 ## Limitations of Static Tokens and Legacy Approaches
 
 Earlier approaches involved scripting token generation by manually crafting JWTs, calling GitHub APIs, and injecting tokens into Harness pipelines via a custom secret manager. While functional, this method:
@@ -26,8 +24,6 @@ Earlier approaches involved scripting token generation by manually crafting JWTs
 * **Did not work reliably in Harness Cloud**, often failing silently or returning incorrect data.
 
 For details on the previous approach, see [this KB article](/kb/continuous-integration/articles/github-app-pat-dispenser/).
-
----
 
 ## Recommended Solution: GitHub App Token Plugin
 
@@ -40,8 +36,6 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
 * Tokens are **ephemeral**, scoped to the pipeline.
 * Securely injected as output variables.
 * Works in **Harness Cloud environments** without special configuration.
-
----
 
 ## Example: Using GitHub App Token in a CI Pipeline
 
@@ -75,8 +69,7 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
 * `private_key`: Must be stored in Harness as a **File-type Secret**.
 * `connectorRef`: Docker connector that can pull the plugin image.
 * The token can also be passed as an environment variable (`GH_TOKEN`) if you're using the GitHub CLI.
-
----
+* The JWT is used to authenticate as the GitHub App and generate the installation token. The JWT expires after 10 minutes by design, but the installation token — which grants actual repo access — lasts for 60 minutes.
 
 ## Best Practices
 
@@ -84,11 +77,4 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
 * Use scoped permissions on your GitHub App to follow the principle of least privilege.
 * Pass the generated token only between pipeline steps — avoid logging or persisting it.
 
----
-
-## Troubleshooting
-
-* Ensure your `private_key` secret is uploaded as **file type**, not plaintext.
-* Confirm the plugin step succeeded by checking `output.outputVariables.GITHUB_APP_TOKEN`.
-* Tokens expire after a short time (\~10 minutes). Use them immediately in the next step.
 

--- a/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
+++ b/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
@@ -1,0 +1,94 @@
+---
+title: Using GitHub App Tokens Securely in Harness CI Pipelines
+description: Learn how to securely authenticate GitHub API calls in Harness CI pipelines using GitHub App tokens and the community plugin for ephemeral token generation.
+sidebar_position: 20
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+When interacting with GitHub from CI pipelines, authentication is required for actions like creating pull requests, committing code, or accessing private repositories. Traditionally, this was done using static personal access tokens (PATs), but this approach comes with significant drawbacks:
+
+* **Rate limits** for user tokens are low.
+* **Security risks** from hardcoded secrets or token exposure.
+* **User binding** ties activity to a specific person rather than a system identity.
+
+This guide walks through a modern, flexible solution that uses a GitHub App to generate short-lived tokens at runtime, powered by a Harness-compatible plugin.
+
+---
+
+## Limitations of Static Tokens and Legacy Approaches
+
+Earlier approaches involved scripting token generation by manually crafting JWTs, calling GitHub APIs, and injecting tokens into Harness pipelines via a custom secret manager. While functional, this method:
+
+* Was **cumbersome and error-prone**.
+* Required external scripts and secret manager setup.
+* **Did not work reliably in Harness Cloud**, often failing silently or returning incorrect data.
+
+For details on the previous approach, see [this KB article](/kb/continuous-integration/articles/github-app-pat-dispenser/).
+
+---
+
+## Recommended Solution: GitHub App Token Plugin
+
+Harness now supports a more robust and cloud-compatible method using the open source [`drone-github-app-token`](https://github.com/harness-community/drone-github-app-token) plugin.
+
+This plugin generates GitHub App installation tokens securely during pipeline execution. It eliminates the need for PATs or static secrets and enables you to use the token immediately in subsequent steps.
+
+### Key Benefits
+
+* Tokens are **ephemeral**, scoped to the pipeline.
+* Securely injected as output variables.
+* Works in **Harness Cloud environments** without special configuration.
+
+---
+
+## Example: Using GitHub App Token in a CI Pipeline
+
+```yaml
+- step:
+    identifier: Generate_GitHub_Token
+    type: Plugin
+    name: Generate GitHub App Token
+    spec:
+      connectorRef: YOUR_DOCKER_CONNECTOR
+      image: plugins/github-app-token:latest
+      settings:
+        app_id: "YOUR_GITHUB_APP_ID"
+        private_key: <+secrets.getValue("YOUR_GITHUB_APP_KEY")>  # Secret of type "File"
+        permission_contents: write
+
+- step:
+    identifier: Use_Token
+    type: Run
+    name: Use GitHub Token
+    spec:
+      shell: Sh
+      command: |
+        curl -H "Authorization: token <+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_TOKEN>" \
+             https://api.github.com/repos/YOUR_ORG/YOUR_REPO/contents
+```
+
+### Notes:
+
+* `app_id`: GitHub App ID (numeric).
+* `private_key`: Must be stored in Harness as a **File-type Secret**.
+* `connectorRef`: Docker connector that can pull the plugin image.
+* The token can also be passed as an environment variable (`GH_TOKEN`) if you're using the GitHub CLI.
+
+---
+
+## Best Practices
+
+* Use Harness Secrets for all sensitive data.
+* Use scoped permissions on your GitHub App to follow the principle of least privilege.
+* Pass the generated token only between pipeline steps — avoid logging or persisting it.
+
+---
+
+## Troubleshooting
+
+* Ensure your `private_key` secret is uploaded as **file type**, not plaintext.
+* Confirm the plugin step succeeded by checking `output.outputVariables.GITHUB_APP_TOKEN`.
+* Tokens expire after a short time (\~10 minutes). Use them immediately in the next step.
+

--- a/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
+++ b/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
@@ -13,7 +13,7 @@ When interacting with GitHub from CI pipelines, authentication is required for a
 * **Security risks** from hardcoded secrets or token exposure.
 * **User binding** ties activity to a specific person rather than a system identity.
 
-This guide walks through a modern, flexible solution that uses a GitHub App to generate short-lived tokens at runtime, powered by a Harness-compatible plugin.
+This guide walks through a modern, flexible solution that uses a GitHub App to generate short-lived tokens at runtime, powered by a [Harness-compatible plugin](https://github.com/harness-community/drone-github-app-token).
 
 ---
 

--- a/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
+++ b/docs/continuous-integration/secure-ci/github-app-token-in-harness.md
@@ -23,15 +23,13 @@ Earlier approaches involved scripting token generation by manually crafting JWTs
 * Required external scripts and secret manager setup.
 * **Did not work reliably in Harness Cloud**, often failing silently or returning incorrect data.
 
-For details on the previous approach, see [this KB article](/kb/continuous-integration/articles/github-app-pat-dispenser/).
-
 ## Recommended Solution: GitHub App Token Plugin
 
 Harness now supports a more robust and cloud-compatible method using the open source [`drone-github-app-token`](https://github.com/harness-community/drone-github-app-token) plugin.
 
 This plugin generates GitHub App installation tokens securely during pipeline execution. It eliminates the need for PATs or static secrets and enables you to use the token immediately in subsequent steps.
 
-### Key Benefits
+***Key Benefits***
 
 * Tokens are **ephemeral**, scoped to the pipeline.
 * Securely injected as output variables.
@@ -45,11 +43,11 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
     type: Plugin
     name: Generate GitHub App Token
     spec:
-      connectorRef: YOUR_DOCKER_CONNECTOR
+      connectorRef: YOUR_DOCKER_CONNECTOR # Docker connector that can pull the plugin image.
       image: plugins/github-app-token:latest
       settings:
-        app_id: "YOUR_GITHUB_APP_ID"
-        private_key: <+secrets.getValue("YOUR_GITHUB_APP_KEY")>  # Secret of type "File"
+        app_id: "YOUR_GITHUB_APP_ID" # Numeric Value
+        private_key: <+secrets.getValue("YOUR_GITHUB_APP_KEY")>  # File-type Secret on Harness
         permission_contents: write
 
 - step:
@@ -63,13 +61,16 @@ This plugin generates GitHub App installation tokens securely during pipeline ex
              https://api.github.com/repos/YOUR_ORG/YOUR_REPO/contents
 ```
 
-### Notes:
+:::note
 
-* `app_id`: GitHub App ID (numeric).
-* `private_key`: Must be stored in Harness as a **File-type Secret**.
-* `connectorRef`: Docker connector that can pull the plugin image.
-* The token can also be passed as an environment variable (`GH_TOKEN`) if you're using the GitHub CLI.
+* The plugin exports several output variables — including the GitHub App token (`GITHUB_APP_TOKEN`), installation ID (`GITHUB_APP_INSTALLATION_ID`), and app slug (`GITHUB_APP_SLUG`). These variables can be referenced in subsequent steps using:
+```bash
+<+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_TOKEN>
+<+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_INSTALLATION_ID>
+<+execution.steps.Generate_GitHub_Token.output.outputVariables.GITHUB_APP_SLUG>
+```
 * The JWT is used to authenticate as the GitHub App and generate the installation token. The JWT expires after 10 minutes by design, but the installation token — which grants actual repo access — lasts for 60 minutes.
+:::
 
 ## Best Practices
 

--- a/kb/continuous-integration/articles/github-app-pat-dispenser.md
+++ b/kb/continuous-integration/articles/github-app-pat-dispenser.md
@@ -4,7 +4,7 @@ description: Use a GitHub App to push commits and interact with the GitHub API i
 sidebar_position: 80
 ---
 
-> **Note**: Looking for a cleaner solution that works in Harness Cloud?  
+> **Note**: Looking for a cleaner solution?  
 > See [Using GitHub App Tokens Securely in Harness CI Pipelines](/docs/continuous-integration/secure-ci/github-app-token-in-harness).
 
 Harness CI's [codebase configuration](https://developer.harness.io/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase) uses a code repo connector to clone your code, push status updates to PRs, and create and use repo webhooks. If your code is stored in GitHub repos, you can [use a GitHub App in a Harness GitHub connector](https://developer.harness.io/docs/platform/connectors/code-repositories/git-hub-app-support) for authentication.

--- a/kb/continuous-integration/articles/github-app-pat-dispenser.md
+++ b/kb/continuous-integration/articles/github-app-pat-dispenser.md
@@ -4,6 +4,9 @@ description: Use a GitHub App to push commits and interact with the GitHub API i
 sidebar_position: 80
 ---
 
+> **Note**: Looking for a cleaner solution that works in Harness Cloud?  
+> See [Using GitHub App Tokens Securely in Harness CI Pipelines](/docs/continuous-integration/secure-ci/github-app-token-in-harness).
+
 Harness CI's [codebase configuration](https://developer.harness.io/docs/continuous-integration/use-ci/codebase-configuration/create-and-configure-a-codebase) uses a code repo connector to clone your code, push status updates to PRs, and create and use repo webhooks. If your code is stored in GitHub repos, you can [use a GitHub App in a Harness GitHub connector](https://developer.harness.io/docs/platform/connectors/code-repositories/git-hub-app-support) for authentication.
 
 However, if you need your CI pipeline to commit and push changes to your repo, the code repo connector doesn't support pushing to the cloned repo.


### PR DESCRIPTION
- Added a new doc at secure-ci/github-app-token-in-harness.md that explains how to securely generate and use GitHub App tokens in Harness CI pipelines using the github-app-token community plugin.

- Updated the legacy PAT dispenser article to include a note linking to the new recommended approach.

This provides a modern, cloud-compatible alternative for ephemeral GitHub authentication in CI workflows.

[JIRA](https://harness.atlassian.net/browse/CI-17916)