### PR TITLE
[FMEPRD-287] FME SSO guide: Add SAML Strict Mode info - not supported in Harness

### DIFF
--- a/docs/feature-management-experimentation/split-to-harness/sso-for-admins.md
+++ b/docs/feature-management-experimentation/split-to-harness/sso-for-admins.md
@@ -33,6 +33,8 @@ Watch the 30-second animation below.  Note the order of steps and the way your u
 - To preserve the instant revert capability seen in the animation above, do not disable your SSO configuration to `app.split.io` at the moment of migration. Users who attempt to use the `app.split.io` SSO after migration will be shown a message pointing them to `app.harness.io`, so it's OK to leave both SSO configurations active for some time. 
 :::
 
+### Harness SAML Supports Strict Mode Only
+
 Once you configure SAML and are migrated to Harness, all users must use SAML to log in to Harness. Unlike legacy Split, Harness does not support toggling off SAML Strict Mode to permit username/password logins. Harness does support Local Login for admin users with the right RBAC settings. See [Harness Local Login](https://developer.harness.io/docs/platform/authentication/single-sign-on-saml/#harness-local-login) for details.
 
 ## Tasks to Perform


### PR DESCRIPTION
## Description

* Add info to **Before and After Guide (SSO for Split Admins)** :

> Once you configure SAML and are migrated to Harness, all users will use SAML to log into Harness. Unlike legacy Split, Harness does not support toggling off SAML Strict Mode to permit username/password logins.

Jira ticket number: FMEPRD-287

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [x] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
