### PR TITLE
docs: [HDH-746] fix outdated secret expression syntax in CD steps FAQ

### DIFF
--- a/docs/continuous-delivery/x-platform-cd-features/cd-steps/cd-steps-faqs.md
+++ b/docs/continuous-delivery/x-platform-cd-features/cd-steps/cd-steps-faqs.md
@@ -261,10 +261,9 @@ python3 eample.py `<+trigger.payload>`
 ### How Do I preserve the formating of multiline secret in shell script?
 
 Please the use below command-
-```
-echo ${secrets.getValue("key_file")} > /tmp/id_rsa_base64
+```bash
+echo <+secrets.getValue("key_file")> > /tmp/id_rsa_base64
 cat /tmp/id_rsa_base64 | base64 -di
-
 ```
 
 ### I need something that value I can change in the middle of pipeline (automatically using bash script for example).


### PR DESCRIPTION
## What

Fixes an outdated secret-reference expression in the CD steps FAQ. Replaces the FirstGen `${secrets.getValue("key_file")}` with the NextGen `<+secrets.getValue("key_file")>`, and adds the missing `bash` language tag on the code block.

## Why

The example used FirstGen syntax that does not resolve in NextGen, so a customer copy-pasting it would get a broken expression. The same file already uses the correct `<+...>` form a few lines above, so it was internally inconsistent.

Jira: HDH-746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
