### PR TITLE
docs: [HDH-747] clarify what the delegate health check verifies

### DIFF
--- a/docs/platform/delegates/manage-delegates/delegate-metrics.md
+++ b/docs/platform/delegates/manage-delegates/delegate-metrics.md
@@ -54,6 +54,28 @@ Metrics with # above the include the suffix `_total` as of Harness Delegate 23.1
 
 This topic includes example YAML files you can use to create application manifests for your Prometheus and Grafana configurations.
 
+## Understand what delegate health covers
+
+A delegate's health and connected status (including the `io_harness_custom_metric_delegate_connected` metric) reflects the delegate itself, not the downstream systems it talks to during a pipeline run. Read these signals as a statement about the delegate, not about every integration that runs on it.
+
+A healthy, connected delegate confirms that:
+
+- The delegate process is running and live.
+- The delegate is connected to the Harness Manager and sending its heartbeat.
+
+A healthy, connected delegate does not confirm that:
+
+- Secret managers are reachable or returning secrets.
+- Cloud provider credentials are valid or unexpired.
+- The target Kubernetes cluster is reachable and the delegate has access to it.
+- Artifact registries are reachable.
+
+These integrations are exercised per step at run time, using the connector, secret, or target that the step references. A delegate can stay healthy and connected while any of these fails, so a green delegate status does not mean a step that runs on it will succeed.
+
+:::tip troubleshoot a failure on a healthy delegate
+When a delegate shows healthy but a step fails, look at the connector, secret, or target that the step references, not at the delegate status. For example, if a step cannot read a secret because the secret manager is unreachable (such as a custom certificate that the delegate does not trust), the delegate stays healthy while the step fails. For one such case, go to [Install delegates with custom certificates](/docs/platform/delegates/secure-delegates/install-delegates-with-custom-certs).
+:::
+
 ### General recommended metrics configuration
 
 Below are the metrics settings recommended by Harness. Tailor these settings according to your organization's specific needs.


### PR DESCRIPTION
## What

Adds a section to the delegate metrics page clarifying what a healthy/connected delegate status verifies (delegate liveness, Manager connectivity) and what it does not (secret manager, cloud connector, target cluster, artifact registry reachability), with guidance on where to look when a delegate is healthy but a step fails.

## Why

Customers repeatedly assume a healthy delegate means all downstream integrations work, leading them to rule out the delegate when it is in fact the cause (observed 3 times). The framing is intentionally about observed behavior, not internal probe mechanics.

Jira: HDH-747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
