### PR TITLE
fix: runtime docs and removed jdbc connector

### DIFF
--- a/docs/database-devops/troubleshooting/troubleshooting.md
+++ b/docs/database-devops/troubleshooting/troubleshooting.md
@@ -136,3 +136,12 @@ git push -u origin main
 - Replace `PAT_TOKEN` with the name of the Harness secret containing your GitLab PAT.
 - Make sure the secret is securely stored in Harness under **Project Settings → Secrets**.
 :::
+
+## 6. If I execute a dropTable or dropColumn and a rollback is triggered, will the data also be recovered? Or is only the schema structure restored?
+When a dropTable or dropColumn operation is executed and subsequently rolled back, only the schema structure can potentially be recreated—the original data will not be restored. While it is technically possible to instruct the rollback to recreate the table or column definition, the associated data is permanently lost unless a backup was taken beforehand.
+
+In scenarios involving destructive operations like DROP, the rollback cannot magically recover deleted data. The only viable recovery strategy would be to restore from a database backup taken prior to the drop operation—which still results in some level of data loss and operational risk.
+
+:::note warning
+Dropping tables or columns in production environments should be treated with extreme caution. It is highly recommended to adopt a backup-first approach and validate rollback strategies before applying such changes.
+:::

--- a/docs/database-devops/use-database-devops/get-started/gitops/_category_.json
+++ b/docs/database-devops/use-database-devops/get-started/gitops/_category_.json
@@ -1,0 +1,11 @@
+{
+    "label":"GitOps",
+    "collapsible":"true",
+    "collapsed":"true",
+    "link":{
+       "type":"generated-index",
+       "title":"GitOps"
+    },
+    "customProps":{
+    }
+ }

--- a/docs/database-devops/use-database-devops/get-started/gitops/gitops-in-dbops.md
+++ b/docs/database-devops/use-database-devops/get-started/gitops/gitops-in-dbops.md
@@ -41,12 +41,11 @@ By integrating GitOps into your database lifecycle, you gain traceability, audit
 When adopting GitOps for database management, two primary branching strategies are commonly used:
 
 1. **Environment-by-Branch**  
-   Each environment (e.g., dev, staging, prod) has a dedicated Git branch. Changes are promoted by merging from lower to higher environments.  
+   Each environment (e.g., dev, staging, prod) has a dedicated Git branch. Changes are promoted by merging from lower to higher environments. → [Learn more](./environment-based-development.md)
 
 2. **Trunk-Based Development**  
-   A single mainline branch (e.g., `main` or `trunk`) is used, with pipelines or metadata controlling environment-specific behavior.  
-   → [Learn more](./gitops/trunk-based-development.md)
+   A single mainline branch (e.g., `main` or `trunk`) is used, with pipelines or metadata controlling environment-specific behavior. → [Learn more](./trunk-based-development.md)
 
-::: tip  
-> If you're not currently using a GitOps-based branching approach, Harness recommends adopting **trunk-based development**. It simplifies change management, accelerates delivery, and aligns well with modern CI/CD and database promotion workflows.
+:::note tip  
+If you're not currently using a GitOps-based branching approach, Harness recommends adopting **trunk-based development**. It simplifies change management, accelerates delivery, and aligns well with modern CI/CD and database promotion workflows.
 :::

--- a/docs/database-devops/use-database-devops/get-started/runtime-secrets.md
+++ b/docs/database-devops/use-database-devops/get-started/runtime-secrets.md
@@ -30,6 +30,14 @@ In DBOps workflows, the following types of secrets are typically required:
 2. **Schema Repo Clone Secrets** – used by scripts to fetch schema definitions from source control.
 3. **Database Passwords** – used for authenticating with databases via JDBC or similar connectors.
 
+### Prerequisites
+
+Ensure you have the following versions:
+- **Harness Delegate**: 858xx or later
+- **Harness CI Addon**: 1.16.81 or later
+- **Harness CI Lite Engine**: 1.16.81 or later
+- **Ng manager**: 1.87.0
+- **Ci-manager**: 1.77.0
 
 ### How it Works
 

--- a/docs/database-devops/use-database-devops/set-up-connectors.md
+++ b/docs/database-devops/use-database-devops/set-up-connectors.md
@@ -29,7 +29,6 @@ The JDBC connector is used for connecting to your database instance.
 | **ORACLE**         | `jdbc:oracle:thin:@//{host}:{port}/{servicename}`                                                                                |
 | **POSTGRES**       | `jdbc:postgresql://{host}:{port}/{dbName}?sslmode=disable`                                                                       |
 | **SQLSERVER**      | `jdbc:sqlserver://{host}:{port};trustServerCertificate=true;databaseName={dbName}`                                               |
-| **MongoAtlasSQL**  | `jdbc:mongodb://{host}:{port}/{dbName}?ssl=true&authSource=admin`                                                                |
 | **MYSQL**          | `jdbc:mysql://{host}:{port}/{dbName}`                                                                                            |
 | **MONGODB**        | `mongodb://{host}:{port}/{dbName}/?authSource=admin`                                                                             |
 | **GOOGLE SPANNER** | `jdbc:cloudspanner:/projects/{project-id}/instances/{instance-id}/databases/{database-name}?lenient=true`                        |


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: 
This pull request introduces several updates to the documentation for database DevOps, focusing on improving clarity, adding new information, and ensuring consistency across files. Key changes include adding a detailed explanation about rollback behavior for destructive database operations, updating GitOps branching strategy links, and introducing prerequisites for runtime secrets. Additionally, minor adjustments were made to connector documentation.

  - Added a detailed explanation about the limitations of rollback operations for `dropTable` and `dropColumn`, emphasizing that data cannot be recovered without a prior backup. A warning was also added to highlight the risks of such operations in production. (`docs/database-devops/troubleshooting/troubleshooting.md`, [docs/database-devops/troubleshooting/troubleshooting.mdR139-R147](diffhunk://#diff-e79472ca31ef56716f7488b537039799424f2017f82de72a34f3a199d1def37bR139-R147))

  - Updated links in the GitOps branching strategy section to point to the correct files, ensuring better navigation. Changed the tip styling for consistency. (`docs/database-devops/use-database-devops/get-started/gitops/gitops-in-dbops.md`, [docs/database-devops/use-database-devops/get-started/gitops/gitops-in-dbops.mdL44-R50](diffhunk://#diff-8db12dbed2f52846b323123f275e1f47300a3de370d01d91215346602b3b2fadL44-R50))

  - Introduced a new "Prerequisites" section listing required versions for Harness components to ensure compatibility in runtime secrets workflows. (`docs/database-devops/use-database-devops/get-started/runtime-secrets.md`, [docs/database-devops/use-database-devops/get-started/runtime-secrets.mdR33-R40](diffhunk://#diff-2f84425ba50a9c1c6ad31639a3339faa5506c931c7e96ebc6558539dcb427dccR33-R40))

  - Removed the `MongoAtlasSQL` entry from the JDBC connector table, likely due to deprecation or redundancy. (`docs/database-devops/use-database-devops/set-up-connectors.md`, [docs/database-devops/use-database-devops/set-up-connectors.mdL32](diffhunk://#diff-81fc4a5a1f57cdafe7978df11c899a71dac27ff702d17f8d6ac20a39ebab575fL32))

* Jira/GitHub Issue numbers (if any): 
1. https://harness.atlassian.net/browse/DBOPS-1360
2. https://harness.atlassian.net/browse/DBOPS-1359
3. https://harness.atlassian.net/browse/DBOPS-1418

* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
