### PR TITLE
Add SSH authentication example for Git access in Run step

### DIFF
--- a/docs/continuous-integration/use-ci/run-step-settings.md
+++ b/docs/continuous-integration/use-ci/run-step-settings.md
@@ -152,6 +152,38 @@ Consider [creating plugins](./use-drone-plugins/custom_plugins.md) for scripts t
 :::
 
 </TabItem>
+<TabItem value="ssh" label="Connect with SSH">
+
+This example demonstrates how to set up SSH authentication in a **Run** step, such as when connecting to a private Git server or remote machine.
+
+The SSH private key must be stored in Harness as a **File-type Secret** to be used securely in the pipeline.
+
+```yaml
+              - step:
+                  type: Run
+                  name: SSH setup and build
+                  identifier: SSH_Build
+                  spec:
+                    shell: Sh
+                    command: |-
+                      mkdir -p ~/.ssh
+                      echo '<+secrets.getValue("account.your-ssh-private-key")>' > ~/.ssh/id_rsa
+                      chmod 600 ~/.ssh/id_rsa
+                      export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
+                      git clone git@github.com:your-org/private-repo.git
+                      ./build.sh
+```
+:::tip
+
+- Replace `account.your-ssh-private-key` with your actual secret reference.
+
+- The `StrictHostKeyChecking=no` flag disables host verification. For production pipelines, consider managing known hosts instead.
+
+- Ensure your build image has OpenSSH tools (ssh, git, etc.) installed.
+:::
+
+</TabItem>
+
 </Tabs>
 
 ## Add the Run step


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: This PR adds a practical example to the Run step docs showing how to configure SSH-based authentication for accessing private Git repositories or other external hosts in a Harness CI pipeline.
* Jira/GitHub Issue numbers (if any): CI-17447
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
