### PR TITLE
FMEPRD-252 Update Harness FME Landing Page and Add Harness FME to Platform Landing Page

### DIFF
--- a/src/components/Docs/FeatureManagementExperimentation.tsx
+++ b/src/components/Docs/FeatureManagementExperimentation.tsx
@@ -23,7 +23,7 @@ export default function FME() {
         <div className={styles.spaceBetween}>
           <div className={styles.content}>
             <p>
-              Split Feature Management & Experimentation (FME) is a feature management solution that provides release monitoring and experimentation for data-driven development.
+              Harness Feature Management & Experimentation (FME) is a feature management platform that helps you manage feature releases, monitor performance, and run experiments for data-driven development.
             </p>
             <div className={styles.illustrationContainer}>
               <img

--- a/src/components/Docs/data/featureManagementExperimentationData.ts
+++ b/src/components/Docs/data/featureManagementExperimentationData.ts
@@ -116,7 +116,7 @@ import { MODULES } from "@site/src/constants"
           title: "Migrate from Split to Harness FME",
           module: MODULES.fme,
           description:
-            "Step-by-step guidance to migrate your features from Split to Harness FME.",
+            "Step-by-step guidance to migrate your account from Split to Harness FME.",
           link: "/docs/feature-management-experimentation/split-to-harness",
         },
         {

--- a/src/components/Docs/data/featureManagementExperimentationData.ts
+++ b/src/components/Docs/data/featureManagementExperimentationData.ts
@@ -14,105 +14,118 @@ import { MODULES } from "@site/src/constants"
       description: "",
       list: [
         {
-          title: "Getting started",
-          module: MODULES.fme,
-          description:
-            "Key concepts",
-          link: "/docs/feature-management-experimentation/getting-started/key-concepts",
-        },
-        {
           title: "What's supported",
           module: MODULES.fme,
           description:
-            "Platforms and technologies supported in FME",
+            "Explore the various platforms and technologies supported in Harness FME.",
           link: "/docs/feature-management-experimentation/getting-started/whats-supported",
         },
         {
-          title: "Development guides",
+          title: "Key concepts",
           module: MODULES.fme,
           description:
-            "Guides for using Harness FME with popular languages and platforms, including mobile development",
-          link: "/docs/feature-management-experimentation/sdks-and-infrastructure",
+            "Learn about key concepts in Harness FME, including feature flags, experiments, and more.",
+          link: "/docs/feature-management-experimentation/getting-started/key-concepts",
+        },
+        {
+          title: "Overview",
+          module: MODULES.fme,
+          description:
+            "Set up Harness FME and start managing your first features.",
+          link: "/docs/feature-management-experimentation/getting-started/overview/",
+        },
+        {
+          title: "SDKs and customer-deployed components",
+          module: MODULES.fme,
+          description:
+            "Integrate Harness FME with your preferred languages and platforms, and configure your environments and infrastructure for seamless feature management.",
+          link: "/docs/feature-management-experimentation/sdks-and-infrastructure/",
         },
       ],
     },
     {
-      name: "FME Features",
+      name: "Use Harness FME",
       description: "",
       list: [
         {
-          title: "Feature management",
+          title: "Feature Management",
           module: MODULES.fme,
           description:
-            "Flag variations, canary releases, and gradual rollouts",
+            "Control feature rollouts with flags, variations, and canary releases.",
           link: "/docs/feature-management-experimentation/feature-management",
         },
         {
-          title: "Release monitoring",
+          title: "Release Monitoring",
           module: MODULES.fme,
           description:
-            "Measure KPIs, performance metrics, and alerting for your feature variations",
+            "Track performance, measure KPIs, and receive alerts on feature impact.",
           link: "/docs/feature-management-experimentation/release-monitoring",
         },
         {
           title: "Experimentation",
           module: MODULES.fme,
           description:
-            "Actionable results analysis for data-driven development",
+            "Run experiments and analyze results for data-driven development.",
           link: "/docs/feature-management-experimentation/experimentation",
+        },
+        {
+          title: "Release Agent",
+          module: MODULES.fme,
+          description:
+            "Use the Release Agent in Harness FME to manage feature flags and experiments.",
+          link: "/docs/feature-management-experimentation/release-agent",
         },
       ],
     },
     {
-      name: "Help and more",
+      name: "Management & Administration",
       description: "",
       list: [
         {
-          title: "Account settings",
+          title: "Team Settings",
           module: MODULES.fme,
           description:
-            "Manage projects, environments, and user access for scalable experimentation",
+            "Manage users, roles and projects to scale your experimentation.",
+          link: "/docs/feature-management-experimentation/team-and-project-settings",
+        },
+        {
+          title: "Account Settings",
+          module: MODULES.fme,
+          description: "Configure account-level settings for your organization.",
           link: "/docs/feature-management-experimentation/account-settings",
         },
         {
-          title: "Harness FME support",
+          title: "Integrations",
           module: MODULES.fme,
-          description: "Open a support ticket with us",
+          description: "Connect Harness FME to messaging, monitoring, issue management, customer data platforms, and analytics tools.",
+          link: "/docs/feature-management-experimentation/integrations",
+        },
+        {
+          title: "API",
+          module: MODULES.fme,
+          description: "Access Harness FME programmatically with API references and examples.",
+          link: "/docs/feature-management-experimentation/api",
+        },
+      ],
+    },
+    {
+      name: "Troubleshooting & Resources",
+      description: "",
+      list: [
+        {
+          title: "Migrate from Split to Harness FME",
+          module: MODULES.fme,
+          description:
+            "Step-by-step guidance to migrate your features from Split to Harness FME.",
+          link: "/docs/feature-management-experimentation/split-to-harness",
+        },
+        {
+          title: "Harness Support",
+          module: MODULES.fme,
+          description: "Find help and support for Harness FME.",
           link: "/docs/feature-management-experimentation/fme-support",
         },
       ],
     },
-    /* Not sure if we want these because
-     - if docs are well written, they may be mostly unneeded
-     - if they are needed, they should likely be close to the related instructions/topic
-    {
-      name: "Help and FAQs",
-      description:
-        "",
-      list: [
-        {
-          title: "Troubleshoot FME",
-          module: MODULES.fme,
-          description:
-            "Troubleshooting guides for Harness FME",
-          link: "/kb/feature-flags/articles/troubleshooting-guide",
-        },
-        {
-          title: "FME FAQs",
-          module: MODULES.fme,
-          description:
-            "Frequently asked questions about Harness FME",
-          link: "/docs/faqs/harness-feature-flag-faqs",
-        },
-        {
-          title: "FME Knowledge base",
-          module: MODULES.fme,
-          description:
-            "In-depth knowledge base articles",
-          link: "/kb/feature-flags",
-        },
-      ],
-    },
-    */
   ];
   /* Define the cards - end */

--- a/src/components/Docs/data/platformData.ts
+++ b/src/components/Docs/data/platformData.ts
@@ -86,7 +86,7 @@ export const docsCards: CardSections = [
       },
       {
         title: "FME",
-        module: MODULES.ff,
+        module: MODULES.fme,
         description: "Feature Management & Experimentation overview",
         link: "/docs/feature-management-experimentation/getting-started/overview",
       },

--- a/src/components/Docs/data/platformData.ts
+++ b/src/components/Docs/data/platformData.ts
@@ -85,6 +85,12 @@ export const docsCards: CardSections = [
         link: "/docs/feature-flags/get-started/onboarding-guide",
       },
       {
+        title: "FME",
+        module: MODULES.ff,
+        description: "Feature Management & Experimentation overview",
+        link: "/docs/feature-management-experimentation/getting-started/overview",
+      },
+      {
         title: "IaCM",
         module: MODULES.iacm,
         description: "Infrastructure as Code Management overview",


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: The current [Harness FME landing page](https://developer.harness.io/docs/feature-management-experimentation) references "Split FME" and also does not reflect the new doc sets that have been added. Also adding FME as an entry next to Feature Flags in the Platform `Get Started with Harness Modules` section of the landing page. Conversation with Dave K on Slack.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/FMEPRD-252
* Preview links/images (Internal contributors only): https://68a51084d44d4eccb96cb0aa--harness-developer.netlify.app//docs/feature-management-experimentation

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
