### PR TITLE
Update FME Admin RBAC guide: Paid (Enterprise plan) account

### DIFF
--- a/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
+++ b/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
@@ -5,6 +5,9 @@ sidebar_label: Administering a Migrated Split Account on Harness
 sidebar_position: 3
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Overview
 
 This guide is intended to be used as a reference shortly after your migration into Harness to guide you through administrative tasks. It will also help you understand permissions in Harness after your Split-to-Harness migration. It explains how legacy **Split access restrictions** map to **Harness RBAC (role-based access control) settings** in two ways:
@@ -77,15 +80,17 @@ This section shows you how to add new Harness users and set up RBAC permissions 
 
 When you add a user at the account level, you can also add the user to an [FME user group](#fme-user-groups). Once a user is added to the Harness platform, it is easy to add the same user to any organization or project.
 
-#### Interactive guide
+<Tabs>
+<TabItem value="interactive" label="Interactive Guide">
 
-This interactive guide shows how to add a user to Harness that will have access to your (unrestricted) migrated FME projects:
+To add a user to Harness that will have access to your (unrestricted) migrated FME projects, view the steps in the interactive guide:
 
 <DocVideo src="https://app.tango.us/app/embed/e9c155c2-1d2d-4fbf-b5d6-7b59591668b6" title="Add a User in Harness" />
 
-#### Step by step guide
+</TabItem>
+<TabItem value="step" label="Step-by-step">
 
-To add a user that will have access to your (unrestricted) migrated FME projects:
+To add a user to Harness that will have access to your (unrestricted) migrated FME projects:
 
 1. Begin adding the user at the Harness account level:
 
@@ -101,6 +106,9 @@ To add a user that will have access to your (unrestricted) migrated FME projects
      - **All FME Viewers** (equivalent to the legacy **Split Viewer** role)
 
 1. Click **Apply** to finish adding the new user. The user will receive an invitation email to join the Harness account.
+
+</TabItem>
+</Tabs>
 
 The RBAC permissions (that mimic legacy Split permissions) are set on the FME user group to which the new Harness user was added. You can learn more about these user group role bindings in the [User Groups](#user-groups) section.
 
@@ -456,13 +464,15 @@ You can use a service account to create a new Harness FME Admin API key and acce
 
 ### Create an Admin API key
 
-#### Interactive guide
+<Tabs>
+<TabItem value="interactive" label="Interactive Guide">
 
-This interactive guide shows how to create an Admin API key with the same permissions as your legacy Split Admin API key in your Harness account:
+To create an Admin API key with the same permissions as your legacy Split Admin API key in your Harness account, view the steps in the interactive guide:
 
 <DocVideo src="https://app.tango.us/app/embed/e76ab685-723c-4e39-964e-cff2c56df2d1" title="Generate an API Key and Token" />
 
-#### Step by step guide
+</TabItem>
+<TabItem value="step" label="Step-by-step">
 
 To create an Admin API key with the same permissions as your legacy Split Admin API key in your Harness account:
 
@@ -475,6 +485,9 @@ To create an Admin API key with the same permissions as your legacy Split Admin 
 1. Click **+ Token**.
 1. Enter a name for the new API key token, set an expiration, and click **Generate Token**.
 1. Copy the token somewhere safe.
+
+</TabItem>
+</Tabs>
 
 If you don’t have a service account with role bindings set up, you can create a service account and role binding for Admin API keys scoped to all projects [(account or organization scope)](#account-or-organization-scope) or scoped to a specific project [(project scope)](#project-scope).
 
@@ -673,11 +686,13 @@ When your Split account is migrated to Harness, an organization named `default` 
 
 ### Create a project
 
-#### Interactive guide
+<Tabs>
+<TabItem value="interactive" label="Interactive Guide">
 
 <DocVideo src="https://app.tango.us/app/embed/4c5d12d9-a82c-4a54-a54e-c0684ddc3475" title="Create a New Project" />
 
-#### Step by step guide
+</TabItem>
+<TabItem value="step" label="Step-by-step">
 
 To create a new project in Harness:
 
@@ -688,6 +703,9 @@ To create a new project in Harness:
 1. Click **+ New Project**.
 1. Enter a name for the project and click **Save and Continue**.
 1. Click **Save and Continue** again to close the modal. You can grant access to the project using **Access Control** in **Project Settings**.
+
+</TabItem>
+</Tabs>
 
 #### Unrestricted and restricted projects
 
@@ -740,8 +758,8 @@ If you do not delete the resources from within your project before deleting the 
 
 If you accidentally delete a project before deleting its resources, see the [Troubleshooting section](#troubleshooting).
 
-#### Interactive guide
-
+<Tabs>
+<TabItem value="interactive" label="Interactive Guide">
 
 To cleanly delete a project in your Harness account:
 
@@ -761,7 +779,8 @@ To cleanly delete a project in your Harness account:
 
 <DocVideo src="https://app.tango.us/app/embed/f046a6bd-4c56-414d-9398-f83ebbeb57d5" title="Delete a Project" />
 
-#### Step by step guide
+</TabItem>
+<TabItem value="step" label="Step-by-step">
 
 To cleanly delete a project in your Harness account:
 
@@ -786,6 +805,9 @@ To cleanly delete a project in your Harness account:
      :::
    * Click **Yes, I want to delete this project**.
    * Type the project’s name in the text field and click **Delete**.
+
+</TabItem>
+</Tabs>
 
 ## FAQs
 

--- a/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
+++ b/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
@@ -46,7 +46,7 @@ This section explains:
 * How RBAC applies to Harness users
 * How to add new users with the same privileges as your legacy Split users
 
-### Users for Harness FME
+#### Users for Harness FME
 
 When your Split account was migrated to Harness, a Harness user was created for each legacy Split user.
 
@@ -125,7 +125,7 @@ This section explains:
 * What Harness user groups were created when your legacy Split account was migrated to Harness, and what RBAC role bindings were assigned
 * How to use Harness user groups to grant new users the same privileges as your legacy Split users
 
-### User Groups for Harness FME
+#### User Groups for Harness FME
 
 When your Split account was migrated to Harness, a Harness user group was created for each legacy Split group.
 
@@ -135,15 +135,15 @@ Here’s how Harness user groups work with RBAC:
 
 User groups hold users. User groups have role bindings that apply to all the users within the user group.
 
-### Roles
+#### Roles
 
 Harness roles are sets of permissions to perform specific operations on a resource group. 
 
-### Resource Groups
+#### Resource Groups
 
 Harness resource groups define the resources (e.g. projects, pipelines, connectors, secrets, folders, users, etc.) that a user group (or user, or service account) can access.
 
-### Role Bindings
+#### Role Bindings
 
 Role bindings are roles assigned to a user, user group, or service account over a resource group.
 
@@ -161,7 +161,7 @@ The screenshot below shows a Harness user group that was created for a legacy Sp
 
 ![](./static/org-settings-user-group.png)
 
-### FME user groups
+#### FME user groups
 
 When your account was migrated to Harness, the migration script created new Harness FME user groups and assigned role bindings to replicate your legacy Split settings.
 
@@ -392,7 +392,7 @@ Harness recommends that you do not delete the All FME Admins, All FME Editors, a
 
 ## Admin API Keys
 
-### Legacy Split Admin API keys
+#### Legacy Split Admin API keys
 
 The Admin API Keys that you created before migration will continue to work after your account is migrated to Harness.
 
@@ -417,7 +417,7 @@ To revoke an Admin API key that was migrated from legacy Split:
 
 Post-migration, you can create new Admin API keys in Harness, as described in the following section.
 
-### Harness FME Admin API keys
+#### Harness FME Admin API keys
 
 This section explains:
 
@@ -460,9 +460,9 @@ To view service accounts in your Harness project settings, click **Project setti
 
 ![](./static/project-settings-service.png)
 
-You can use a service account to create a new Harness FME Admin API key and access token. The access token can be used in the same way as a legacy Split Admin API key except that service accounts with environment-scoped Admin API keys will not be available until the “Granular permissions in RBAC” [roadmap item](https://developer.harness.io/roadmap/#fme) is delivered).
-
 ### Create an Admin API key
+
+You can use a service account to create a new Harness FME Admin API key and access token. The access token can be used in the same way as a legacy Split Admin API key (except that service accounts with environment-scoped Admin API keys will not be available until the “Granular permissions in RBAC” [roadmap item](https://developer.harness.io/roadmap/#fme) is delivered).
 
 <Tabs>
 <TabItem value="interactive" label="Interactive Guide">
@@ -489,7 +489,9 @@ To create an Admin API key with the same permissions as your legacy Split Admin 
 </TabItem>
 </Tabs>
 
+:::tip[To create an Admin API key when you don't have a service account:]
 If you don’t have a service account with role bindings set up, you can create a service account and role binding for Admin API keys scoped to all projects [(account or organization scope)](#account-or-organization-scope) or scoped to a specific project [(project scope)](#project-scope).
+:::
 
 #### Account or organization scope
 
@@ -608,7 +610,7 @@ If you prefer, you can instead create the service account at the Harness organiz
 If created at the project level, the API key would not be sharable (by inheriting) across multiple projects. You would only be able to use it in the project where it was created.
 :::
 
-### Environment Scope
+#### Environment Scope
 
 :::warning
 Creating a new Admin API key scoped to specific FME environments in the Harness FME module is not yet possible using Harness RBAC.
@@ -717,6 +719,22 @@ Until you grant access to your project using **Access Control** in your **Projec
 
 To grant access to your project, you can choose to follow the permission pattern of a legacy Split restricted project or unrestricted project. Initially, we recommend following one of these patterns. After some time, you may prefer to implement RBAC strategies aligned to your company policies and practices.
 
+<Tabs>
+<TabItem value="unrestricted" label="Unrestricted project">
+
+To implement permissions similar to the legacy Split unrestricted project:
+
+From your **Project Settings** inherit each of the [FME user groups](#fme-user-groups) and add the following project-level role bindings:
+   
+   - All FME Admins: **Split FME Administrator Role** - **All Project Level Resources**
+   - All FME Editors: **Split FME Manager Role** - **All Project Level Resources**
+   - All FME Viewers: **Project Viewer** - **All Project Level Resources**
+
+Role bindings added at the project level grant access to the given project.
+
+</TabItem>
+<TabItem value="restricted" label="Restricted project">
+
 To implement permissions similar to the legacy Split restricted project:
 
 1. From your **Project Settings**, add or inherit one or more of the following RBAC principals:
@@ -731,15 +749,8 @@ To implement permissions similar to the legacy Split restricted project:
    - **Split FME Manager Role** corresponds to the legacy Editor role
    - **Project Viewer** corresponds to the legacy Viewer role
 
-To implement permissions similar to the legacy Split unrestricted project:
-
-1. Inherit each of the [FME user groups](#fme-user-groups) at your project level and add the following project-level role bindings:
-   
-   - All FME Admins: **Split FME Administrator Role** - **All Project Level Resources**
-   - All FME Editors: **Split FME Manager Role** - **All Project Level Resources**
-   - All FME Viewers: **Project Viewer** - **All Project Level Resources**
-
-Role bindings added at the project level grant access to the specific project.
+</TabItem>
+</Tabs>
 
 ### Add an Admin API key (service account) to the project
 
@@ -897,17 +908,17 @@ To view SDK API keys for a project:
 
 ## Troubleshooting
 
-### My SDK feature flag evaluations work, but my FME project is not visible in Harness
+#### My SDK feature flag evaluations work, but my FME project is not visible in Harness
 
 Check with your Harness admin to be sure that the FME project does not exist in Harness. It could be that an admin somehow removed your view privileges.
 
 If your Harness admin does not see your FME project on the Projects page in FME Settings, then the project may have been deleted in Harness without first deleting all FME project resources. You can take the steps in the next section (below).
 
-### What can I do if I deleted a project without first deleting all FME project resources?
+#### What can I do if I deleted a project without first deleting all FME project resources?
 
 Contact support@split.io and provide us with the workspace ID of your orphaned FME project and the name of the deleted project in Harness. We will advise you on your next steps.
 
-### My legacy Split Admin API key stopped working
+#### My legacy Split Admin API key stopped working
 
 Check if the corresponding service account exists in Harness:
 
@@ -920,7 +931,7 @@ If you found the corresponding service account, you can investigate that its rol
 
 If you did not find the corresponding service account, you can take the steps in the next section (below).
 
-### What can I do if I mistakenly deleted a service account that was linked with my legacy Split Admin API key?
+#### What can I do if I mistakenly deleted a service account that was linked with my legacy Split Admin API key?
 
 Your legacy Split Admin API key will no longer authenticate your API requests.
 

--- a/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
+++ b/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
@@ -504,7 +504,7 @@ If you don’t have a service account with role bindings set up, you can create 
 
 This section provides steps to create a service account and role bindings for an Admin API key scoped to all existing projects in your Harness account or organization. You can follow these steps if you don’t have a service account created during migration or if you prefer not to use it.
 
-:::danger All Resources Including Child Scopes (resource group) is not recommended
+:::warning All Resources Including Child Scopes (resource group) is not recommended
 The steps in this section guide you to add an **Account Admin** role for **All Account Level Resources**, and then grant equivalent permissions at the organization and project levels.
 
 It is not recommended to use the **Account Admin** role for **All Resources Including Child Scopes**. This resource group includes all child resources at the organization and project levels.
@@ -635,11 +635,11 @@ While it is currently not possible post-migration to create Admin API keys scope
 
 Currently, for FME resources, resource groups in Harness define RBAC access to *all* entities of a given type. This means that access to specific environments within a project cannot be configured; only access to *all* environments within a project can be granted or revoked.
 
-:::info
-New API keys created in Harness cannot be scoped to specific FME environments of a project, even if you add the API key to a Harness service account linked to an environment-scoped legacy Split Admin API key.
-:::
+Note that new API keys created in Harness cannot be scoped to specific FME environments of a project, even if you add the API key to a Harness service account linked to an environment-scoped legacy Split Admin API key.
 
+:::info
 Your legacy Split Admin API key (created pre-migration) scoped to specific environments will continue to work that way. The legacy API key will be authorized by the back-end servers, as before migration.
+:::
 
 ### Delete an Admin API key
 

--- a/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
+++ b/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
@@ -28,11 +28,10 @@ The following terminology is referenced in this guide:
 * **Harness FME**: This refers to the legacy Split application once it has been migrated to `app.harness.io`. The migration preserves the application intact and converts it to a module within Harness called Feature Management and Experimentation (FME).
 * **The Harness FME team**: The Split team is here referred to as the Harness FME team (renamed after Split was acquired by Harness), but it is the same people.
 * **API keys**:
-
   * **Admin API keys**: Authentication tokens used to authorize [Split Admin API requests](https://docs.split.io/reference/introduction). These authentication tokens can be created on the Harness platform after migrating.
   * **SDK API keys**: Authentication tokens used to authorize FME SDK requests. SDK API keys are managed by the Harness FME module.
   * **API keys**: The Harness platform manages API keys and tokens within service accounts.* When “API keys” is not preceded by “Admin” or “SDK”, then this guide is referring to these Harness platform API key entities.
-
+  
   :::info
   In Harness, API keys can also be created at the [personal user scope](/docs/platform/automation/api/add-and-manage-api-keys/#create-personal-api-keys-and-tokens), but the migration script does not create personal access API keys and tokens, so these are outside the scope of this guide.
   :::
@@ -76,7 +75,7 @@ No role bindings were added to your individual Harness users at the account or o
 
 This section shows you how to add new Harness users and set up RBAC permissions that mimic your legacy Split permissions.
 
-When you add a user, you will see the FME user groups that were created at the account or organization level. You’ll be guided to add the new Harness user at the same scope. Once a user is added to the Harness platform, it is easy to add the same user at all other scopes.
+When you add a user at the account level, you can also add the user to an [FME user group](#fme-user-groups). Once a user is added to the Harness platform, it is easy to add the same user to any organization or project.
 
 #### Interactive guide
 
@@ -88,9 +87,9 @@ This interactive guide shows how to add a user to Harness that will have access 
 
 To add a user that will have access to your (unrestricted) migrated FME projects:
 
-1. Begin adding the user at the same scope (account or organization) as your [FME user groups](#fme-user-groups):
+1. Begin adding the user at the Harness account level:
 
-   - In the left navigation panel, click **Account settings** or **Organization settings**, click **Access Control** at the top of the page, and click the **Users** tile.
+   - In the left navigation panel, click **Account settings**, click **Access Control** at the top of the page, and click the **Users** tile.
    - Click **+ New User** to begin adding a new user.
    - Type the user email in the **Users (name or email)** textbox, and select **+ email you just typed** that appears below the textbox. (You can add multiple users at once by entering multiple email addresses.)
 1. Apply permissions to the user by adding the user to a user group:
@@ -156,29 +155,186 @@ The screenshot below shows a Harness user group that was created for a legacy Sp
 
 ### FME user groups
 
-When your account was migrated to Harness, the migration script created new Harness user groups and role bindings to replicate your legacy Split settings:
+When your account was migrated to Harness, the migration script created new Harness FME user groups and assigned role bindings to replicate your legacy Split settings.
 
-| **Legacy Split setting** | **Harness user group** | **Harness scope** (where the user group is created and managed) | **Harness role** | **Harness resource group** |
-|--------------------------|-------------------------|------------------------------------------------------------------|-------------------|-----------------------------|
-| Administrators (Legacy Split group) | All FME Admins | Harness account (for a new Harness account) <br /><br /> Harness organization (for a pre-existing Harness account) | Account Admin (new account) <br /><br /> Organization Admin (pre-existing account) | All Resources Including Child Scopes |
-| Editors (Legacy Split role) | All FME Editors | Harness account <br /> Harness organization |  | All Resources Including Child Scopes |
-| Viewers (Legacy Split role) | All FME Viewers | Harness account <br /> Harness organization |  | All Resources Including Child Scopes |
+#### Role bindings at the account and organization levels
 
-The user groups were created at the Harness account scope (if no Harness account existed before the migration) or Harness organization scope (if you already had an existing Harness account that your legacy Split objects were merged into).
+| Legacy Split setting | Harness user group | Harness scope <br /> <span style={{ fontWeight: 100 }}>where the user group is created and managed</span> | Role binding <br /> <span style={{ fontWeight: 100 }}>Harness role + Harness resource group</span> |
+|---|---|---|---|
+| Administrators <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split group</span> | All FME Admins | Harness account | <span style={{fontFamily: 'Courier New'}}>For a new Harness account:</span> <br /> Account Admin + All Resources Including Child Scopes <br /><br /> Organization Viewer + All Organization Level Resources <br /><br /> <span style={{fontFamily: 'Courier New'}}>For a pre-existing Harness account:</span> <br /> Organization Admin + All Organization Level Resources |
+| Editors <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role</span> | All FME Editors | Harness account |  Organization Viewer + All Organization Level Resources |
+| Viewers <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role</span> | All FME Viewers | Harness account |  Organization Viewer + All Organization Level Resources |
+
+These FME user groups were created at the Harness account scope. The FME user groups for a new Harness account (no Harness account existed before migration) is shown in the screenshot below.
 
 ![](./static/account-settings-user-group.png)
 
+:::info[Where are Role bindings assigned?]
+Role bindings are assigned at the scope where they apply. For example:
+  * The role binding **Account Admin + All Resources Including Child Scopes** is assigned in Account settings.
+  * The role binding **Organization Viewer + All Organization Level Resources** is assigned in Organization settings.
+  * Project-scoped role bindings are assigned in Project settings.
+:::
+
 #### Role bindings at the project level
 
-To grant similar permissions to your legacy Split settings, the new Harness user groups were inherited by Harness projects and role bindings were applied:
+To grant similar permissions to your legacy Split settings, the new Harness FME user groups were inherited by Harness projects and the following role bindings were assigned:
 
-| **Legacy Split setting** | **Harness user group** | **Role binding (role + resource group)** (and the scope where the role binding was assigned) | **Harness scope** | **Harness role** | **Harness resource group** |
-|--------------------------|------------------------|----------------------------------------------------------------------------------------------|--------------------|-------------------|-----------------------------|
-| Project (any permission settings) - All FME Admins | Harness project | Split FME Administrator Role <br /> *(Project scope)* | Project | Split FME Administrator Role | All Project Level Resources |
-| Project (any permission settings) - All FME Editors | Harness project | Split FME Manager Role <br /> *(Project scope)* | Project | Split FME Manager Role <br /> Project Viewer | All Project Level Resources |
-| Project (any permission settings) - All FME Viewers | Harness project | Project Viewer <br /> *(Project scope)* | Project | Project Viewer | All Project Level Resources |
-| Legacy Split group <br /> *(group you created in Split)* + **Editor** (Legacy Split role of all users in the group) | Harness group <br /> *(created at the Harness organization level)* | Split FME Manager Role <br /> Project Viewer <br /> *(Project scope)* | Harness project <br /> *(if project is not restricted OR restricted but grants group access)* | Split FME Manager Role <br /> Project Viewer | All Project Level Resources |
-| Legacy Split group <br /> *(group you created in Split)* + **Viewer** (Legacy Split role of at least one user in the group)* | Harness group <br /> *(created at the Harness organization level)* | Project Viewer <br /> *(Project scope)* | Harness project <br /> *(if project is not restricted OR restricted but grants group access)* | Project Viewer | All Project Level Resources |
+<div>
+      <table>
+        <colgroup>
+          <col style={{width: '35%'}} />
+          <col style={{width: '15%'}} />
+          <col style={{width: '19%'}} />
+          <col style={{width: '13%'}} />
+          <col style={{width: '18%'}} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th rowspan="2" scope="col">
+              Legacy Split setting
+            </th>
+            <th rowspan="2" scope="col">
+              Harness user group
+            </th>
+            <th colspan="3" scope="col">
+              <strong>Role binding</strong> <span style={{fontWeight: 300}}> (role + resource group) assigned to the user group (and the scope where the role binding was assigned)</span>
+            </th>
+          </tr>
+          <tr>
+            <th scope="col">
+              Harness scope
+            </th>
+            <th scope="col">
+              Harness role
+            </th>
+            <th scope="col">
+              Harness resource group
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <p>
+                Project <br /> <span style={{fontFamily: 'Courier New'}}>(any permission settings)</span>
+              </p>
+            </td>
+            <td>
+              All FME Admins
+            </td>
+            <td>
+              Harness project
+            </td>
+            <td>
+              <p>
+                Split FME Administrator Role
+              </p>
+              <p>
+                Project Viewer
+              </p>
+            </td>
+            <td>
+              All Project Level Resources
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                Project - Anyone can access <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split project permissions</span>
+              </p>
+            </td>
+            <td>
+              All FME Editors
+            </td>
+            <td>
+              Harness project
+            </td>
+            <td>
+              <p>
+                Split FME Manager Role
+              </p>
+              <p>
+                Project Viewer
+              </p>
+            </td>
+            <td>
+              All Project Level Resources
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                Project - Anyone can access <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split project permissions</span>
+              </p>
+            </td>
+            <td>
+              All FME Viewers
+            </td>
+            <td>
+              Harness project
+            </td>
+            <td>
+              Project Viewer
+            </td>
+            <td>
+              All Project Level Resources
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                Legacy Split group <br /> <span style={{fontFamily: 'Courier New'}}>A group you created in Split</span> <br /> + <br /> Editor <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role (of all users in the group)</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                Harness group <br /> <span style={{fontFamily: 'Courier New'}}>Created at the Harness organization level</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                Harness project <br /> <span style={{fontFamily: 'Courier New'}}>if the project is not restricted OR the project is restricted but grants the group access</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                Split FME Manager Role
+              </p>
+              <p>
+                Project Viewer
+              </p>
+            </td>
+            <td>
+              All Project Level Resources
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>
+                Legacy Split group <br /> <span style={{fontFamily: 'Courier New'}}>A group you created in Split</span> <br /> + <br /> Viewer <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role (of at least one user in the group)*</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                Harness group <br /> <span style={{fontFamily: 'Courier New'}}>Created at the Harness organization level</span>
+              </p>
+            </td>
+            <td>
+              <p>
+                Harness project <br /> <span style={{fontFamily: 'Courier New'}}>if the project is not restricted OR the project is restricted but grants the group access</span>
+              </p>
+            </td>
+            <td>
+              Project Viewer
+            </td>
+            <td>
+              All Project Level Resources
+            </td>
+          </tr>
+        </tbody>
+      </table>
+</div>
 
 \* Users may lose edit permissions for a restricted project.  
 
@@ -196,7 +352,7 @@ For an unrestricted project:
 
 The Website project was an unrestricted project in legacy Split. After migration, the FME user groups (**All FME Admins**, **All FME Editors**, and **All FME Viewers**) are inherited and role bindings are assigned at the project level as shown below. (All role bindings are for the **All Project Level Resources** resource group.)
 
-The **All Project Users** is a Harness managed group that is created on project creation, and users are automatically added to this group when added to the project
+The **All Project Users** is a Harness managed group that is created on project creation, and users are automatically added to this group when added to the project.
 
 For a restricted project:
 
@@ -265,10 +421,10 @@ When your Split account is migrated to Harness, a service account is created for
 :::danger Do not delete service accounts linked with legacy Admin API keys
 Each service account created by the migration script and its role bindings are linked with one of your legacy Split Admin API keys. The service account role bindings define the access granted to the Admin API key over Harness resources, and are necessary for the Admin API key to authorize your API requests after your migration to Harness.
 
-This association between your legacy Split Admin API keys and service accounts is not visually shown in Harness. The service accounts do not appear to contain tokens (on the pages where they are managed in Harness); however, the tokens are the legacy Split Admin API keys (shown in FME Settings). It is best to delete the legacy Split Admin API key in FME Settings before deleting the associated service account; otherwise, if the service account is deleted before the Admin API key, then the Admin API key will not work.
+This association between your legacy Split Admin API keys and service accounts is **not visually shown** in Harness. The service accounts do not appear to contain tokens (on the pages where they are managed in Harness); however, the tokens are the legacy Split Admin API keys (shown in FME Settings). It is best to delete the legacy Split Admin API key in FME Settings before deleting the associated service account; otherwise, if the service account is deleted before the Admin API key, then the Admin API key will not work.
 :::
 
-:::info How to find which Harness service account is linked with a legacy Split Admin API key
+:::tip To find which Harness service account is linked with a legacy Split Admin API key:
 You can look for the service account name that matches the name of your legacy Split Admin API key. This service account is internally linked to your Admin API key, and the role bindings of this service account are applied to your Admin API key.
 
 In the left navigation panel, click **Account settings** or **Organization settings**, and click the **Service accounts** tile. The name of the linked service account is the same as the name of your legacy Split Admin API key, with spaces removed.
@@ -332,15 +488,13 @@ The steps in this section guide you to add an **Account Admin** role for **All A
 It is not recommended to use the **Account Admin** role for **All Resources Including Child Scopes**. This resource group includes all child resources at the organization and project levels.
 
 The **All Resources Including Child Scopes** is not recommended because it would grant permissions to access:
-
-- Any projects with restricted permissions (set up before migration)
-- All projects added to the account in the future
+    - Any projects with restricted permissions (set up before migration)
+    - All projects added to the account in the future
 :::
 
 To create an Admin API key scoped to all projects in your Harness account:
 
 1. At the account level, create the service account and assign roles:
-   
    - In the left navigation panel, click **Account settings**.
    - Click the **Access control** button at the top of the page.
    - Click the **Service accounts** tile.
@@ -350,6 +504,7 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **+ Add**.
    - Select the **Account Admin** role and the **All Account Level Resources** resource group.
    - Click **Apply**. The role binding is added to the service account.
+
 1. At the organization level, inherit the service account and assign roles:
    - In the left navigation panel, select the default organization.
    - Click **Organization settings**.
@@ -361,9 +516,10 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **Apply Selected**.
    - In the **Manage Role Bindings** modal, select the **Organization Admin** role and leave the **All Organization Level Resources** resource group unchanged.
    - Click **Apply**. The service account and role binding is listed.
+
 1. For each project: At the project level, inherit the service account and assign roles:
    - In the left navigation panel, select the project.
-   - Click Project settings.
+   - Click **Project settings**.
    - Click the **Access control** button at the top of the page.
    - Click the **Service accounts** tile.
    - Click the **Inherit Service Accounts and Assign Roles** button at the top of the page.
@@ -372,6 +528,7 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **Apply Selected**.
    - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged.
    - Click **Apply**. The service account and role binding is listed.
+   
 1. Create the API key and token at the account level:
    - In the left navigation panel, click **Account settings**.
    - Click the **Access control** button at the top of the page.
@@ -404,6 +561,7 @@ To create an Admin API key scoped to a specific project in your Harness account:
    - Click **+ Add**.
    - Select the **Account Admin** role and the **All Account Level Resources** resource group.
    - Click **Apply**. The role binding is added to the service account.
+
 1. At the project level, inherit the service account and assign roles:
    - In the left navigation panel, select the project.
    - Click **Project settings**.
@@ -415,6 +573,7 @@ To create an Admin API key scoped to a specific project in your Harness account:
    - Click **Apply Selected**.
    - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged.
    - Click **Apply**. The service account and role binding is listed.
+
 1. Create the API key and token at the account level:
    - In the left navigation panel, click **Account settings**.
    - Click the **Access control** button at the top of the page.
@@ -514,6 +673,12 @@ When your Split account is migrated to Harness, an organization named `default` 
 
 ### Create a project
 
+#### Interactive guide
+
+<DocVideo src="https://app.tango.us/app/embed/4c5d12d9-a82c-4a54-a54e-c0684ddc3475" title="Create a New Project" />
+
+#### Step by step guide
+
 To create a new project in Harness:
 
 1. In the left navigation panel, click the Grid icon and click **Feature Management & Experimentation**.
@@ -523,10 +688,6 @@ To create a new project in Harness:
 1. Click **+ New Project**.
 1. Enter a name for the project and click **Save and Continue**.
 1. Click **Save and Continue** again to close the modal. You can grant access to the project using **Access Control** in **Project Settings**.
-
-#### Interactive guide
-
-<DocVideo src="https://app.tango.us/app/embed/4c5d12d9-a82c-4a54-a54e-c0684ddc3475" title="Create a New Project" />
 
 #### Unrestricted and restricted projects
 
@@ -581,6 +742,23 @@ If you accidentally delete a project before deleting its resources, see the [Tro
 
 #### Interactive guide
 
+
+To cleanly delete a project in your Harness account:
+
+1. First delete the following FME resources from your project:
+
+   * Integrations
+   * Feature flags
+   * Segments
+   * Metrics
+   * Experiments
+   * Traffic types
+   * Admin API keys
+   * SDK API keys
+   * Environments
+
+2. **When all FME resources are deleted from your project**, you can cleanly delete a project from the Harness Projects page:
+
 <DocVideo src="https://app.tango.us/app/embed/f046a6bd-4c56-414d-9398-f83ebbeb57d5" title="Delete a Project" />
 
 #### Step by step guide
@@ -599,16 +777,13 @@ To cleanly delete a project in your Harness account:
    * SDK API keys
    * Environments
 
-1. When all FME resources are deleted from your project, you can cleanly delete a project from the Harness **Projects** page:
+2. **When all FME resources are deleted from your project**, you can cleanly delete a project from the Harness Projects page:
    * Click the PROJECT (scope button) on the left navigation panel and click **Select Another Scope**.
-   * Click **Select Another Scope**.
    * On the **Projects** tab, click **Manage Projects**.
    * Find the tile listing the project that you’d like to delete, click the **More options (⋮)** menu, and select **Delete**.
-
      :::info
      The warning in the dialog does not reflect the state of your project's FME resources. You will still see the warning "However, resources in the Feature Management & Experimentation (FME) module…" even after you have deleted all FME resources from the project.
      :::
-
    * Click **Yes, I want to delete this project**.
    * Type the project’s name in the text field and click **Delete**.
 
@@ -664,7 +839,7 @@ The **All environments** page is not shown in Harness.
 
 Instead, you can view environments per project:
 
-1. In the left navigation panel, click the Grid icon and click **Feature Management & Experimentation**.
+1. In the left navigation panel, click the **Grid** icon and click **Feature Management & Experimentation**.
 1. Click **FME Settings**.
 1. Click **Projects**.
 1. Find the row listing the project with the environments you’d like to view and click **View** in the **Actions** column.
@@ -678,7 +853,7 @@ The **All traffic types** page is not shown in Harness.
 
 Instead, you can view traffic types per project:
 
-1. In the left navigation panel, click the Grid icon and click **Feature Management & Experimentation**.
+1. In the left navigation panel, click the **Grid** icon and click **Feature Management & Experimentation**.
 1. Click **FME Settings**.
 1. Click **Projects**.
 1. Find the row listing the project with the traffic types you’d like to view and click **View** in the **Actions** column.
@@ -692,7 +867,7 @@ The **SDK API Keys** tab has moved to the project page in **FME Settings**.
 
 To view SDK API keys for a project:
 
-1. In the left navigation panel, click the Grid icon and click **Feature Management & Experimentation**.
+1. In the left navigation panel, click the **Grid** icon and click **Feature Management & Experimentation**.
 1. Click **FME Settings**.
 1. Click **Projects**.
 1. Find the row listing the project with the SDK API keys you’d like to view and click **View** in the **Actions** column.

--- a/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
+++ b/docs/feature-management-experimentation/split-to-harness/administering-migrated-account.md
@@ -34,10 +34,8 @@ The following terminology is referenced in this guide:
   * **Admin API keys**: Authentication tokens used to authorize [Split Admin API requests](https://docs.split.io/reference/introduction). These authentication tokens can be created on the Harness platform after migrating.
   * **SDK API keys**: Authentication tokens used to authorize FME SDK requests. SDK API keys are managed by the Harness FME module.
   * **API keys**: The Harness platform manages API keys and tokens within service accounts.* When “API keys” is not preceded by “Admin” or “SDK”, then this guide is referring to these Harness platform API key entities.
-  
-  :::info
-  In Harness, API keys can also be created at the [personal user scope](/docs/platform/automation/api/add-and-manage-api-keys/#create-personal-api-keys-and-tokens), but the migration script does not create personal access API keys and tokens, so these are outside the scope of this guide.
-  :::
+
+<span style={{fontSize: '0.8em'}}>\* *In Harness, API keys can also be created at the [personal user scope](/docs/platform/automation/api/add-and-manage-api-keys/#create-personal-api-keys-and-tokens), but the migration script does not create personal access API keys and tokens, so these are outside the scope of this guide.*</span>
 
 ## Users
 
@@ -112,7 +110,9 @@ To add a user to Harness that will have access to your (unrestricted) migrated F
 
 The RBAC permissions (that mimic legacy Split permissions) are set on the FME user group to which the new Harness user was added. You can learn more about these user group role bindings in the [User Groups](#user-groups) section.
 
-If you want to grant the user access to a restricted project, you’ll need to add the user directly to the project (in the Project Settings) and assign the role binding for **All Project Level Resources**: **Split FME Administrator Role**, **Split FME Manager**, or **Project Viewer**. Go to [Unrestricted and Restricted Projects](#unrestricted-and-restricted-projects) to learn more.
+:::tip
+If you want to grant the user access to a restricted project, you’ll need to add the user directly to the project (in the Project Settings) and assign the project-level role binding. Go to [Unrestricted and Restricted Projects](#unrestricted-and-restricted-projects) to learn more.
+:::
 
 ### Delete a user
 
@@ -167,7 +167,7 @@ When your account was migrated to Harness, the migration script created new Harn
 
 #### Role bindings at the account and organization levels
 
-| Legacy Split setting | Harness user group | Harness scope <br /> <span style={{ fontWeight: 100 }}>where the user group is created and managed</span> | Role binding <br /> <span style={{ fontWeight: 100 }}>Harness role + Harness resource group</span> |
+| Legacy Split setting | Harness user group | Harness scope <br /> <span style={{fontWeight: 100}}>where the user group is created and managed</span> | Role binding <br /> <span style={{fontWeight: 100}}>Harness role + Harness resource group</span> |
 |---|---|---|---|
 | Administrators <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split group</span> | All FME Admins | Harness account | <span style={{fontFamily: 'Courier New'}}>For a new Harness account:</span> <br /> Account Admin + All Resources Including Child Scopes <br /><br /> Organization Viewer + All Organization Level Resources <br /><br /> <span style={{fontFamily: 'Courier New'}}>For a pre-existing Harness account:</span> <br /> Organization Admin + All Organization Level Resources |
 | Editors <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role</span> | All FME Editors | Harness account |  Organization Viewer + All Organization Level Resources |
@@ -243,7 +243,7 @@ To grant similar permissions to your legacy Split settings, the new Harness FME 
               </p>
             </td>
             <td>
-              All Project Level Resources
+              All Project Level Resources <br /> <span style={{fontFamily: 'Courier New'}}>or</span> <br /> FME All Resources\*
             </td>
           </tr>
           <tr>
@@ -267,7 +267,7 @@ To grant similar permissions to your legacy Split settings, the new Harness FME 
               </p>
             </td>
             <td>
-              All Project Level Resources
+              All Project Level Resources <br /> <span style={{fontFamily: 'Courier New'}}>or</span> <br /> FME All Resources\*
             </td>
           </tr>
           <tr>
@@ -286,7 +286,7 @@ To grant similar permissions to your legacy Split settings, the new Harness FME 
               Project Viewer
             </td>
             <td>
-              All Project Level Resources
+              All Project Level Resources <br /> <span style={{fontFamily: 'Courier New'}}>or</span> <br /> FME All Resources\*
             </td>
           </tr>
           <tr>
@@ -314,13 +314,13 @@ To grant similar permissions to your legacy Split settings, the new Harness FME 
               </p>
             </td>
             <td>
-              All Project Level Resources
+              All Project Level Resources <br /> <span style={{fontFamily: 'Courier New'}}>or</span> <br /> FME All Resources\*
             </td>
           </tr>
           <tr>
             <td>
               <p>
-                Legacy Split group <br /> <span style={{fontFamily: 'Courier New'}}>A group you created in Split</span> <br /> + <br /> Viewer <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role (of at least one user in the group)*</span>
+                Legacy Split group <br /> <span style={{fontFamily: 'Courier New'}}>A group you created in Split</span> <br /> + <br /> Viewer <br /> <span style={{fontFamily: 'Courier New'}}>Legacy Split role (of at least one user in the group)</span>\*\*
               </p>
             </td>
             <td>
@@ -337,19 +337,24 @@ To grant similar permissions to your legacy Split settings, the new Harness FME 
               Project Viewer
             </td>
             <td>
-              All Project Level Resources
+              All Project Level Resources <br /> <span style={{fontFamily: 'Courier New'}}>or</span> <br /> FME All Resources\*
             </td>
           </tr>
         </tbody>
       </table>
 </div>
 
-\* Users may lose edit permissions for a restricted project.  
+<span style={{fontSize: '0.8em'}}>
+
+\* *If you were migrated to a Harness account on the Enterprise plan, then the **FME All Resources** project-level resource group was created and used in role bindings at the project level. Harness accounts on the Free plan do not have permissions to create resource groups, so the **All Project Level Resources** Harness built-in resource group was used instead.*
+
+\*\* *Users may lose edit permissions for a restricted project:*
+</span>
 
 :::warning In legacy Split groups with both editors and viewers – Editors will lose permissions.
-If a group in legacy Split had both editors and viewers (legacy roles) and the group was given access to a restricted project, then post-migration the Harness group will be assigned only the Project Viewer role. (This prevents viewers from gaining broader permissions upon migration.) The users that were legacy Split editors will no longer have edit permissions for the project.
+If a group in legacy Split had both editors and viewers (legacy roles) and the group was given access to a restricted project, then post-migration the Harness group will be assigned only the **Project Viewer** role. (This prevents viewers from gaining broader permissions upon migration.) The users that were legacy Split editors will no longer have edit permissions for the project.
 
-Since RBAC is additive, you can assign edit permissions by adding the Harness user (with the legacy Editor role) at the project level and assigning the role binding: Split FME Manager Role role and All Project Level Resources resource group.
+Since RBAC is additive, you can assign edit permissions by adding the Harness user (with the legacy Editor role) at the project level and assigning the role binding: **Split FME Manager Role** role and **All Project Level Resources** (or **FME All Resources**) resource group.
 :::
 
 #### Examples showing user group inheritance and role bindings
@@ -358,9 +363,11 @@ For an unrestricted project:
 
 ![](./static/unrestricted-project.png)
 
-The Website project was an unrestricted project in legacy Split. After migration, the FME user groups (**All FME Admins**, **All FME Editors**, and **All FME Viewers**) are inherited and role bindings are assigned at the project level as shown below. (All role bindings are for the **All Project Level Resources** resource group.)
+The Website project was an unrestricted project in legacy Split. After migration, the FME user groups (**All FME Admins**, **All FME Editors**, and **All FME Viewers**) are inherited and role bindings are assigned at the project level as shown below. (All role bindings are for the **All Project Level Resources** resource group, created on the Harness Free plan. On the Harness Enterprise plan, the **FME All Resources** resource group would be created and used instead.)
 
+:::note[&nbsp;]
 The **All Project Users** is a Harness managed group that is created on project creation, and users are automatically added to this group when added to the project.
+:::
 
 For a restricted project:
 
@@ -521,7 +528,7 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **Apply**. The role binding is added to the service account.
 
 1. At the organization level, inherit the service account and assign roles:
-   - In the left navigation panel, select the default organization.
+   - In the left navigation panel, select the organization [where your Split legacy projects were migrated](#projects) (or where your FME objects are defined or will be defined).
    - Click **Organization settings**.
    - Click the **Access control** button at the top of the page.
    - Click the **Service accounts** tile.
@@ -541,7 +548,7 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **Select Service Accounts**.
    - Select the **Account** tab and select the service account created in Step 1.
    - Click **Apply Selected**.
-   - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged.
+   - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged (or select **FME All Resources**\*).
    - Click **Apply**. The service account and role binding is listed.
    
 1. Create the API key and token at the account level:
@@ -554,6 +561,10 @@ To create an Admin API key scoped to all projects in your Harness account:
    - Click **+ Token**.
    - Enter a name for the new API key token, set an expiration, and click **Generate Token**.
    - Copy the token somewhere safe.
+
+<span style={{fontSize: '0.8em'}}>\* *The **FME All Resources** resource group was created if you were migrated to a Harness account on the Enterprise plan. If you were migrated to a Harness account on the Free plan, you should use the **All Project Level Resources** resource group.* </span>
+
+<br /><br />
 
 :::tip Service accounts for <code>Admin API keys scoped to all projects</code> can also be created at the organization level
 If you prefer, you can instead create the service account at the Harness organization level. Steps 1 and 4 would be done at the organization level, and Step 2 would be omitted. The **Organization Admin** role for **All Organization Level Resources** is required for the Admin API key to be granted permission to list Harness projects and Harness elements attached to projects.
@@ -586,7 +597,7 @@ To create an Admin API key scoped to a specific project in your Harness account:
    - Click **Select Service Accounts**.
    - Select the **Account** tab and select the service account created in Step 1.
    - Click **Apply Selected**.
-   - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged.
+   - In the **Manage Role Bindings** modal, select the **Project Admin** role and leave the **All Project Level Resources** resource group unchanged (or select **FME All Resources**\*).
    - Click **Apply**. The service account and role binding is listed.
 
 1. Create the API key and token at the account level:
@@ -600,12 +611,16 @@ To create an Admin API key scoped to a specific project in your Harness account:
    - Enter a name for the new API key token, set an expiration, and click **Generate Token**.
    - Copy the token somewhere safe.
 
+<span style={{fontSize: '0.8em'}}>\* *The **FME All Resources** resource group was created if you were migrated to a Harness account on the Enterprise plan. If you were migrated to a Harness account on the Free plan, you should use the **All Project Level Resources** resource group.* </span>
+
+<br /><br />
+
 :::tip Service accounts for <code>Admin API keys scoped to specific projects</code> can also be created at the organization/project level
 
 If you prefer, you can instead create the service account at the Harness organization or project level:
 
 - **Organization level**: Steps 1 and 3 would be done at the organization level. In step 1, you would apply the role binding: Organization Admin role for All Organization Level Resources.
-- **Project level**: Steps 1 and 3 would be done at the project level, and step 2 would be omitted. In step 1, you would apply the role binding: Project Admin role for All Project Level Resources.
+- **Project level**: Steps 1 and 3 would be done at the project level, and step 2 would be omitted. In step 1, you would apply the role binding: Project Admin role for All Project Level Resources (or FME All Resources).
 
 If created at the project level, the API key would not be sharable (by inheriting) across multiple projects. You would only be able to use it in the project where it was created.
 :::
@@ -684,7 +699,7 @@ To clone an SDK API key in your Harness account:
 
 In Harness, an account contains a set of [organizations](#what-is-a-harness-organization), and an organization contains a set of projects.
 
-When your Split account is migrated to Harness, an organization named `default` is created. Your projects are created within this organization. These Harness projects each internally link to your Harness FME projects.
+If your Split account is migrated to a Harness account on the Enterprise plan, a Harness organization named <strong> *legacy Split account name* FME</strong> is created, and your projects are created within this organization. On the Free plan, your projects are created in the **default** Harness organization in your Harness account. These Harness projects each internally link to your Harness FME projects.
 
 ### Create a project
 
@@ -726,9 +741,9 @@ To implement permissions similar to the legacy Split unrestricted project:
 
 From your **Project Settings** inherit each of the [FME user groups](#fme-user-groups) and add the following project-level role bindings:
    
-   - All FME Admins: **Split FME Administrator Role** - **All Project Level Resources**
-   - All FME Editors: **Split FME Manager Role** - **All Project Level Resources**
-   - All FME Viewers: **Project Viewer** - **All Project Level Resources**
+   - All FME Admins: **Split FME Administrator Role** - **FME All Resources**\*
+   - All FME Editors: **Split FME Manager Role** - **FME All Resources**\*
+   - All FME Viewers: **Project Viewer** - **FME All Resources**\*
 
 Role bindings added at the project level grant access to the given project.
 
@@ -743,7 +758,7 @@ To implement permissions similar to the legacy Split restricted project:
    - Inherit a **user group** (from the account or organization) and assign role bindings at the project level.
    - Inherit a **service account** with an API key and token (grants access to an Admin API key) and assign role bindings at the project level.
 
-1. Apply a role binding for **All Project Level Resources** that assigns one of the following roles:
+1. Apply a role binding for **FME All Resources**\* that assigns one of the following roles:
 
    - **Split FME Administrator Role** corresponds to the legacy Split Administrator permissions
    - **Split FME Manager Role** corresponds to the legacy Editor role
@@ -752,11 +767,13 @@ To implement permissions similar to the legacy Split restricted project:
 </TabItem>
 </Tabs>
 
+<span style={{fontSize: '0.8em'}}>\* *If you were migrated to a Harness account on the Free plan, you can use the **All Project Level Resources** resource group.* </span>
+
 ### Add an Admin API key (service account) to the project
 
 To grant an Admin API key access to your project, we recommend you follow the steps in [Create an API key - Project scope](#project-scope):
 
-- Steps 1-3 guide you to create a service account and grant **Project Admin** permissions to **All Project Level Resources** of your project.
+- Steps 1-3 guide you to create a service account and grant **Project Admin** permissions to **All Project Level Resources** (or **FME All Resources**) of your project.
 - You only need to do Step 2 if the service account is already created, and the API key and token are already added to it.
 
 ### Delete a project
@@ -836,7 +853,7 @@ An organization is a Harness entity that fits into the Harness structure as show
 
 ![](./static/org-diagram.png)
 
-The migration script created a Harness organization named `default`. Harness projects that correspond to legacy Split projects were created in this organization.
+The migration script created Harness projects that correspond to legacy Split projects. These Harness projects are created in the **default** organization (on the Free plan) or in an organization named <strong> *legacy Split account name* FME</strong> (on the Enterprise plan).
 
 #### What are Harness environments (resources) shown in Harness Project, Organization, or Account settings?
 


### PR DESCRIPTION
## Description

1. [link to [commit](https://github.com/harness/developer-hub/commit/8fb55dcccff278252b0b973ad004a53936f00b7a)] Add the following info for paid accounts:

  Harness account with **Enterprise plan** vs Harness account with **free plan**
* **Naming:**
   * **Enterprise plan**
     * Harness account name = [Split account name]
     * **Harness organization name = [Split account name] + FME**
  * Free plan
    * Harness account name = [Split account name]
    * Harness organization name = default

* **Resource group used at the project level**
  * **Enterprise plan - FME All Resources**
  * Free plan - All Project Level Resources

2. [link to [commit](https://github.com/harness/developer-hub/commit/3ce73b253253611371a6e791fd4f036728569d3a)] Correct, complete, or clarify info related to **shared** vs **FME only** scenarios (shared = legacy Split is migrated into a pre-existing Harness account with other modules enabled / FME only = legacy Split is migrated into a Harness account that did not exist before, and only the FME module is enabled). These details were mostly already documented:
  * Service account created for Admin API Key at the
    * Shared - Organization level
    * FME only - Account level

  * Admin group role binding
    * Shared - Organization Admin role + All Organization Level Resources resource group
    * FME only - Account Admin role + All Resources Including Child Scopes resource group

  * Harness modules enabled:
    * Shared - the migration script makes no change
    * FME only - only FME module is enabled for the Harness account

5. [link to [commit](https://github.com/harness/developer-hub/commit/64a7a715ebbfd2c9d2d105f8d9b828826f1c4d80)] Simplify page-embedded table of contents (to include only admin actions).

6. [link to [commit](https://github.com/harness/developer-hub/commit/c363ba6fd39b34e8b7eaade4270d197bfcba2bb9)] Use tabs with interactive/step-by-step guides.

7. Minor formatting improvements.


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
