### PR TITLE
FMEPRD-266 Add Harness IDP Integration and Doc Page Link

### DIFF
--- a/docs/feature-management-experimentation/10-getting-started/split-and-harness.md
+++ b/docs/feature-management-experimentation/10-getting-started/split-and-harness.md
@@ -12,7 +12,7 @@ For more information about the acquisition, go to the [Harness blog](https://www
 
 ## Get started with Harness
 
-If you're new to Harness, go to [Get started with Harness](/docs/category/get-started-with-harness) for a jumpstart into the Harness software delivery platform.
+If you're new to Harness, go to [Get started with Harness](/docs/category/get-started-with-harness) and learn about the Harness software delivery platform.
 
 ## Authentication, access, and user management
 
@@ -23,8 +23,14 @@ Authentication, access, and user management are part of the Harness platform. Pe
 
 ## Administering a Migrated Split Account on Harness
 
-Split administrators should read the [Before and After Guide: Administering a Migrated Split Account on Harness](https://help.split.io/hc/en-us/articles/37936926294541-Before-and-After-Guide-Administering-a-Migrated-Split-Account-on-Harness) published in the [Split to Harness Migration section of the Split by Harness Help Center](https://help.split.io/hc/en-us/sections/34618781681933-Split-to-Harness-Migration). The guide will walk you through administrative tasks which change to standard Harness platform features after your migration into Harness.
+Split administrators should read the [Before and After Guide: Administering a Migrated Split Account on Harness](/docs/feature-management-experimentation/split-to-harness/administering-migrated-account/). The guide will walk you through administrative tasks which change to standard Harness platform features after your migration into Harness.
 
-## Harness platform integrations coming soon
+## Harness platform integrations
 
-We are moving rapidly to unlock integrations with Harness's innovative DevOps tools, DevEx improvements, Security features, and cloud optimizations, while also accelerating the roadmap of enhancements to the core of what you have previously known as Split. You can visit our [roadmap](https://developer.harness.io/roadmap/#fme) to learn more.
+We are moving rapidly to unlock integrations with Harness's innovative DevOps tools, developer experience improvements, security features, and cloud optimizations, while continuing to enhance the core of what you've previously known as Split. 
+
+You can use Harness FME directly within the [Harness Internal Developer Portal (IDP)](/docs/internal-developer-portal). This integration allows you to view and manage your feature flags and experiments directly from your developer portal, alongside other Harness tools. 
+
+For setup instructions and configuration details, see the [Harness IDP documentation](/docs/internal-developer-portal/plugins/available-plugins/harness-native-plugins/harness-fme).
+
+Visit our [roadmap](https://developer.harness.io/roadmap/#fme) to learn more about upcoming integrations and planned enhancements.

--- a/docs/feature-management-experimentation/80-integrations/index.md
+++ b/docs/feature-management-experimentation/80-integrations/index.md
@@ -16,7 +16,15 @@ Split integrates across several categories, including messaging, monitoring, iss
 If you're not seeing a tool you need to be connected to Split, you can use Split’s [API](https://docs.split.io/) and [SDKs](/docs/feature-management-experimentation/sdks-and-infrastructure) to connect with the tools your team uses. For assistance with Split’s SDK or API, contact [Harness Support](/docs/feature-management-experimentation/fme-support).
 :::
 
-import { Section, supportedWorkflows, supportedDatasources, supportedAdminchanges, supportedCommunity } from '/src/components/Docs/data/fmeIntegrations';
+import { Section, supportedModules, supportedWorkflows, supportedDatasources, supportedAdminchanges, supportedCommunity } from '/src/components/Docs/data/fmeIntegrations';
+
+<Section 
+  title="Harness Module Integrations" 
+  items={supportedModules} 
+  perRow={6} 
+  rowSpacing="20px" 
+  description="Harness integrations allow you to access and manage your feature flags and experiments directly within the Harness modules your team already uses." 
+/>
 
 <Section 
   title="Split-supported Workflow Integrations" 

--- a/src/components/Docs/data/fmeIntegrations.js
+++ b/src/components/Docs/data/fmeIntegrations.js
@@ -8,6 +8,10 @@ function chunkArray(array, size) {
   );
 }
 
+export const supportedModules = [
+  { name: "Harness IDP", img: "/img/icon_idp.svg", link: "/docs/internal-developer-portal/plugins/available-plugins/harness-native-plugins/harness-fme" },
+];
+
 export const supportedWorkflows = [
   { name: "AppDynamics", img: "/provider-logos/fme-integrations/appdynamics-logo.png", link: "/docs/feature-management-experimentation/integrations/appdynamics" },
   { name: "Azure DevOps", img: "/provider-logos/fme-integrations/azure-devops-logo.png", link: "/docs/feature-management-experimentation/integrations/azure-devops" },


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Updating the `Harness platform integrations` section in the Split + Harness doc page and adds a tile for Harness IDP as a `Harness Module Integration` on the Integrations landing page. Flagged by Josh Klein and Trevor on Slack.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/FMEPRD-266
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
