### PR TITLE
feature: Add lastUpdatedDates for docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,6 +13,8 @@ function hideIndexFromSidebarItems(items) {
   return result;
 }
 
+const injectLastUpdated = require('./plugins/remark-inject-last-updated.cjs');
+
 const config: Config = {
   title: 'Harness Developer Hub',
   tagline:
@@ -538,7 +540,7 @@ const config: Config = {
         routeBasePath: 'university',
         exclude: ['**/shared/**', '**/static/**'],
         sidebarPath: require.resolve('./sidebars-university.js'),
-        editUrl: 'https://github.com/harness/developer-hub/tree/main',
+          editUrl: 'https://github.com/harness/developer-hub/tree/main',
         // ... other options
       },
     ],
@@ -577,8 +579,11 @@ const config: Config = {
         editUrl: 'https://github.com/harness/developer-hub/tree/main', // /tree/main/packages/create-docusaurus/templates/shared/
         // include: ["tutorials/**/*.{md, mdx}", "docs/**/*.{md, mdx}"],
         exclude: ['**/shared/**', '**/static/**', '**/content/**'],
+        showLastUpdateTime: true,
+        showLastUpdateAuthor: false,
         routeBasePath: 'docs', //CHANGE HERE
         remarkPlugins: [
+          injectLastUpdated,
           [
             remarkMath,
             {

--- a/plugins/remark-inject-last-updated.cjs
+++ b/plugins/remark-inject-last-updated.cjs
@@ -1,0 +1,20 @@
+// Injects <LastUpdatedTop /> as the first child in every MDX doc.
+module.exports = function remarkInjectLastUpdated() {
+    return (tree) => {
+      // Avoid double-inject during fast refresh by checking first node.
+      const first = tree.children?.[0];
+      const alreadyInjected =
+        first &&
+        (first.type === 'mdxJsxFlowElement' || first.type === 'mdxJsxTextElement') &&
+        first.name === 'LastUpdatedTop';
+  
+      if (!alreadyInjected) {
+        tree.children.unshift({
+          type: 'mdxJsxFlowElement',
+          name: 'LastUpdatedTop',
+          attributes: [],
+          children: [],
+        });
+      }
+    };
+  };

--- a/src/components/LastUpdatedTop.tsx
+++ b/src/components/LastUpdatedTop.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+
+function formatLastUpdated(ts: number | string | undefined): string | null {
+  if (!ts) return null;
+
+  let date: Date;
+  if (typeof ts === 'number') {
+    // Heuristic: < 1e12 → seconds; otherwise milliseconds.
+    date = new Date(ts < 1e12 ? ts * 1000 : ts);
+  } else {
+    // String: dev mode often provides an ISO-like string.
+    const d = new Date(ts);
+    if (Number.isNaN(d.getTime())) return null;
+    date = d;
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+export default function LastUpdatedTop() {
+  let metadata: any | undefined;
+  try {
+    ({metadata} = useDoc());
+  } catch {
+    return null; // not a docs route
+  }
+
+  const label = formatLastUpdated(metadata?.lastUpdatedAt);
+  if (!label) return null;
+
+  return (
+    <div
+      style={{
+        marginTop: '-0.5rem',  // pulls it snug under the H1
+        marginBottom: '1rem',
+        fontSize: '0.875rem',
+        fontWeight: 600,
+        color: 'var(--ifm-color-emphasis-700)',
+      }}
+      aria-label="Document last updated date"
+      data-testid="last-updated-top"
+    >
+      {`Last updated: ${label}`}
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1767,3 +1767,16 @@ html[data-theme='dark'] .sidebar-opensource > a::before {
   background: linear-gradient(135deg, #3dc7f6, #00ade4);
   box-shadow: 0 2px 4px rgba(61, 199, 246, 0.4);
 }
+
+[data-testid="last-updated-top"] {
+  display: block;
+  margin-top: -0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.theme-last-updated {
+  display: none !important;
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -9,6 +9,7 @@ import DocsButton from "../components/DocsButton";
 import DocsTag from "../components/DocsTag";
 import Telemetry from "../components/Telemetry";
 import HarnessApiData from "../components/HarnessApiData";
+import LastUpdatedTop from "../components/LastUpdatedTop";
 
 export default {
   // Re-use the default mapping
@@ -23,4 +24,5 @@ export default {
   DocsTag: DocsTag,
   Telemetry: Telemetry,
   HarnessApiData: HarnessApiData,
+  LastUpdatedTop: LastUpdatedTop,
 };


### PR DESCRIPTION
## Description
- Add lastUpdatedDates to doc pages

PR contains 
- A new custom plugin because docusaurus.config.ts sets the docs preset to false, so the built in option isn't available
- A new component to grab the last git commit for the file and render it
- global css rules to place the lastUpdatedDate under the frontmatter title of each page.

Proposed further additions:
- Add a CI stage to fetch the latest commits daily or add it to the build/deploy stage already in place

### Screenshot / Preview
https://github.com/user-attachments/assets/c99de094-d960-41de-bab3-9dbc1d9a170d


PRs must meet these requirements to be merged:
- [x] Successful preview build.
- [x] Code owner review.
- [x] No merge conflicts.
- [x] Release notes/new features docs: Feature/version released to at least one prod environment.