### PR TITLE
Fix typo in Test Intelligence usage description

### DIFF
--- a/docs/continuous-integration/use-ci/run-tests/ti-overview.md
+++ b/docs/continuous-integration/use-ci/run-tests/ti-overview.md
@@ -21,7 +21,7 @@ Testing is an important part of Continuous Integration (CI). Testing safeguards 
 
 Harness Test Intelligence (TI) improves unit test time by running only the unit tests required to confirm the quality of the code changes that triggered the build. You can also use parallelism (test splitting) with TI to further optimize your test times.
 
-You can used Test Intelligence with **Python**, **Java** , **Ruby**, **C#**, **Kotlin**, or **Scala** programming languages.
+You can use Test Intelligence with **Python**, **Java** , **Ruby**, **C#**, **Kotlin**, or **Scala** programming languages.
 
 :::tip Test Intelligence Beta
 Test Intelligence for **JavaScript (Jest)** and **Kotest** is now available in **beta**. If you're interested in joining the beta program, please contact Harness support or your account representative.


### PR DESCRIPTION
Corrected a typo in the usage of 'use' for Test Intelligence.

Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: \__Corrected a typo in the usage of 'use' for Test Intelligence.

* Jira/GitHub Issue numbers (if any): \______________________________
* Preview links/images (Internal contributors only): \ <img width="1036" height="381" alt="Screenshot 2026-04-07 at 20 36 48" src="https://github.com/user-attachments/assets/d4dde76d-16f2-4cb8-846a-6b72ab68b8a3" />

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
