### PR TITLE
FMEPRD-271 Add Release Agent to Harness AI Platform Documentation

### DIFF
--- a/docs/platform/harness-aida/ai-devops.md
+++ b/docs/platform/harness-aida/ai-devops.md
@@ -1,7 +1,7 @@
 ---
 title: Harness AI DevOps Agent
 description: Harness AI DevOps Agent unlocks your pipeline productivity.
-sidebar_position: 53
+sidebar_position: 8
 ---
 # Harness AI DevOps Agent
 

--- a/docs/platform/harness-aida/aida-ccm.md
+++ b/docs/platform/harness-aida/aida-ccm.md
@@ -1,7 +1,7 @@
 ---
 title: Optimize cloud costs using Harness AI
 description: Learn how to use Harness AI for cloud asset governance.
-sidebar_position: 30
+sidebar_position: 3
 canonical_url: https://www.harness.io/blog/elevating-aida-harness-unveils-7-new-innovative-capabilities
 ---
 

--- a/docs/platform/harness-aida/aida-ci.md
+++ b/docs/platform/harness-aida/aida-ci.md
@@ -1,7 +1,7 @@
 ---
-title: Troubleshoot builds and deployments with AI
-description: Troubleshoot with Harness AI DevOps agent .
-sidebar_position: 20
+title: Troubleshoot builds and deployments with Harness AI
+description: Troubleshoot builds and deployments with Harness AI.
+sidebar_position: 2
 ---
 
 import Intro from '/docs/continuous-integration/shared/aida-intro.md';

--- a/docs/platform/harness-aida/aida-code-pr.md
+++ b/docs/platform/harness-aida/aida-code-pr.md
@@ -1,7 +1,7 @@
 ---
 title: Generate PR summaries with Harness AI
 description: Create PR summaries with Harness AI.
-sidebar_position: 51
+sidebar_position: 6
 ---
 
 import AidaPr from '/docs/code-repository/pull-requests/aida-code-pr.md';

--- a/docs/platform/harness-aida/aida-code.md
+++ b/docs/platform/harness-aida/aida-code.md
@@ -1,7 +1,7 @@
 ---
 title: Search your code with Harness AI
 description: Supercharge your code searches with Harness AI.
-sidebar_position: 50
+sidebar_position: 5
 ---
 
 import AidaCode from '/docs/code-repository/work-in-repos/semantic-search.md';

--- a/docs/platform/harness-aida/aida-overview.md
+++ b/docs/platform/harness-aida/aida-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview of Harness AI 
 description: Learn about how AI improves your experience on the Harness platform.
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 The Harness Platform leverages Harness AI to revolutionize software delivery processes. By combining AI capabilities with robust DevOps tools, features, and practices, the Harness platform streamlines and accelerates the software delivery lifecycle, and it empowers teams to deliver high-quality applications quickly and efficiently. Its AI-driven predictive analytics, continuous verification, and advanced release orchestration capabilities empower teams to drive innovation, improve efficiency, and ultimately deliver exceptional user experiences.
@@ -30,20 +30,21 @@ For more information about navigation 2.0, go to [Harness navigation 2.0](https:
 
 ## Harness AI features
 
-| Module   | Feature                                                                                         | Description                                                                                                                                                                                                               | Availability        |
-|----------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
-| Platform | Harness Support                                                                                 | Harness AI can answer questions and suggest relevant documentation to help you browse and discover Harness features and documentation.                                                                                          | Generally available |
-| Platform | Harness Support                                                                                 | Harness AI provides content recommendations when you create a support ticket.                                                                                                                                                   | Generally available |
-| Platform | [Dashboard Intelligence](/docs/platform/dashboards/use-dashboard-intelligence-by-aida)          | Harness AI empowers you to craft customized dashboards with widget-level control through interactive prompts.                                                                                                                   | Generally available |
-| Platform | [Code Generation](/docs/platform/harness-aida/code-agent)                                    | With the Harness AI Code Agent IDE extension, you can increase productivity by generating multi-line code updates through comments in your IDE, eliminating the need to manually write common functions or look up unknown syntax. | Beta         |
-| CCM      | [Generate governance rules](/docs/category/harness-aida-for-asset-governance)                   | Generate rules for asset governance accompanied with detailed descriptions to optimize your cloud spend.                                                                                                                  | Generally available |
-| CD       | Troubleshoot CD deployments                                                                     | Resolve your deployment failures with AI's root cause analysis (RCA).                                                                                                                                                   | Generally available |
-| CD       | Policy As Code Assistant                                                                        | Generate and integrate Open Policy Agent (OPA) Rego policies to meet your compliance standards with the Harness AI DevOps Agent.                                                                                                                           | Generally available         |
-| CE       | [ChaosGuard](/docs/chaos-engineering/guides/governance/governance-in-execution/)        | Generate conditions for your chaos experiments with ChaosGuard.                                                                                                                                                           | Generally available |
-| CODE     | [Semantic Search](/docs/code-repository/work-in-repos/semantic-search)                          | Search code repositories to provide accurate and context-aware results in Harness Code.                                                                                                                                   | Generally available |
-| CODE     | [Pull Request Summaries](/docs/code-repository/pull-requests/aida-code-pr)                      | Automatically generate comprehensive and informative PR descriptions.                                                                                                                                                     | Generally available |
-| CI       | [Troubleshoot CI builds](/docs/continuous-integration/troubleshoot-ci/aida)                     | Resolve your build failures with Harness AI DevOps Agent's RCA.                                                                                                                                                                              | Generally available |
-| STO      | [Security remediation](/docs/security-testing-orchestration/remediations/ai-based-remediations) | Leverage AI to quickly analyze vulnerabilities and secure applications.                                                                                                                                                 | Generally available |
+| Module | Feature | Description | Availability |
+|---|---|---|---|
+| Platform | Harness Support | Harness AI can answer questions and suggest relevant documentation to help you browse and discover Harness features and documentation. | Generally available |
+| Platform | Harness Support | Harness AI provides content recommendations when you create a support ticket. | Generally available |
+| Platform | [Dashboard Intelligence](/docs/platform/dashboards/use-dashboard-intelligence-by-aida) | Harness AI empowers you to craft customized dashboards with widget-level control through interactive prompts. | Generally available |
+| Platform | [Code Generation](/docs/platform/harness-aida/code-agent) | With the Harness AI Code Agent IDE extension, you can increase productivity by generating multi-line code updates through comments in your IDE, eliminating the need to manually write common functions or look up unknown syntax. | Beta |
+| CCM | [Generate governance rules](/docs/category/harness-aida-for-asset-governance) | Generate rules for asset governance accompanied with detailed descriptions to optimize your cloud spend. | Generally available |
+| CD | Troubleshoot CD deployments | Resolve your deployment failures with AI's root cause analysis (RCA). | Generally available |
+| CD | Policy As Code Assistant | Generate and integrate Open Policy Agent (OPA) Rego policies to meet your compliance standards with the Harness AI DevOps Agent. | Generally available |
+| CE | [ChaosGuard](/docs/chaos-engineering/guides/governance/governance-in-execution/) | Generate conditions for your chaos experiments with ChaosGuard. | Generally available |
+| CODE | [Semantic Search](/docs/code-repository/work-in-repos/semantic-search) | Search code repositories to provide accurate and context-aware results in Harness Code. | Generally available |
+| CODE | [Pull Request Summaries](/docs/code-repository/pull-requests/aida-code-pr) | Automatically generate comprehensive and informative PR descriptions. | Generally available |
+| CI | [Troubleshoot CI builds](/docs/continuous-integration/troubleshoot-ci/aida) | Resolve your build failures with Harness AI DevOps Agent's RCA. | Generally available |
+| FME | [AI Summarize](/docs/platform/harness-aida/release-agent#ai-summarize) | Delivers answers from Harness FME documentation and blogs while summarizing experiment and metric results on their dashboards. | Generally available |
+| STO | [Security remediation](/docs/security-testing-orchestration/remediations/ai-based-remediations) | Leverage AI to quickly analyze vulnerabilities and secure applications. | Generally available |
 
 ## Harness AI terms and data privacy information
 

--- a/docs/platform/harness-aida/aida-sto.md
+++ b/docs/platform/harness-aida/aida-sto.md
@@ -1,7 +1,7 @@
 ---
-title: Fix security vulnerabilities using AI
-description: Enhanced remediation using Harness AI
-sidebar_position: 40
+title: Fix security vulnerabilities using Harness AI
+description: Enhanced remediation using Harness AI.
+sidebar_position: 4
 ---
 
 

--- a/docs/platform/harness-aida/code-agent.md
+++ b/docs/platform/harness-aida/code-agent.md
@@ -1,7 +1,7 @@
 ---
 title: Harness AI Code Agent
 description: Harness AI Code Agent for enhanced coding productivity.
-sidebar_position: 52
+sidebar_position: 7
 redirect_from:
   - /docs/platform/harness-aida/code-assistant
 ---

--- a/docs/platform/harness-aida/harness-mcp-server.md
+++ b/docs/platform/harness-aida/harness-mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: Harness MCP Server (Beta)
 description: A unified interface for AI agents to interact with Harness tools and services using the Model Context Protocol (MCP).
-sidebar_position: 54
+sidebar_position: 10
 ---
 
 The Harness Model Context Protocol (MCP) Server (in Beta) enables integration with Harness tools, providing endpoints for pipelines, pull requests, and more. This guide outlines the installation, configuration, and usage of the MCP server.

--- a/docs/platform/harness-aida/release-agent.md
+++ b/docs/platform/harness-aida/release-agent.md
@@ -1,0 +1,9 @@
+---
+title: Harness AI Release Agent
+description: Learn how to release features confidently with data and feature operations like deploying, targeting, and managing flags with the Harness AI Release Agent.
+sidebar_position: 9
+---
+
+import Releaseagent from '../../feature-management-experimentation/release-agent/index.md';
+
+<Releaseagent />

--- a/docs/platform/harness-aida/release-agent.md
+++ b/docs/platform/harness-aida/release-agent.md
@@ -4,6 +4,6 @@ description: Learn how to release features confidently with data and feature ope
 sidebar_position: 9
 ---
 
-import Releaseagent from '../../feature-management-experimentation/release-agent/index.md';
+import Releaseagent from '/docs/feature-management-experimentation/release-agent/index.md';
 
 <Releaseagent />


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: Adding a doc page for the Release Agent as a part of the Harness AI Platform doc set. This reflects the `AI Across Your SDLC` section on the [marketing website](https://www.harness.io/products/harness-ai#:~:text=with%20intelligent%20automation.-,AI%20Across%20Your%20SDLC,-Harness%20AI%20is) where Release Agent and the AI SRE Agent are folded into the **Release & Manage Incidents** section.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/FMEPRD-271
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
