### PR TITLE
Remove mention to unnecessary Feature Flags in Delegate 2.0 Docs

### DIFF
--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/install-delegate-2-0.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/install-delegate-2-0.md
@@ -23,11 +23,9 @@ Harness Delegate 2.0 is under **Beta** and can only be used for Mac Build, Andro
 
 :::note
 
-Please enable the following feature flags to use Delegate 2.0. To enable these flags, contact [Harness Support](mailto:support@harness.io)
+Please enable the following feature flag to use Delegate 2.0. To enable this flag, contact [Harness Support](mailto:support@harness.io)
 
 - `PL_ENABLE_UNIFIED_TASK`
-- `PL_USE_RUNNER`
-- `CI_ADD_CONNECTOR_REF_TO_IMPLICIT_GIT_CLONE_STEP`
 
 :::
 

--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/install-delegate-2-0.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/install-delegate-2-0.md
@@ -21,14 +21,6 @@ Harness Delegate 2.0 is under **Beta** and can only be used for Mac Build, Andro
 
 :::
 
-:::note
-
-Please enable the following feature flag to use Delegate 2.0. To enable this flag, contact [Harness Support](mailto:support@harness.io)
-
-- `PL_ENABLE_UNIFIED_TASK`
-
-:::
-
 ## What's Supported
 
 ### Supported Connectors


### PR DESCRIPTION
Removing mention of Feature Flags  related to enabling Delegate 2.0.
None of these feature flags are required, and we are working on removing them from code.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

This is how the page will look like now:
<img width="1070" height="703" alt="image" src="https://github.com/user-attachments/assets/7c6f4974-de66-47e5-bbc2-ceb26c2e69e3" />



## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
