### PR TITLE
document plugin step output secrets

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/containerized-steps/plugin-step.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/containerized-steps/plugin-step.md
@@ -155,6 +155,25 @@ If the step is within a step group, include the step group identifier in the exp
 <+pipeline.stages.STAGE_ID.spec.execution.steps.STEP_GROUP_ID.steps.STEP_ID.output.outputVariables.VAR_NAME>
 ```
 
+#### Output secrets
+
+Plugin step can export output secrets, which can be used in subsequent steps or stages. These behave exactly like output variables but are stored and referenced securely.
+
+To export an output secret from your plugin, write to the `$HARNESS_OUTPUT_SECRET_FILE` environment variable:
+```
+echo "SECRET_KEY=supersecretvalue" >> $HARNESS_OUTPUT_SECRET_FILE
+```
+
+Referencing output secrets works the same way as output variables. Harness masks their values in logs and ensures secure handling.
+
+:::info Feature flags
+Make sure the following feature flags are enabled to use output secrets:
+
+- `CI_SKIP_NON_EXPRESSION_EVALUATION`
+- `CI_ENABLE_OUTPUT_SECRETS`
+- `CI_ENABLE_PLUGIN_OUTPUT_SECRETS` (required for Docker Runner only)
+:::
+
 ### Image Pull Policy
 
 Select an option to set the pull policy for the image.

--- a/docs/continuous-integration/use-ci/use-drone-plugins/plugin-step-settings-reference.md
+++ b/docs/continuous-integration/use-ci/use-drone-plugins/plugin-step-settings-reference.md
@@ -112,6 +112,27 @@ If the step is within a step group, include the step group identifier in the exp
 <+execution.steps.STEP_GROUP_ID.steps.STEP_ID.output.outputVariables.VAR_NAME>
 <+pipeline.stages.STAGE_ID.spec.execution.steps.STEP_GROUP_ID.steps.STEP_ID.output.outputVariables.VAR_NAME>
 ```
+#### Output secrets
+
+Plugin step can export output secrets, which can be used in subsequent steps or stages just like output variables. Output secrets are handled securely by Harness: their values are masked in logs and treated as secrets.
+
+To export an output secret, write to the file path provided by the `$HARNESS_OUTPUT_SECRET_FILE` environment variable. For example:
+
+```
+echo "SECRET_KEY=supersecretvalue" >> $HARNESS_OUTPUT_SECRET_FILE
+```
+At runtime, Harness automatically captures these values as secrets. They can be referenced in subsequent steps or stages the same way as output variables, using expression syntax:
+```
+<+steps.STEP_ID.output.outputVariables.SECRET_KEY>
+<+stages.STAGE_ID.spec.execution.steps.STEP_ID.output.outputVariables.SECRET_KEY>
+```
+:::info Feature flags
+To use output secrets, the following feature flags must be enabled:
+- `CI_SKIP_NON_EXPRESSION_EVALUATION`
+- `CI_ENABLE_OUTPUT_SECRETS`
+For Harness Docker Runner, also enable:
+- `CI_ENABLE_PLUGIN_OUTPUT_SECRETS`
+:::
 
 #### Output Variables on Step Failure
 


### PR DESCRIPTION
* Change: document plugin step output secrets
  - Added new "Output secrets" sections to Plugin step and Plugin step settings pages
  - Explained how plugins can export secrets using $HARNESS_OUTPUT_SECRET_FILE
  - Provided Bash example and reference to OIDC plugin Golang implementation
  - Documented required feature flags (CI_SKIP_NON_EXPRESSION_EVALUATION, CI_ENABLE_OUTPUT_SECRETS, CI_ENABLE_PLUGIN_OUTPUT_SECRETS for Docker Runner)
  - Clarified that output secrets behave like output variables but are handled securely (masked in logs)
* Jira/GitHub Issue numbers (if any): CI-17522

