### PR TITLE
Add CI_APPEND_CERTS note for appending self-signed certs during Docker builds

### DIFF
--- a/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
+++ b/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates.md
@@ -146,8 +146,11 @@ Custom certificates or self-signed certificates are only supported for linux nod
 
 :::important
 
-This workflow is applicable only if you're using a self-hosted registry to store your container images. For all other workflows, go to [Enable self-signed certificates](#enable-self-signed-certificates). 
-
+- This workflow is applicable only if you're using a self-hosted registry to store your container images. For all other workflows, go to [Enable self-signed certificates](#enable-self-signed-certificates). 
+- Starting with delegate release XXX, **self-signed certificates provided via `DESTINATION_CA_PATH` and `CI_MOUNT_VOLUMES` will now be _appended_ to the existing public certificates at the destination path**, rather than replacing them.
+- This change is controlled by the feature flag `CI_APPEND_CERTS`.
+  - Supported only on **Linux nodes**  
+  - **Windows nodes are not supported** — mounting certs this way will not work on Windows agents.
 :::
 
 1. Create a Kubernetes secret or config map with the required certificates in the same namespace used by the Harness delegate. For example:


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Added a note under self-hosted image registry section documenting that self-signed certs provided via DESTINATION_CA_PATH and CI_MOUNT_VOLUMES are now appended (not replaced) in CI build pods. Controlled by FF CI_APPEND_CERTS and supported only on Linux nodes.
Note: Satya Lingam to provide specific delegate version for the placeholder XXX

* Jira/GitHub Issue numbers (if any): CI-16816
* Preview links/images (Internal contributors only): \__________________
<img width="1347" height="741" alt="Screenshot 2025-08-06 at 7 54 19 PM" src="https://github.com/user-attachments/assets/bd38b162-04eb-4847-88c3-e10ff743b9a6" />

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
