### PR TITLE
feat: add release notes for 1.5x.x for dbdevops

### DIFF
--- a/release-notes/database-devops.md
+++ b/release-notes/database-devops.md
@@ -35,7 +35,7 @@ The `1.54.x` release focuses on improving usability in the schema overview exper
 - `dbservice` – 1.54.x
 
 ### Release 1.53.x
-The `1.53.x` release focuses on improving database schema management workflows and stabilizing the Liquibase integration. Customers editing schemas can now select a primary instance directly from the UI.
+The `1.53.x` release focuses on improving database schema management workflows and stabilizing the Liquibase integration. Customers editing schemas can now select a primary instance directly from the UI. Customers editing schemas can now select a primary instance directly from the UI. Certain upcoming features will use this instance for development and validation use cases.
 
 #### Key Highlights:
 
@@ -49,6 +49,11 @@ The `1.53.x` release focuses on improving database schema management workflows a
 
 ### Release 1.52.x
 The `1.52.x` release expands the platform’s authoring and validation capabilities. Teams can now author database changesets directly from the UI with a built-in YAML renderer and execution status visibility. This reduces reliance on external editors and brings change management closer to the deployment workflow. At the same time, we’ve added support for the Liquibase validate command, helping teams catch invalid changes early in the pipeline.
+
+:::note Beta Feature
+The YAML authoring and validation functionality is currently in **beta** and gated behind a non-GA feature flag.  
+Please contact [Harness Product Manager](https://support.harness.io) if you would like to be added to the beta for this functionality.
+:::
 
 #### Key Highlights:
 

--- a/release-notes/database-devops.md
+++ b/release-notes/database-devops.md
@@ -31,6 +31,9 @@ The `1.54.x` release focuses on improving usability in the schema overview exper
 **Bug Fixes**
   - Added a searchable schema dropdown on the Overview page, resolving limitations with subset display and missing pagination/infinite scroll.
 
+**Minimum Supported Versions:**
+- `dbservice` – 1.54.x
+
 ### Release 1.53.x
 The `1.53.x` release focuses on improving database schema management workflows and stabilizing the Liquibase integration. Customers editing schemas can now select a primary instance directly from the UI.
 
@@ -40,7 +43,9 @@ The `1.53.x` release focuses on improving database schema management workflows a
   - Select a primary instance directly while editing a DB schema with a new dropdown in the UI.
 * **Bug Fixes:**
   - DB Test and Preview steps now return detailed messages that appear in the chat UI, improving debugging visibility.
-  - Downgraded Liquibase image to resolve issues introduced in version 4.33.
+
+**Minimum Supported Versions:**
+- `dbservice` – 1.53.x
 
 ### Release 1.52.x
 The `1.52.x` release expands the platform’s authoring and validation capabilities. Teams can now author database changesets directly from the UI with a built-in YAML renderer and execution status visibility. This reduces reliance on external editors and brings change management closer to the deployment workflow. At the same time, we’ve added support for the Liquibase validate command, helping teams catch invalid changes early in the pipeline.
@@ -51,8 +56,10 @@ The `1.52.x` release expands the platform’s authoring and validation capabilit
   - A new YAML renderer and execution status plugin allow teams to create and review changesets directly from the UI.
   - Added support for the Liquibase `validate` command, ensuring changes are verified before deployment.
 * **Bug Fixes:**
-  - Upgraded Liquibase from `4.27` → `4.33` to address vulnerabilities.
   - Fixed execution URL display and added PR link support in the UI.
+
+**Minimum Supported Versions:**
+- `dbservice` – 1.52.x
 
 ### Release 1.51.x
 The `1.51.x` release strengthens rollback flexibility and control. For scenarios where teams need to customize how rollbacks are applied, this release introduces support for Custom Rollback SQL. Customers can now define custom rollback logic for complex cases where auto-generated SQL may not suffice. This includes onboarding and storing step outputs for UpdateSQL and RollbackSQL, along with a dedicated CustomUpdateSQL step for better pipeline integration.
@@ -61,6 +68,9 @@ The `1.51.x` release strengthens rollback flexibility and control. For scenarios
 
 * **Feature Enhancements:**
   - Custom Rollback SQL: Teams can now onboard and store step outputs for UpdateSQL and RollbackSQL, with a dedicated CustomUpdateSQL step in dbops-service.
+
+**Minimum Supported Versions:**
+- `dbservice` – 1.51.x
 
 ## July 2025
 
@@ -74,7 +84,6 @@ The `1.49.x` release introduces key improvements across schema discovery, rollba
   - The platform now supports optional Primary DB instanceId, streamlining deployments across multi-instance environments.
 
 **Minimum Supported Versions:**
-- `ngmanager` – 1.49.x
 - `dbservice` – 1.49.x
 
 ### Release 1.48.x
@@ -93,5 +102,4 @@ This release brings several critical feature enhancements and extended support a
 * Metadata fields such as comments, labels, and authors now visible.
 
 **Minimum Supported Versions:**
-- `ngmanager` – 1.48.0
 - `dbservice` – 1.48.0

--- a/release-notes/database-devops.md
+++ b/release-notes/database-devops.md
@@ -23,8 +23,17 @@ These release notes describe recent changes to Harness Database DevOps.
 :::
 
 ## August 2025
+
+### Release 1.54.x
+The `1.54.x` release focuses on improving usability in the schema overview experience. Previously, the schema dropdown on the Overview page only displayed a limited subset of schemas, making it difficult to navigate in environments with many schemas. With this update, customers now get a searchable dropdown that scales better for large environments, simplifying schema selection and improving visibility into migration states.
+
+#### Key Highlights:
+**Bug Fixes**
+  - Added a searchable schema dropdown on the Overview page, resolving limitations with subset display and missing pagination/infinite scroll.
+
 ### Release 1.53.x
 The `1.53.x` release focuses on improving database schema management workflows and stabilizing the Liquibase integration. Customers editing schemas can now select a primary instance directly from the UI.
+
 #### Key Highlights:
 
 * **Feature Enhancements:**

--- a/release-notes/database-devops.md
+++ b/release-notes/database-devops.md
@@ -22,6 +22,37 @@ These release notes describe recent changes to Harness Database DevOps.
 - **More release notes:** Go to [Harness Release Notes](/release-notes) to explore all Harness release notes, including module, delegate, Self-Managed Enterprise Edition, and FirstGen release notes.
 :::
 
+## August 2025
+### Release 1.53.x
+The `1.53.x` release focuses on improving database schema management workflows and stabilizing the Liquibase integration. Customers editing schemas can now select a primary instance directly from the UI.
+#### Key Highlights:
+
+* **Feature Enhancements:**
+  - Select a primary instance directly while editing a DB schema with a new dropdown in the UI.
+* **Bug Fixes:**
+  - DB Test and Preview steps now return detailed messages that appear in the chat UI, improving debugging visibility.
+  - Downgraded Liquibase image to resolve issues introduced in version 4.33.
+
+### Release 1.52.x
+The `1.52.x` release expands the platform’s authoring and validation capabilities. Teams can now author database changesets directly from the UI with a built-in YAML renderer and execution status visibility. This reduces reliance on external editors and brings change management closer to the deployment workflow. At the same time, we’ve added support for the Liquibase validate command, helping teams catch invalid changes early in the pipeline.
+
+#### Key Highlights:
+
+* **Feature Enhancements:**
+  - A new YAML renderer and execution status plugin allow teams to create and review changesets directly from the UI.
+  - Added support for the Liquibase `validate` command, ensuring changes are verified before deployment.
+* **Bug Fixes:**
+  - Upgraded Liquibase from `4.27` → `4.33` to address vulnerabilities.
+  - Fixed execution URL display and added PR link support in the UI.
+
+### Release 1.51.x
+The `1.51.x` release strengthens rollback flexibility and control. For scenarios where teams need to customize how rollbacks are applied, this release introduces support for Custom Rollback SQL. Customers can now define custom rollback logic for complex cases where auto-generated SQL may not suffice. This includes onboarding and storing step outputs for UpdateSQL and RollbackSQL, along with a dedicated CustomUpdateSQL step for better pipeline integration.
+
+#### Key Highlights:
+
+* **Feature Enhancements:**
+  - Custom Rollback SQL: Teams can now onboard and store step outputs for UpdateSQL and RollbackSQL, with a dedicated CustomUpdateSQL step in dbops-service.
+
 ## July 2025
 
 ### Release 1.49.x


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: 

This pull request updates the `release-notes/database-devops.md` file with new release notes for August 2025, covering versions 1.51.x through 1.54.x. The changes focus on usability improvements, feature enhancements, and bug fixes across the schema overview experience, database schema management workflows, authoring and validation capabilities, and rollback flexibility.
* Jira/GitHub Issue numbers (if any): https://harness.atlassian.net/browse/DBOPS-1514
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.
