### PR TITLE
docs: [HDH-748] fix SEI GitHub Actions api_key field and GHES base URL convention

### DIFF
--- a/docs/software-engineering-insights/shared/integrations/github-actions.mdx
+++ b/docs/software-engineering-insights/shared/integrations/github-actions.mdx
@@ -73,7 +73,7 @@ The steps for configuring the integration using the **Ingestion Satellite** is s
 1. In **Integration Name**, enter a **Name** for the integration.
 2. Add a **Description** for the integration. (Optional)
 3. Enter the **Personal Access Token** that you generated earlier.
-4. In the **GitHub Actions URL** field, add the URL where your GitHub Actions instance is hosted.
+4. In the **GitHub Actions URL** field, add the bare server base URL where your GitHub Actions instance is hosted, for example, `https://github.example.com`. Do not append the API path. SEI adds the `/api/v3` path automatically.
 5. Click on the **Download YAML File** button and save the `satellite.yml` file. Update it following the instructions [here](/docs/software-engineering-insights/propelo-sei/setup-sei/sei-ingestion-satellite/run-the-satellite-container).
 
    <img src={downloadYaml} alt="Download YAML File" width="1000" /> 
@@ -92,8 +92,10 @@ satellite:
 integrations:
   - id: "<INTEGRATION_ID>"
     application: github_actions
+    # Supply the bare server base URL, for example, https://github.example.com.
+    # Do not append /api/v3. SEI adds the API path automatically.
     url: "<GITHUB_INSTANCE_URL>"
-    authentication: apikey
+    authentication: api_key
 ```
 
 :::note

--- a/docs/software-engineering-insights/shared/integrations/github-server.mdx
+++ b/docs/software-engineering-insights/shared/integrations/github-server.mdx
@@ -54,7 +54,7 @@ To set up the integration for the GitHub Enterprise:
 6. Configure the integration settings and authentication:
    * Add the **PAT Key** that you previously generated for your GitHub account.
      Note that you can add multiple PATs for the same integration.
-   * Enter the URL of your GitHub Enterprise On-prem instance, for example, `<https://GITHUB.ORGANIZATION-DOMAIN>`. Ensure it's a valid URL.
+   * Enter the bare server base URL of your GitHub Enterprise On-prem instance, for example, `https://github.example.com`. Do not append the API path. SEI adds the `/api/v3` path automatically. Ensure it's a valid URL.
 
      <img src={onpremInstance} alt="GitHub Enterprise On-Prem Configuration" width="900" />
 
@@ -88,7 +88,7 @@ To set up the integration for the GitHub Enterprise:
 5. Configure the integration settings and authentication:
    * Add the **PAT Key** that you previously generated for your GitHub account.
      Note that you can add multiple PATs for the same integration.
-   * Enter the URL of your GitHub Enterprise On-prem instance, for example, `<https://GITHUB.ORGANIZATION-DOMAIN>`. Ensure it's a valid URL.
+   * Enter the bare server base URL of your GitHub Enterprise On-prem instance, for example, `https://github.example.com`. Do not append the API path. SEI adds the `/api/v3` path automatically. Ensure it's a valid URL.
 
      <img src={onpremInstance} alt="GitHub Enterprise Configuration" width="900" />
 
@@ -124,6 +124,8 @@ satellite:
 integrations:
   - id: '<INTEGRATION_ID>'
     application: github
+    # Supply the bare server base URL, for example, https://github.example.com.
+    # Do not append /api/v3. SEI adds the API path automatically.
     url: '<GITHUB_ENTERPRISE_INSTANCE_URL>'
     authentication: multiple_api_keys
     keys:


### PR DESCRIPTION
## What

Fixes the SEI GitHub Actions integration docs:
- Corrects the ingestion field name `apikey` to `api_key`.
- Clarifies that GitHub Enterprise Server customers supply the bare server base URL; the `/api/v3` path is appended automatically.

## Why

The incorrect field name and inconsistent GHES base-URL guidance caused failed integration setups for self-managed GHES customers. Behavior was confirmed by engineering.

Jira: HDH-748

## Notes for reviewers

Example hostnames are generic (`https://github.example.com`). No customer-specific domains are referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
