### PR TITLE
Update single-sign-on-saml.md clarify there is no download function (view, copy, paste, save instead)

### DIFF
--- a/docs/platform/authentication/single-sign-on-saml.md
+++ b/docs/platform/authentication/single-sign-on-saml.md
@@ -155,7 +155,7 @@ Sometimes users might have mixed case email addresses in Okta. In these situatio
 Download the **Identity Provider metadata** XML from your Okta app and upload it into Harness.
 
 1. In your Harness Okta app, go to the **Sign On** tab, and then select **Edit**.
-2. Select **Actions** to download the SAML metadata file.
+2. Select **Actions** to view the SAML metadata, then copy that data into a file and save it with an .xml extension.
 
    ![](./static/single-sign-on-saml-60.png)
 


### PR DESCRIPTION
The actions menu let's you "view IdP metadata" which brings it up in a browser window.  The user must then copy that and paste it by hand into a new file and save it.  

Using the word "download" here as we do now runs the risk of leading them to the other menu option, which is "Download certificate" (not the right choice here).

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \______Minor clarification of wording: user must view, copy, paste, save (there is no direct "download" option for xml metadata_____________
* Jira/GitHub Issue numbers (if any): \________N/A______________________
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
