### PR TITLE
Feature Flag cleanup: CDS_EVENT_LISTENER_STEP

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/event-listener-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/utilities/event-listener-step.md
@@ -10,10 +10,6 @@ import TabItem from '@theme/TabItem';
 
 The **Event Listener Step** introduces an event-driven mechanism to Harness pipelines, eliminating the need for polling and improving performance. Instead of continuously checking for status updates, this step reacts to **webhook events** in real time to determine whether a pipeline should resume or fail based on predefined conditions.
 
-:::note
-This feature is behind the feature flag: `CDS_EVENT_LISTENER_STEP`
-:::
-
 ## Key Features
 
 - **Webhook Event Handling**  


### PR DESCRIPTION
This feature has been GAed and is now being cleaned up. GA-ed for QA, Prod1, Prod2, Prod3. 

Additional details: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/harness-core/pulls/105357/

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [ ] Code owner review.
- [x] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
