### PR TITLE
feature: Update DMS to allow fragments and heading delimiter

### DIFF
--- a/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.tsx
+++ b/src/components/DynamicMarkdownSelector/DynamicMarkdownSelector.tsx
@@ -229,7 +229,10 @@ const DynamicMarkdownSelector: React.FC<DynamicMarkdownSelectorProps> = ({
                     className={`selector-card${
                       selected === label ? " selected" : ""
                     }`}
-                    onClick={() => setSelected(label)}
+                    onClick={() => {
+                      setSelected(label);
+                      setSectionId("");   
+                    }}
                     type="button"
                   >
                     {entry.logo ? (


### PR DESCRIPTION
## Description
* Update DMS component to enable a delimiter in addition to the selected tile fragment.

### Former behaviour
- If you select a tile, e.g., Python, the URL would update with a fragment and append `#python`
- But if you select a header within the selected tile's content, e.g., Python -> Prerequisites, the URL would replace `#python` with `#prerequisites`, losing the context and sharability of the selected tile.

### New behaviour
Now, if you select a subheader, the URL will keep the selected tile fragment and append `--header-name` to the URL, e.g. 
`#python--prerequisites`.

### Screenshot / Preview
https://github.com/user-attachments/assets/7e231f21-4a13-4947-91fd-4bc98f45d36c

PRs must meet these requirements to be merged:
- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.