### PR TITLE
Update fme-support.md with correct in Harness app steps

### DIFF
--- a/docs/feature-management-experimentation/fme-support.md
+++ b/docs/feature-management-experimentation/fme-support.md
@@ -25,13 +25,14 @@ If you are already on the Harness platform, you can create a Harness Zendesk Sup
 
 To create a support ticket:
 
-1. Go to [https://support.harness.io](https://support.harness.io)
-2. Log in and Click on Submit a Request
-3. Enter a meaningful subject
-4. Provide steps to reproduce the issue in the description field
-5. Select the priority level
-6. Attach any relevant screenshots or mini video clips
-7. Submit the ticket
+1. Click "Help" in the Harness left navigation
+2. Click "Submit a ticket" in the dialog that appears
+3. Enter a meaningful subject and click "Continue"
+4. Select the priority level
+5. Choose "Feature Management & Experimentation" from the module menu
+6. Provide steps to reproduce the issue in the description field
+7. Attach any relevant screenshots or mini video clips
+8. Submit the ticket
 
 This will create an internal Zendesk ticket, which is actively monitored.
 
@@ -59,3 +60,4 @@ And that’s it!
 The product management team will triage these submitted ideas, ask questions if needed, allow all users interested in participating in the conversation, and provide updates on the progress and ETA. Users will automatically be notified on each change of tickets that they are subscribed to (either voted on or created the feature request).
 
 -->
+


### PR DESCRIPTION
Better to teach users how to log support cases from within the app then sending them to the zendesk portal, which requires them to log in via the app first anyway.

I could be wrong here... might be that the SSO via app to get them into Zendesk could work when their account access has an issue, but it struck me as odd that the instructions were not to the in-app experience.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__________________________________
* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \__________________
Here are the actual steps if you are "already on the Harness platform"
<img width="754" height="807" alt="image" src="https://github.com/user-attachments/assets/6454fc5c-c394-4879-8eed-c939e25c5481" />
<img width="1077" height="857" alt="image" src="https://github.com/user-attachments/assets/37fcb831-ed97-4b41-af69-214303495cf8" />


## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
