### PR TITLE
Add BuildKit self-signed cert configuration for Dockerfile builds usi…

### DIFF
--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-and-push/build-and-push-to-docker-registry.md
@@ -87,6 +87,11 @@ The name of the repository where you want to store the image, for example, `<hub
 
 For private Docker registries, specify a fully qualified repo name.
 
+:::tip
+Using a private Docker registry with a self-signed certificate?  
+[Learn how to configure BuildKit to trust self-signed certs.](/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/)
+:::
+
 ### Tags
 
 Add [Docker build tags](https://docs.docker.com/engine/reference/commandline/build/#tag). This is equivalent to the `-t` flag.

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
@@ -374,6 +374,8 @@ envVariables:
 
 ### Run step to prepare certs and BuildKit config
 
+Here is an example `Run` step that uses CA certs already mounted into the Delegate and build pod (e.g., via volume mounts to `/harness-shared-certs-path`), prepares the BuildKit config file, and builds a Dockerfile
+
 ```yaml
 - step:
     type: Run

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
@@ -365,8 +365,7 @@ To make BuildKit trust your self-signed registry certs, you need to:
 
 ```yaml
 sharedPaths:
-  - /etc/buildkit/certs/your.registry.com:5000
-  - /etc/docker/certs.d/your.registry.com:5000
+  - /etc/buildkit/certs/your.registry.com
 
 envVariables:
   PLUGIN_BUILDER_CONFIG: /harness/buildkit.toml
@@ -387,30 +386,24 @@ Here is an example `Run` step that uses CA certs already mounted into the Delega
       shell: Sh
       command: |-
         # Registry address (update this to match your use case)
-        REG="your.registry.com:5000"
-        CERT_PATH_DOCKER="/etc/docker/certs.d/${REG}"
+        REG="your.registry.com"
         CERT_PATH_BUILDX="/etc/buildkit/certs/${REG}"
         BUILDKIT_TOML="/harness/buildkit.toml"
 
         # Create cert paths
-        mkdir -p "$CERT_PATH_DOCKER"
         mkdir -p "$CERT_PATH_BUILDX"
 
         # Concatenate all mounted PEMs into a single CA bundle
         for cert in /harness-shared-certs-path/*.pem; do
-          cat "$cert" >> "$CERT_PATH_DOCKER/ca.crt"
-          echo >> "$CERT_PATH_DOCKER/ca.crt"
+          cat "$cert" >> "$CERT_PATH_BUILDX/ca.crt"
+          echo >> "$CERT_PATH_BUILDX/ca.crt"
         done
-
-        # Symlink for BuildKit
-        ln -s "$CERT_PATH_DOCKER/ca.crt" "$CERT_PATH_BUILDX/ca.crt"
 
         # Write buildkit.toml
         echo "Writing buildkit.toml..."
         cat <<EOF > "$BUILDKIT_TOML"
         [registry."$REG"]
           ca = ["$CERT_PATH_BUILDX/ca.crt"]
-          insecure = false
         EOF
 
         ls -lr "$CERT_PATH_BUILDX"


### PR DESCRIPTION
## Description

* Please describe your changes: 
This PR updates the Kubernetes build farm configuration doc to include a new section:
"Using Dockerfile builds with self-signed certificates (BuildKit-specific)"

Key additions:

- Detailed workaround for using self-signed certificates with Docker BuildKit in BuildAndPushDockerRegistry steps.

- Example pipeline (from @anurag-harness) with Run step to create and mount certs, and usage of PLUGIN_BUILDER_CONFIG to inject the custom buildkit.toml.

- Internal anchor link structure to enable cross-linking from other doc pages.

* Jira/GitHub Issue numbers (if any): CI-18319
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
