### PR TITLE
Roadmap: Display feature count on roadmap columns

### DIFF
--- a/src/components/Roadmap/index.module.scss
+++ b/src/components/Roadmap/index.module.scss
@@ -159,8 +159,9 @@
 
         .titleLine {
           display: flex;
+          flex-direction: column;
           gap: 8px;
-          align-items: center;
+          align-items: flex-start;
           h4 {
             margin: 0;
             padding: 0;

--- a/src/components/Roadmap/index.module.scss
+++ b/src/components/Roadmap/index.module.scss
@@ -158,8 +158,9 @@
         margin: 0;
 
         .titleLine {
-          margin: 0;
-          padding: 0;
+          display: flex;
+          gap: 8px;
+          align-items: center;
           h4 {
             margin: 0;
             padding: 0;
@@ -168,6 +169,18 @@
             line-height: 26px;
             letter-spacing: 0px;
             text-align: left;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            .featureCount {
+              background-color: #eef8ff;
+              color: #007bff;
+              font-size: 12px;
+              font-weight: 600;
+              padding: 2px 8px;
+              border-radius: 12px;
+              line-height: 1.5;
+            }
           }
           p {
             margin: 0;
@@ -237,12 +250,24 @@
         margin: 0;
         font-size: 18px;
         font-weight: 700;
+        display: flex;
+        align-items: center;
+        gap: 8px;
         line-height: 26px;
         letter-spacing: 0px;
         text-align: left;
         list-style: none;
         color: var(--text-color);
         cursor: pointer;
+        .featureCount {
+          background-color: #eef8ff;
+          color: #007bff;
+          font-size: 12px;
+          font-weight: 600;
+          padding: 2px 8px;
+          border-radius: 12px;
+          line-height: 1.5;
+        }
       }
     }
   }

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -152,19 +152,15 @@ const Roadmap = () => {
                   <div className={styles.section}>
                     <div className={styles.sectionDescription}>
                       <div className={styles.titleLine}>
-                        <h4>{key[index]}</h4>
+                        <h4>{k} <span className={styles.featureCount}>{selectedModule.horizon[k].feature.length}</span></h4>
                         <p>
                           {Object.keys(selectedModule.horizon).length > 0 &&
-                            selectedModule.horizon[
-                              Object.keys(selectedModule.horizon)[index]
-                            ].description}
+                            selectedModule.horizon[k].description}
                         </p>
                       </div>
                     </div>
                     {Object.keys(selectedModule.horizon).length > 0 &&
-                      selectedModule.horizon[
-                        Object.keys(selectedModule.horizon)[index]
-                      ].feature.map((feature, index) => (
+                      selectedModule.horizon[k].feature.map((feature, index) => (
                         <HorizonCard
                           module={selectedModule.module}
                           tag={feature.tag}
@@ -188,7 +184,7 @@ const Roadmap = () => {
                         }`}
                       onClick={() => handleSwitchTab(key)}
                     >
-                      <li key={index}>{key}</li>
+                      <li key={index}>{key} <span className={styles.featureCount}>{selectedModule.horizon[key].feature.length}</span></li>
                     </div>
                   ))}
               </ul>


### PR DESCRIPTION
Enhances the roadmap by adding a feature count next to each column title (Now, Next, Later). The count is styled as a badge to improve visibility and provide a better user experience.

Changes include:
- Displaying the number of features in each roadmap category.
- Styling the count as a distinct badge for better UI.
- Ensuring the feature count is visible on both desktop and mobile views.

Before:
<img width="1303" height="389" alt="Screenshot 2025-08-11 at 10 12 26 PM" src="https://github.com/user-attachments/assets/9575db91-0f13-484d-ba1a-ce0edf7241d2" />

After:
<img width="1328" height="408" alt="Screenshot 2025-08-11 at 11 39 39 PM" src="https://github.com/user-attachments/assets/59bb60a6-43c4-4222-863f-40f4641c335d" />
