### PR TITLE
Add guidance to exclude Build and Cache Intel directories from Apache…

### DIFF
--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -251,7 +251,7 @@ To avoid this, explicitly exclude the following directories in your pom.xml file
 `/harness/.mvn` (also applies to cache-related scans)
 
 **Example: Update to pom.xml**
-Add the following snippet under the <build> section to configure the apache-rat-plugin to ignore these paths:
+Add the following snippet under the `<build>` section to configure the apache-rat-plugin to ignore these paths:
 
 ```xml
 <build>

--- a/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
+++ b/docs/continuous-integration/use-ci/build-and-upload-artifacts/build-intelligence.md
@@ -233,3 +233,48 @@ This is currently supported with Gradle build tool only .
 ![Build Intelligence Savings](./static/build-intelligence-savings.png)
 
 Visit [Intelligence Savings](/docs/continuous-integration/use-ci/harness-ci-intelligence#intelligence-savings) for more information.
+
+### Troubleshooting
+
+#### Ignoring Build and Cache Intel Directories in Apache RAT Scans
+
+If you are using the Apache RAT plugin for license compliance, it may incorrectly mark Harness Build Intelligence or Cache Intelligence directories as invalid files. This can cause unnecessary failures in your build pipeline.
+
+To avoid this, explicitly exclude the following directories in your pom.xml file.
+
+**Directories to Ignore**
+- Build Intelligence:
+`/harness/.mvn`
+
+- Cache Intelligence:
+`/harness/.m2`
+`/harness/.mvn` (also applies to cache-related scans)
+
+**Example: Update to pom.xml**
+Add the following snippet under the <build> section to configure the apache-rat-plugin to ignore these paths:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.rat</groupId>
+      <artifactId>apache-rat-plugin</artifactId>
+      <version>0.15</version> <!-- Or use the latest version -->
+      <configuration>
+        <excludes>
+          <exclude>/harness/.mvn</exclude>
+          <exclude>/harness/.m2</exclude> <!-- Optional, but recommended -->
+        </excludes>
+      </configuration>
+      <executions>
+        <execution>
+          <phase>verify</phase>
+          <goals>
+            <goal>check</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```

--- a/docs/continuous-integration/use-ci/run-tests/tests-v2.md
+++ b/docs/continuous-integration/use-ci/run-tests/tests-v2.md
@@ -386,7 +386,52 @@ config:
 
 ## Troubleshoot Test Intelligence
 
-Go to the [CI Knowledge Base](/kb/continuous-integration/continuous-integration-faqs) for questions and issues related to Test Intelligence, including:
+### Troubleshooting
+
+#### Ignoring Build and Cache Intel Directories in Apache RAT Scans
+
+If you are using the Apache RAT plugin for license compliance, it may incorrectly mark Harness Build Intelligence or Cache Intelligence directories as invalid files. This can cause unnecessary failures in your build pipeline.
+
+To avoid this, explicitly exclude the following directories in your pom.xml file.
+
+**Directories to Ignore**
+- Build Intelligence:
+`/harness/.mvn`
+
+- Cache Intelligence:
+`/harness/.m2`
+`/harness/.mvn` (also applies to cache-related scans)
+
+**Example: Update to pom.xml**
+Add the following snippet under the <build> section to configure the apache-rat-plugin to ignore these paths:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.rat</groupId>
+      <artifactId>apache-rat-plugin</artifactId>
+      <version>0.15</version> <!-- Or use the latest version -->
+      <configuration>
+        <excludes>
+          <exclude>/harness/.mvn</exclude>
+          <exclude>/harness/.m2</exclude> <!-- Optional, but recommended -->
+        </excludes>
+      </configuration>
+      <executions>
+        <execution>
+          <phase>verify</phase>
+          <goals>
+            <goal>check</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+Go to the [CI Knowledge Base](/kb/continuous-integration/continuous-integration-faqs) for more questions and issues related to Test Intelligence, including:
 
 * [Does Test Intelligence split tests? Can I use parallelism with Test Intelligence?](/kb/continuous-integration/continuous-integration-faqs/#does-test-intelligence-split-tests-why-would-i-use-test-splitting-with-test-intelligence)
 * [Test Intelligence call graph is empty.](/kb/continuous-integration/continuous-integration-faqs/#on-the-tests-tab-the-test-intelligence-call-graph-is-empty-and-says-no-call-graph-is-created-when-all-tests-are-run)

--- a/docs/continuous-integration/use-ci/run-tests/tests-v2.md
+++ b/docs/continuous-integration/use-ci/run-tests/tests-v2.md
@@ -403,7 +403,7 @@ To avoid this, explicitly exclude the following directories in your pom.xml file
 `/harness/.mvn` (also applies to cache-related scans)
 
 **Example: Update to pom.xml**
-Add the following snippet under the <build> section to configure the apache-rat-plugin to ignore these paths:
+Add the following snippet under the `<build>` section to configure the apache-rat-plugin to ignore these paths:
 
 ```xml
 <build>


### PR DESCRIPTION
* Please describe your changes: Added documentation to help users configure the apache-rat-plugin to ignore Harness Build Intelligence and Cache Intelligence directories. These directories may be incorrectly flagged during license compliance checks. The update includes a list of paths to exclude and a sample pom.xml configuration snippet.
* Jira/GitHub Issue numbers (if any): CI-17857
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
