### PR TITLE
docs: [HDH-736][HDH-750] regex.extract NextGen availability and JEXL ternary null example

### DIFF
--- a/docs/platform/harness-platform-faqs.md
+++ b/docs/platform/harness-platform-faqs.md
@@ -3235,7 +3235,25 @@ They are a way to refer to something in Harness such as an entity name or a conf
 
 ### What is the correct syntax for the Regex Extract built-in variable?
 
-`regex.extract("v[0-9]+.[0-9]+", artifact.fileName)` is the correct syntax.
+`regex.extract("v[0-9]+.[0-9]+", artifact.fileName)` is the correct syntax. This expression is available in both FirstGen and NextGen.
+
+The argument order is pattern first, input string second:
+
+```text
+<+regex.extract("<pattern>", <stringInput>)>
+```
+
+For example, to pull the version prefix out of an artifact file name:
+
+```text
+<+regex.extract("v[0-9]+.[0-9]+", <+artifact.fileName>)>
+```
+
+:::note argument order matters
+
+Pass the regex pattern as the first argument and the string to search as the second. If the arguments are reversed, the expression may return an empty string instead of the extracted match.
+
+:::
 
 ### What are the statuses of nodes using the Harness looping Strategy?
 

--- a/docs/platform/variables-and-expressions/harness-variables.md
+++ b/docs/platform/variables-and-expressions/harness-variables.md
@@ -358,7 +358,27 @@ In the example expression above, we can create a test variable with this express
 >
 ```
 
-For more information about using ternary operators in Harness, go to [Using Ternary Operators with Triggers](https://developer.harness.io/docs/continuous-delivery/kb-articles/articles/ternary-operator/).
+For more information about using ternary operators in Harness, go to [Use ternary operators with triggers](/docs/continuous-delivery/kb-articles/articles/ternary-operator) to see worked trigger examples.
+
+#### Keep ternary branches nested
+
+Keep the entire ternary expression nested inside a single outer `<+...>` delimiter. If you split the branches into their own delimiters so that the operators sit outside the expression, the expression can silently evaluate to `null` instead of returning the branch value. The engine resolves the inner delimiters first and then has no complete ternary left to evaluate, so no error is raised and the output is empty.
+
+For example, assume a pipeline variable `myvar` with a value of `1.1`.
+
+* De-nested (returns a silent `null`): the operators and branch values are outside the inner delimiters, so the ternary is not evaluated as a whole.
+
+  ```text
+  <+stage.variables.myvar>=="1.1"?<+pipeline.variables.passValue>:<+pipeline.variables.failValue>
+  ```
+
+* Corrected (returns the intended value): wrap the full ternary in one outer delimiter so the condition and both branches are evaluated together.
+
+  ```text
+  <+<+stage.variables.myvar>=="1.1"?<+pipeline.variables.passValue>:<+pipeline.variables.failValue>>
+  ```
+
+If a ternary expression resolves to an empty value with no error, check that the whole condition-and-branches expression is wrapped in a single outer `<+...>` delimiter.
 
 #### Using isResolved and isUnresolved evaluation instead of null
 Customers may be considering using a ternary evaluations which will evaluate whether the expression `== null` or `!= null` as the condition.
@@ -975,7 +995,7 @@ To achieve this same result in NextGen, you must declare each expression with se
 | `workflow.pipelineResumeUuid`   | Not applicable in NextGen |
 | `workflow.lastGoodReleaseNo`    | Not applicable in NextGen     |
 | `workflow.lastGoodDeploymentDisplayName`     | Not applicable in NextGen    |
-| `regex.extract("v[0-9]+.[0-9]+", artifact.fileName)`   | Not applicable in NextGen     |
+| `regex.extract("v[0-9]+.[0-9]+", artifact.fileName)`   | Available in NextGen. Use the same `regex.extract` expression, with the pattern as the first argument and the input string as the second. |
 | `currentStep.type`  | Not applicable in NextGen    |
 
 </details>


### PR DESCRIPTION
## What

Two related expression-reference fixes (both touch `harness-variables.md`, so they share one PR):

- **HDH-736:** Corrects the `regex.extract` table entry from "Not applicable in NextGen" to "Available in NextGen," and documents the pattern-first / string-second argument order in the platform FAQ with a worked example.
- **HDH-750:** Adds a worked example showing a de-nested ternary that silently evaluates to `null`, and the corrected form wrapped in a single outer `<+...>` delimiter.

## Why

`regex.extract` works in NextGen but was wrongly documented as unavailable, and its argument order was undocumented. The de-nested ternary returning a silent null is a hard-to-debug footgun.

Jira: HDH-736, HDH-750

## Notes for reviewers

The "works in NextGen" and "pattern-first" facts are stated plainly (reproduction-verified). The "reversed arguments may return an empty string" behavior is hedged, since it is not cleanly isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
