### PR TITLE
Add docs for customizing PodSpec using overlay YAML in K8s build infra

### DIFF
--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/customize-podspec.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/customize-podspec.md
@@ -1,0 +1,98 @@
+---
+title: Customize the PodSpec in Kubernetes build infrastructure
+description: You can customize the build pod's Kubernetes spec using a Pod Spec Overlay field in Harness CI.
+sidebar_position: 50
+---
+
+Harness CI supports advanced customization of the Kubernetes PodSpec used for your build pods. You can use this to apply configurations like projected volumes, custom security contexts, node selectors, and topology spread constraints.
+
+> ⚠️ **Feature Flag Required:** This feature is gated by the feature flag `CI_K8S_OVERLAY_YAML` and requires Harness Delegate version `863` or higher.
+
+## Overview
+
+Once the `CI_K8S_OVERLAY_YAML` flag is enabled, you can reuse the **Pod Spec Overlay** field in the build infrastructure settings to pass a partial Kubernetes Pod YAML that overrides the default pod created by Harness CI.
+
+- The YAML must follow the standard Kubernetes PodSpec structure.
+- You only need to specify the fields you want to override.
+- Fields like `spec.containers` and `spec.initContainers` are **ignored** if passed — you can't override them.
+
+## Examples
+
+### Add a projected volume
+
+```yaml
+spec:
+  volumes:
+    - name: projected-vol
+      projected:
+        sources:
+          - configMap:
+              name: my-config
+          - secret:
+              name: my-secret
+```
+
+### Set a primary group ID for the build container
+```yaml
+spec:
+  securityContext:
+    runAsGroup: 15
+```
+
+## Transition from legacy format
+
+Previously, the Pod Spec Overlay field only supported `topologySpreadConstraints`, and you could pass them without nesting under `spec:`. That changes with the feature flag.
+
+### Before (feature flag OFF)
+
+When the feature flag is off, you can pass fields directly like this:
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 3
+    minDomains: 2
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - my-app
+```
+
+Harness automatically injected this into the pod under the hood.
+
+### After (feature flag ON)
+
+Once the feature flag is on, Harness expects a proper PodSpec YAML structure. You must wrap your fields inside a `spec:` block:
+
+```yaml
+spec:
+  topologySpreadConstraints:
+    - maxSkew: 3
+      minDomains: 2
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - my-app
+```
+
+:::warning
+If you leave out the `spec:` wrapper while the feature flag is on, the pod override will fail and your build will likely error out.
+:::
+
+Best Practices
+- Only include the fields you want to override.
+
+- Always use the `spec:` wrapper if the feature flag is enabled.
+
+- Do not pass `spec.containers` or `spec.initContainers` — they are not overrideable.
+
+- Invalid YAML or unsupported fields can cause your build to fail.
+
+For more background, check out [Topology Spread Constraints](/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure/#topology-spread-constraints) which were previously supported without this feature flag.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/set-up-a-kubernetes-cluster-build-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 title: Set up a Kubernetes cluster build infrastructure
 description: You can use a Kubernetes cluster build infrastructure for a Harness CI pipeline.
-sidebar_position: 30
+sidebar_position: 10
 helpdocs_topic_id: ia5dwx5ya8
 helpdocs_category_id: rg8mrhqm95
 helpdocs_is_private: false

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/tutorial-ci-kubernetes-build-infra.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/tutorial-ci-kubernetes-build-infra.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Build and test on a Kubernetes cluster
 description: Learn how to create a pipeline that uses a Kubernetes cluster build infrastructure.
-sidebar_position: 11
+sidebar_position: 20
 redirect_from:
   - /tutorials/ci-pipelines/kubernetes-build-farm
 ---


### PR DESCRIPTION
### What’s Changed

- Added a new documentation page: **"Customize the PodSpec in Kubernetes build infrastructure"**
- Describes how to use the Pod Spec Overlay field in Harness CI to override parts of the Kubernetes PodSpec
- Includes examples for:
  - Adding projected volumes
  - Setting security context (e.g., runAsGroup)
  - Applying topology spread constraints
- Clarifies the difference in YAML structure before and after enabling the `CI_K8S_OVERLAY_YAML` feature flag
- Emphasizes that `spec.containers` and `spec.initContainers` cannot be overridden

### Why

This change documents the newly enhanced support for advanced pod-level customizations when using Kubernetes build infrastructure with Harness CI. The behavior of the Pod Spec Overlay field has changed significantly with the feature flag `CI_K8S_OVERLAY_YAML`, and this doc guides users through how to use it correctly.

### Related

- Feature flag: `CI_K8S_OVERLAY_YAML`
- Delegate requirement: version `863+`

### Question to Reviewer

- Need full delegate version instead of partial `863` @devkimittal 