### PR TITLE
Remove HTML Styling in Chaos Engineering and CCM Module Navigation Menus

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1364,7 +1364,7 @@ const sidebars: SidebarsConfig = {
       items: [ 
       {
         type: "html",
-        value: '<span style="color:#000000; font-weight:1000;">New to CCM?</span>',
+        value: 'New to CCM?',
         className: "horizontal-bar",
       },
       "cloud-cost-management/get-started/overview",
@@ -1372,7 +1372,7 @@ const sidebars: SidebarsConfig = {
       "cloud-cost-management/get-started/onboarding-guide/external-data-ingestion",
       {
         type: "html",
-        value: '<span style="color:#000000; font-weight:1000;"> Use CCM </span>',
+        value: 'Use CCM',
         className: "horizontal-bar",
       },
       "cloud-cost-management/get-started/key-concepts",
@@ -1483,7 +1483,7 @@ const sidebars: SidebarsConfig = {
       },
       {
         type: "html",
-        value: '<span style="color:#000000; font-weight:1000;">Troubleshooting & Resources</span>',
+        value: 'Troubleshooting & Resources',
         className: "horizontal-bar",
       },
       "cloud-cost-management/whats-supported",
@@ -1708,7 +1708,7 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: "html",
-          value: '<span style="color:#000000; font-weight:1000;"> Getting Started </span>',
+          value: 'Getting Started',
           className: "horizontal-bar",
         },
         "chaos-engineering/overview",
@@ -1718,7 +1718,7 @@ const sidebars: SidebarsConfig = {
         "chaos-engineering/quickstart",
         {
           type: "html",
-          value: '<span style="color:#000000; font-weight:1000;"> Guides </span>',
+          value: 'Guides',
           className: "horizontal-bar",
         },
         {
@@ -1800,7 +1800,7 @@ const sidebars: SidebarsConfig = {
         "chaos-engineering/guides/license-consumption",
         {
           type: "html",
-          value: '<span style="color:#000000; font-weight:1000;"> Faults </span>',
+          value: 'Faults',
           className: "horizontal-bar",
         },
         "chaos-engineering/faults/chaos-faults",
@@ -1825,7 +1825,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "html",
-          value: '<span style="color:#000000; font-weight:1000;"> Integrations </span>',
+          value: 'Integrations',
           className: "horizontal-bar",
         },
         {
@@ -1850,7 +1850,7 @@ const sidebars: SidebarsConfig = {
 
         {
           type: "html",
-          value: '<span style="color:#000000; font-weight:1000;"> Security </span>',
+          value: 'Security',
           className: "horizontal-bar",
         },
         "chaos-engineering/security/index",
@@ -2215,7 +2215,7 @@ const sidebars: SidebarsConfig = {
       items: [ 
       {
         type: "html",
-        value: '<span style="color:#000000; font-weight:1000;"> New to CDE? </span>',
+        value: 'New to CDE?',
         className: "horizontal-bar",
       },
       "cloud-development-environments/overview",
@@ -2239,7 +2239,7 @@ const sidebars: SidebarsConfig = {
       },
       {
         type: "html",
-        value: '<span style="color:#000000; font-weight:1000;"> Use CDE </span>',
+        value: 'Use CDE',
         className: "horizontal-bar",
       },
       {


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Noticed something curious where when the text is set to black (`color:#000000`), and Dark Mode is enabled, that the TOC is not visible in HDH. By removing the styling, we can standardize the look/feel of our product modules so that the left-hand navigation menu across the product documentation is consistent.
  
  Light Mode
  
  <img width="1650" height="559" alt="Screenshot 2025-08-14 at 12 05 38 PM" src="https://github.com/user-attachments/assets/fba4f467-be5a-4622-bf55-44d66113358e" />
  
  Dark Mode
  
  <img width="1650" height="558" alt="Screenshot 2025-08-14 at 12 06 32 PM" src="https://github.com/user-attachments/assets/a0aa8484-7891-4f93-89c7-e6790dc9aaea" />

  
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
